### PR TITLE
Fix level order comment

### DIFF
--- a/js/LevelConfig.js
+++ b/js/LevelConfig.js
@@ -9,8 +9,9 @@ class LevelConfig {
             /** the names of the level groups */
             this.groups = [];
             /** sort order of the levels for each group
-             *   every entry is a number where:
-             *     ->  (FileId * 10 + FilePart) * (useOddTabelEntry? -1 : 1)
+             *   each entry is calculated as:
+             *     (FileId * 10 + FilePart) * (useOddTableEntry ? -1 : 1)
+             *   where a negative value means the odd table should be used
              */
             this.order = [];
         }


### PR DESCRIPTION
## Summary
- clarify how `level.order` entries are computed in LevelConfig
- fix typo in odd-table entry reference

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683fe241ecf0832d833aa53877cf4960