### PR TITLE
Refactor action classes to use common base

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,40 @@
+# Dependency Review Action
+#
+# This Action will scan dependency manifest files that change as part of a Pull Request,
+# surfacing known-vulnerable versions of the packages declared or updated in the PR.
+# Once installed, if the workflow run is marked as required, PRs introducing known-vulnerable
+# packages will be blocked from merging.
+#
+# Source repository: https://github.com/actions/dependency-review-action
+# Public documentation: https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review#dependency-review-enforcement
+name: 'Dependency review'
+on:
+  pull_request:
+    branches: [ "master" ]
+
+# If using a dependency submission action in this workflow this permission will need to be set to:
+#
+# permissions:
+#   contents: write
+#
+# https://docs.github.com/en/enterprise-cloud@latest/code-security/supply-chain-security/understanding-your-software-supply-chain/using-the-dependency-submission-api
+permissions:
+  contents: read
+  # Write permissions for pull-requests are required for using the `comment-summary-in-pr` option, comment out if you aren't using this option
+  pull-requests: write
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout repository'
+        uses: actions/checkout@v4
+      - name: 'Dependency Review'
+        uses: actions/dependency-review-action@v4
+        # Commonly enabled options, see https://github.com/actions/dependency-review-action#configuration-options for all available options.
+        with:
+          comment-summary-in-pr: always
+          vulnerability-check: true
+          fail-on-severity: moderate
+          retry-on-snapshot-warnings: true
+        #   deny-licenses: GPL-1.0-or-later, LGPL-2.0-or-later

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The goal is to create a solid, performant port first. Then build out the sequenc
 <p align=center><img src="https://github.com/user-attachments/assets/291d0c6a-ca2e-4de1-bee7-5c0cfb169ae9" width=50% height=50%></img></p>
 
 ## New Features
+  - [Keyboard Shortcuts](https://github.com/doublemover/LemmingsJS-MIDI/blob/master/README.md#keyboard-shortcuts)
   - Speed is displayed at the bottom of the Paws (Pause) button
     - Click `f` for faster, `-` for slower
     - Right clicking Paws resets the Speed to 1
@@ -18,7 +19,8 @@ The goal is to create a solid, performant port first. Then build out the sequenc
   - Traps animate, are deadly, and have cooldowns
   - Frying, Jumping, Hoisting animations
   - Improved Steel terrain
-    - Using magic numbers based on level pack & ground#.dat to flag steel images and calculate opaque size for precise placement
+    - Steel sprite indexes are stored in `js/steelSprites.json` by game and pack
+      to calculate opaque size for precise placement
   - Arrow Walls function
   - Minimap
     - Accumulates ground at full resolution for enhanced accuracy
@@ -94,7 +96,7 @@ The goal is to create a solid, performant port first. Then build out the sequenc
     - [ ] packname or vnum/difficulty name or number/level title or number nav
   - [ ] Display selection rect around lemming nearest to cursor on hover
   - [ ] Minimap
-    - [ ] switch to uint8
+    - [X] switch to uint8
     - [ ] dots broken
     - [ ] Full vp rect
   - [X] Partial support for xmas91/92 and holiday93/94 level packs
@@ -105,21 +107,6 @@ The goal is to create a solid, performant port first. Then build out the sequenc
     - [ ] debounce/toggle
     - [ ] html needs size set
     - [ ] better level nav buttons/pack & diff dropdowns
-  - [ ] Keyboard shortcuts
-    - [ ] Decrease Release Rate
-    - [ ] Min Release Rate
-    - [ ] Increase Release Rate
-    - [ ] Max Release Rate
-    - [ ] Climb/Float/Bomb/Block/Build/Bash/Mine/Dig
-    - [ ] Pause
-    - [ ] Nuke
-    - [ ] Reset Speed
-    - [ ] Increase Speed
-    - [ ] Decrease Speed
-    - [ ] Restart
-    - [ ] Debug
-    - [ ] Skill/Lem Cycle
-    - [ ] Viewport Movement, Zoom, Reset, Focus Lem/D
   - [ ] Tick Step
 </details>
 
@@ -202,6 +189,24 @@ URL parameters (shortcut in brackets):
 - `nukeAfter (na)`: Automatically nukes after x*10 (default: 0)
 - `scale (sc)`: Adjusts starting zoom .0125-5 (default: 2)
 - `extra (ex)`: Extra lemmings per spawn 1-1000 (default: 0)
+
+## Keyboard Shortcuts
+
+- `(Shift+)1`: Decrease Release Rate (Minimum)
+- `(Shift+)2`: Increase Release Rate (Maximum)
+- `3, 4, 5, 6`: Select Climber, Floater, Bomber, Blocker
+- `Q, W, E, R`: Select Builder, Basher, Miner, Digger
+- `Space`: Pause
+- `(Shift+)T`: Nuke (Instant)
+- `Backspace`: Restart level
+- `(Shift+)←↑↓→`: Move viewport (More)
+- `(Shift+)Z` / `X`: Zoom in / out (More)
+- `V`: Reset zoom to 2
+- `(Shift+)-` / `=`: Decrease / Increase game speed (More)
+- `,` / `.`: Previous / Next level
+- `Shift+,` / `Shift+.`: Previous / Next group
+- `Tab`: Cycle through skills
+- `\`: Toggle debug mode
   
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ The goal is to create a solid, performant port first. Then build out the sequenc
   - [ ] perf.measure helper
 - [ ] Still possible to apply bomb to exploding bombers, probably need to adjust the frame at which they are removed
   - [ ] Same deal with splatting, drowning, and maybe falling lemmings
-- [ ] There is not a pallete swapped frying animation for the 'ice thrower' traps, I want to make one anyways
+- [ ] There is not a palette swapped frying animation for the 'ice thrower' traps, I want to make one anyways
   - [ ] 2-2-9, 1-4-30
 - [ ] Trigger.disabledUntilTick overruns after 24 days
 - [ ] Lemming.isRemoved() null/removed conflict

--- a/css/game.css
+++ b/css/game.css
@@ -101,3 +101,16 @@ canvas {
 .game_container.small > .arrow_r {
     zoom: 0.6
 }
+
+/* style level selection dropdowns */
+#levelSelects select {
+    background-color: #002200;
+    color: #0f0;
+    border: 1px solid #0f0;
+    margin-right: 4px;
+    font-size: 15px;
+}
+
+.game_container.small #levelSelects select {
+    font-size: 11px;
+}

--- a/index.html
+++ b/index.html
@@ -53,10 +53,21 @@
     let lemmings;
     function init() {
       lemmings = new Lemmings.GameView();
-      lemmings.elementLevelName = document.getElementById("levelName");
+      lemmings.elementSelectGameType = document.getElementById("gameTypeSelect");
+      lemmings.elementSelectLevelGroup = document.getElementById("levelGroupSelect");
+      lemmings.elementSelectLevel = document.getElementById("levelIndexSelect");
       lemmings.gameCanvas = document.getElementById("gameCanvas");
       lemmings.setup();
       lemmings.midiOut = WebMidi.outputs[0];
+      lemmings.elementSelectGameType.addEventListener("change", (e) => {
+        lemmings.selectGameType(lemmings.strToNum(e.target.value));
+      });
+      lemmings.elementSelectLevelGroup.addEventListener("change", (e) => {
+        lemmings.selectLevelGroup(lemmings.strToNum(e.target.value));
+      });
+      lemmings.elementSelectLevel.addEventListener("change", (e) => {
+        lemmings.selectLevel(lemmings.strToNum(e.target.value));
+      });
     }
 
     function setSize() {
@@ -104,9 +115,14 @@
   <div class="game">
     <div class="game_container">
       <canvas height="480" width="800" id="gameCanvas"></canvas>
+      <div id="levelSelects" class="level_name">
+        <select id="gameTypeSelect"></select>
+        <select id="levelGroupSelect"></select>
+        <select id="levelIndexSelect"></select>
+      </div>
       <span id="levelName" class="level_name"></span>
-      <img class="arrow_l" src="img/arrow_l.png" onclick="lemmings.moveToLevel(-1)"/>
-      <img class="arrow_r" src="img/arrow_r.png" onclick="lemmings.moveToLevel(1)"/>
+      <img class="arrow_l" src="img/arrow_l.png" width="37" height="58" onclick="lemmings.moveToLevel(-1)"/>
+      <img class="arrow_r" src="img/arrow_r.png" width="37" height="58" onclick="lemmings.moveToLevel(1)"/>
     </div>
   </div>
   <img src="https://sneakyness.com/stats/lemmings-MIDI"/>

--- a/js/ActionBaseSystem.js
+++ b/js/ActionBaseSystem.js
@@ -1,0 +1,80 @@
+import { Lemmings } from './LemmingsNamespace.js';
+
+/**
+ * Base class for all action systems.
+ * Handles sprite and mask caching as well as common draw/trigger logic.
+ */
+class ActionBaseSystem {
+    static spriteCache = new Map();
+    static maskCache = new Map();
+    /**
+     * @param {Object} options
+     * @param {*} options.sprites Sprite provider
+     * @param {*} options.spriteType SpriteTypes enum value
+     * @param {boolean} [options.singleSprite=false] true if only one sprite is used
+     * @param {*} [options.masks] Mask provider
+     * @param {*} [options.maskTypes] mask type or {left, right} pair
+     */
+    constructor({sprites=null, spriteType=null, singleSprite=false, masks=null, maskTypes=null, actionName=null} = {}) {
+        this.sprites = null;
+        this.masks   = null;
+        this.actionName = actionName || '';
+
+        if (sprites && spriteType !== null) {
+            const cacheKey = this.actionName || spriteType;
+            if (!ActionBaseSystem.spriteCache.has(cacheKey)) {
+                const map = new Map();
+                if (singleSprite) {
+                    map.set('both', sprites.getAnimation(spriteType, false));
+                } else {
+                    map.set('left', sprites.getAnimation(spriteType, false));
+                    map.set('right', sprites.getAnimation(spriteType, true));
+                }
+                ActionBaseSystem.spriteCache.set(cacheKey, map);
+            }
+            this.sprites = ActionBaseSystem.spriteCache.get(cacheKey);
+        }
+
+        if (masks && maskTypes !== null) {
+            const cacheKey = this.actionName || JSON.stringify(maskTypes);
+            if (!ActionBaseSystem.maskCache.has(cacheKey)) {
+                const map = new Map();
+                if (singleSprite) {
+                    map.set('both', masks.GetMask(maskTypes));
+                } else {
+                    map.set('left', masks.GetMask(maskTypes.left));
+                    map.set('right', masks.GetMask(maskTypes.right));
+                }
+                ActionBaseSystem.maskCache.set(cacheKey, map);
+            }
+            this.masks = ActionBaseSystem.maskCache.get(cacheKey);
+        }
+    }
+
+    /** Default implementation simply returns configured actionName. */
+    getActionName() {
+        return this.actionName || '';
+    }
+
+    /**
+     * Default trigger sets the action on the lemming and returns true.
+     */
+    triggerLemAction(lem) {
+        lem.setAction(this);
+        return true;
+    }
+
+    /**
+     * Draw the sprite frame based on lemming direction.
+     */
+    draw(gameDisplay, lem) {
+        if (!this.sprites) return;
+        const key = this.sprites.has('both') ? 'both' : lem.getDirection();
+        const ani = this.sprites.get(key);
+        const frame = ani.getFrame(lem.frameIndex);
+        gameDisplay.drawFrame(frame, lem.x, lem.y);
+    }
+}
+
+Lemmings.ActionBaseSystem = ActionBaseSystem;
+export { ActionBaseSystem };

--- a/js/ActionBashSystem.js
+++ b/js/ActionBashSystem.js
@@ -1,31 +1,15 @@
 import { Lemmings } from './LemmingsNamespace.js';
+import { ActionBaseSystem } from './ActionBaseSystem.js';
 
-class ActionBashSystem {
-    static sprites = new Map();
-    static masks = new Map();
+class ActionBashSystem extends ActionBaseSystem {
     constructor(sprites, masks) {
-        if (ActionBashSystem.sprites.size == 0) {
-            ActionBashSystem.sprites.set("left", sprites.getAnimation(Lemmings.SpriteTypes.BASHING, false));
-            ActionBashSystem.sprites.set("right", sprites.getAnimation(Lemmings.SpriteTypes.BASHING, true));
-        }
-        if (ActionBashSystem.masks.size == 0) {
-            ActionBashSystem.masks.set("left", masks.GetMask(Lemmings.MaskTypes.BASHING_L));
-            ActionBashSystem.masks.set("right", masks.GetMask(Lemmings.MaskTypes.BASHING_R));
-        }
-    }
-    getActionName() {
-        return "bashing";
-    }
-
-    triggerLemAction(lem) {
-        lem.setAction(this);
-        return true;
-    }
-
-    draw(gameDisplay, lem) {
-        const ani = ActionBashSystem.sprites.get(lem.getDirection());
-        const frame = ani.getFrame(lem.frameIndex);
-        gameDisplay.drawFrame(frame, lem.x, lem.y);
+        super({
+            sprites,
+            spriteType: Lemmings.SpriteTypes.BASHING,
+            masks,
+            maskTypes: { left: Lemmings.MaskTypes.BASHING_L, right: Lemmings.MaskTypes.BASHING_R },
+            actionName: 'bashing'
+        });
     }
 
     process(level, lem) {
@@ -43,7 +27,7 @@ class ActionBashSystem {
         }
         // apply mask
         if ((state > 1) && (state < 6)) {
-            const subMask = ActionBashSystem.masks.get(lem.getDirection()).GetMask(state - 2);
+            const subMask = this.masks.get(lem.getDirection()).GetMask(state - 2);
             if (state === 3) {
                 if (level.hasSteelUnderMask(subMask, lem.x, lem.y) ||
                     level.hasArrowUnderMask(subMask, lem.x, lem.y, lem.lookRight)) {

--- a/js/ActionBlockerSystem.js
+++ b/js/ActionBlockerSystem.js
@@ -1,23 +1,10 @@
 import { Lemmings } from './LemmingsNamespace.js';
+import { ActionBaseSystem } from './ActionBaseSystem.js';
 
-class ActionBlockerSystem {
-    static sprites = new Map();
+class ActionBlockerSystem extends ActionBaseSystem {
     constructor(sprites, triggerManager) {
+        super({ sprites, spriteType: Lemmings.SpriteTypes.BLOCKING, singleSprite: true, actionName: 'blocking' });
         this.triggerManager = triggerManager;
-        if (ActionBlockerSystem.sprites.size == 0) {
-            ActionBlockerSystem.sprites.set("both", sprites.getAnimation(Lemmings.SpriteTypes.BLOCKING, false));
-        }
-    }
-    getActionName() {
-        return "blocking";
-    }
-    triggerLemAction(lem) {
-        lem.setAction(this);
-        return true;
-    }
-    draw(gameDisplay, lem) {
-        const frame = ActionBlockerSystem.sprites.get("both").getFrame(lem.frameIndex);
-        gameDisplay.drawFrame(frame, lem.x, lem.y);
     }
     process(level, lem) {
         if (lem.state == 0) {

--- a/js/ActionBuildSystem.js
+++ b/js/ActionBuildSystem.js
@@ -1,26 +1,9 @@
 import { Lemmings } from './LemmingsNamespace.js';
+import { ActionBaseSystem } from './ActionBaseSystem.js';
 
-class ActionBuildSystem {
-    static sprites = new Map();
+class ActionBuildSystem extends ActionBaseSystem {
     constructor(sprites) {
-        if (ActionBuildSystem.sprites.size == 0) {
-            ActionBuildSystem.sprites.set("left", sprites.getAnimation(Lemmings.SpriteTypes.BUILDING, false));
-            ActionBuildSystem.sprites.set("right", sprites.getAnimation(Lemmings.SpriteTypes.BUILDING, true));
-        }
-    }
-
-    getActionName() {
-        return "building";
-    }
-
-    triggerLemAction(lem) {
-        lem.setAction(this);
-        return true;
-    }
-    draw(gameDisplay, lem) {
-        const ani = ActionBuildSystem.sprites.get(lem.getDirection());
-        const frame = ani.getFrame(lem.frameIndex);
-        gameDisplay.drawFrame(frame, lem.x, lem.y);
+        super({ sprites, spriteType: Lemmings.SpriteTypes.BUILDING, actionName: 'building' });
     }
     process(level, lem) {
         lem.frameIndex = (lem.frameIndex + 1) % 16;

--- a/js/ActionClimbSystem.js
+++ b/js/ActionClimbSystem.js
@@ -1,17 +1,10 @@
 import { Lemmings } from './LemmingsNamespace.js';
+import { ActionBaseSystem } from './ActionBaseSystem.js';
     
-class ActionClimbSystem {
-    static sprites = new Map();
+class ActionClimbSystem extends ActionBaseSystem {
 
     constructor(sprites) {
-        if (ActionClimbSystem.sprites.size == 0) {
-            ActionClimbSystem.sprites.set("left", sprites.getAnimation(Lemmings.SpriteTypes.CLIMBING, false));
-            ActionClimbSystem.sprites.set("right", sprites.getAnimation(Lemmings.SpriteTypes.CLIMBING, true));
-        }
-    }
-
-    getActionName() {
-        return "climbing";
+        super({ sprites, spriteType: Lemmings.SpriteTypes.CLIMBING, actionName: 'climbing' });
     }
 
     triggerLemAction(lem) {
@@ -20,12 +13,6 @@ class ActionClimbSystem {
         }
         lem.canClimb = true;
         return true;
-    }
-
-    draw(gameDisplay, lem) {
-        const ani = ActionClimbSystem.sprites.get(lem.getDirection());
-        const frame = ani.getFrame(lem.frameIndex);
-        gameDisplay.drawFrame(frame, lem.x, lem.y);
     }
 
     process(level, lem) {

--- a/js/ActionCountdownSystem.js
+++ b/js/ActionCountdownSystem.js
@@ -1,15 +1,13 @@
 import { Lemmings } from './LemmingsNamespace.js';
+import { ActionBaseSystem } from './ActionBaseSystem.js';
 
-class ActionCountdownSystem {
+class ActionCountdownSystem extends ActionBaseSystem {
     static numberMasks = new Map();
     constructor(masks) {
+        super({ actionName: 'countdown' });
         if (ActionCountdownSystem.numberMasks.size == 0) {
             ActionCountdownSystem.numberMasks.set("numbers", masks.GetMask(Lemmings.MaskTypes.NUMBERS));
         }
-    }
-
-    getActionName() {
-        return "countdown";
     }
 
     triggerLemAction(lem) {

--- a/js/ActionDiggSystem.js
+++ b/js/ActionDiggSystem.js
@@ -1,25 +1,10 @@
 import { Lemmings } from './LemmingsNamespace.js';
+import { ActionBaseSystem } from './ActionBaseSystem.js';
         
-class ActionDiggSystem {
-    static sprites = new Map();
-        constructor(sprites) {
-            if (ActionDiggSystem.sprites.size == 0) {
-                ActionDiggSystem.sprites.set("left", sprites.getAnimation(Lemmings.SpriteTypes.DIGGING, false));
-                ActionDiggSystem.sprites.set("right", sprites.getAnimation(Lemmings.SpriteTypes.DIGGING, true));
-            }
-        }
-        draw(gameDisplay, lem) {
-            const ani = ActionDiggSystem.sprites.get(lem.getDirection());
-            const frame = ani.getFrame(lem.frameIndex);
-            gameDisplay.drawFrame(frame, lem.x, lem.y);
-        }
-        getActionName() {
-            return "digging";
-        }
-        triggerLemAction(lem) {
-            lem.setAction(this);
-            return true;
-        }
+class ActionDiggSystem extends ActionBaseSystem {
+    constructor(sprites) {
+        super({ sprites, spriteType: Lemmings.SpriteTypes.DIGGING, actionName: 'digging' });
+    }
         process(level, lem) {
             if (level.isSteelGround(lem.x, lem.y) || 
                 level.isSteelGround(lem.x, lem.y - 1) || 

--- a/js/ActionDrowningSystem.js
+++ b/js/ActionDrowningSystem.js
@@ -1,21 +1,15 @@
 import { Lemmings } from './LemmingsNamespace.js';
+import { ActionBaseSystem } from './ActionBaseSystem.js';
 
-class ActionDrowningSystem {
-    static sprites = new Map();
+class ActionDrowningSystem extends ActionBaseSystem {
     constructor(sprites) {
-        if (ActionDrowningSystem.sprites.size == 0) {
-            ActionDrowningSystem.sprites.set("both", sprites.getAnimation(Lemmings.SpriteTypes.DROWNING, false));
-        }
-    }
-    getActionName() {
-        return "drowning";
+        super({ sprites, spriteType: Lemmings.SpriteTypes.DROWNING, singleSprite: true, actionName: 'drowning' });
     }
     triggerLemAction(lem) {
         return false;
     }
     draw(gameDisplay, lem) {
-        const frame = ActionDrowningSystem.sprites.get("both").getFrame(lem.frameIndex);
-        gameDisplay.drawFrame(frame, lem.x, lem.y);
+        super.draw(gameDisplay, lem);
         if (lem.frameIndex >= 15) {
             lemmings.game.lemmingManager.miniMap.addDeath(lem.x, lem.y);
         }

--- a/js/ActionExitingSystem.js
+++ b/js/ActionExitingSystem.js
@@ -1,22 +1,16 @@
 import { Lemmings } from './LemmingsNamespace.js';
+import { ActionBaseSystem } from './ActionBaseSystem.js';
 
-class ActionExitingSystem {
-    static sprites = new Map();
+class ActionExitingSystem extends ActionBaseSystem {
     constructor(sprites, gameVictoryCondition) {
+        super({ sprites, spriteType: Lemmings.SpriteTypes.EXITING, singleSprite: true, actionName: 'exiting' });
         this.gameVictoryCondition = gameVictoryCondition;
-        if (ActionExitingSystem.sprites.size == 0) {
-            ActionExitingSystem.sprites.set("both", sprites.getAnimation(Lemmings.SpriteTypes.EXITING, false));
-        }
-    }
-    getActionName() {
-        return "exiting";
     }
     triggerLemAction(lem) {
         return false;
     }
     draw(gameDisplay, lem) {
-        const frame = ActionExitingSystem.sprites.get("both").getFrame(lem.frameIndex)
-        gameDisplay.drawFrame(frame, lem.x, lem.y);
+        super.draw(gameDisplay, lem);
     }
     process(level, lem) {
         lem.disable();

--- a/js/ActionExplodingSystem.js
+++ b/js/ActionExplodingSystem.js
@@ -1,23 +1,21 @@
 import { Lemmings } from './LemmingsNamespace.js';
+import { ActionBaseSystem } from './ActionBaseSystem.js';
 
-class ActionExplodingSystem {
-    static sprites = new Map();
-    static masks = new Map();
+class ActionExplodingSystem extends ActionBaseSystem {
 
     constructor(sprites, masks, triggerManager, particleTable) {
+        super({
+            sprites,
+            spriteType: Lemmings.SpriteTypes.EXPLODING,
+            singleSprite: true,
+            masks,
+            maskTypes: Lemmings.MaskTypes.EXPLODING,
+            actionName: 'exploding'
+        });
         this.triggerManager = triggerManager;
         this.particleTable = particleTable;
-        if (ActionExplodingSystem.sprites.size == 0) {
-            ActionExplodingSystem.sprites.set("both", sprites.getAnimation(Lemmings.SpriteTypes.EXPLODING, false));
-        }
-        if (ActionExplodingSystem.masks.size == 0) {
-            ActionExplodingSystem.masks.set("both", masks.GetMask(Lemmings.MaskTypes.EXPLODING));
-        }
     }
 
-    getActionName() {
-        return "exploding";
-    }
 
     triggerLemAction(lem) {
         return false;
@@ -25,7 +23,7 @@ class ActionExplodingSystem {
 
     draw(gameDisplay, lem) {
         if (lem.frameIndex == 0) {
-            const ani = ActionExplodingSystem.sprites.get("both");
+            const ani = this.sprites.get("both");
             const frame = ani.getFrame(lem.frameIndex);
             gameDisplay.drawFrame(frame, lem.x-10, lem.y-8);
         } else {
@@ -38,7 +36,7 @@ class ActionExplodingSystem {
         lem.frameIndex++;
         if (lem.frameIndex == 1) {
             this.triggerManager.removeByOwner(lem);
-            level.clearGroundWithMask(ActionExplodingSystem.masks.get("both").GetMask(0), lem.x, lem.y);
+            level.clearGroundWithMask(this.masks.get("both").GetMask(0), lem.x, lem.y);
         }
         if (lem.frameIndex == 52) {
             return Lemmings.LemmingStateType.OUT_OF_LEVEL;

--- a/js/ActionFallSystem.js
+++ b/js/ActionFallSystem.js
@@ -1,23 +1,15 @@
 import { Lemmings } from './LemmingsNamespace.js';
-class ActionFallSystem {
-    static sprites = new Map();
+import { ActionBaseSystem } from './ActionBaseSystem.js';
+class ActionFallSystem extends ActionBaseSystem {
     constructor(sprites) {
-        if (ActionFallSystem.sprites.size == 0) {
-            ActionFallSystem.sprites.set("left", sprites.getAnimation(Lemmings.SpriteTypes.FALLING, false));
-            ActionFallSystem.sprites.set("right", sprites.getAnimation(Lemmings.SpriteTypes.FALLING, true));
-        }
-    }
-    getActionName() {
-        return "falling";
+        super({ sprites, spriteType: Lemmings.SpriteTypes.FALLING, actionName: 'falling' });
     }
     triggerLemAction(lem) {
         return false;
     }
     /** render Lemming to gamedisplay */
     draw(gameDisplay, lem) {
-        const ani = ActionFallSystem.sprites.get(lem.getDirection());
-        const frame = ani.getFrame(lem.frameIndex);
-        gameDisplay.drawFrame(frame, lem.x, lem.y);
+        super.draw(gameDisplay, lem);
     }
     process(level, lem) {
         lem.frameIndex++;

--- a/js/ActionFloatingSystem.js
+++ b/js/ActionFloatingSystem.js
@@ -1,18 +1,12 @@
 import { Lemmings } from './LemmingsNamespace.js';
+import { ActionBaseSystem } from './ActionBaseSystem.js';
 
 const FLOAT_SPEED = [3, 3, 3, 3, -1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2];
 const FLOAT_FRAME = [0, 1, 3, 5, 5, 5, 5, 5, 5, 6, 7, 7, 6, 5, 4, 4];
 
-class ActionFloatingSystem {
-    static sprites = new Map();
+class ActionFloatingSystem extends ActionBaseSystem {
     constructor(sprites) {
-        if (ActionFloatingSystem.sprites.size == 0) {
-            ActionFloatingSystem.sprites.set("left", sprites.getAnimation(Lemmings.SpriteTypes.UMBRELLA, false));
-            ActionFloatingSystem.sprites.set("right", sprites.getAnimation(Lemmings.SpriteTypes.UMBRELLA, true));
-        }
-    }
-    getActionName() {
-        return "floating";
+        super({ sprites, spriteType: Lemmings.SpriteTypes.UMBRELLA, actionName: 'floating' });
     }
     triggerLemAction(lem) {
         if (lem.hasParachute) {
@@ -23,7 +17,7 @@ class ActionFloatingSystem {
     }
     /** render Lemming to gamedisplay */
     draw(gameDisplay, lem) {
-        const ani = ActionFloatingSystem.sprites.get(lem.getDirection());
+        const ani = this.sprites.get(lem.getDirection());
         const frame = ani.getFrame(FLOAT_FRAME[lem.frameIndex]);
         gameDisplay.drawFrame(frame, lem.x, lem.y);
     }

--- a/js/ActionFryingSystem.js
+++ b/js/ActionFryingSystem.js
@@ -1,15 +1,9 @@
 import { Lemmings } from './LemmingsNamespace.js';
+import { ActionBaseSystem } from './ActionBaseSystem.js';
 
-class ActionFryingSystem {
-    static sprites = new Map();
+class ActionFryingSystem extends ActionBaseSystem {
     constructor(sprites) {
-        if (ActionFryingSystem.sprites.size == 0) {
-            ActionFryingSystem.sprites.set("both", sprites.getAnimation(Lemmings.SpriteTypes.FRYING, false));
-        }
-    }
-
-    getActionName() {
-        return "frying";
+        super({ sprites, spriteType: Lemmings.SpriteTypes.FRYING, singleSprite: true, actionName: 'frying' });
     }
 
     triggerLemAction(lem) {
@@ -17,8 +11,7 @@ class ActionFryingSystem {
     }
 
     draw(gameDisplay, lem) {
-        const frame = ActionFryingSystem.sprites.get("both").getFrame(lem.frameIndex);
-        gameDisplay.drawFrame(frame, lem.x, lem.y);
+        super.draw(gameDisplay, lem);
     }
 
     process(level, lem) {

--- a/js/ActionHoistSystem.js
+++ b/js/ActionHoistSystem.js
@@ -1,16 +1,9 @@
 import { Lemmings } from './LemmingsNamespace.js';
+import { ActionBaseSystem } from './ActionBaseSystem.js';
 
-class ActionHoistSystem {
-    static sprites = new Map();
+class ActionHoistSystem extends ActionBaseSystem {
     constructor(sprites) {
-        if (ActionHoistSystem.sprites.size == 0) {
-            ActionHoistSystem.sprites.set("left", sprites.getAnimation(Lemmings.SpriteTypes.POSTCLIMBING, false));
-            ActionHoistSystem.sprites.set("right", sprites.getAnimation(Lemmings.SpriteTypes.POSTCLIMBING, true));
-        }
-    }
-
-    getActionName() {
-        return "hoist";
+        super({ sprites, spriteType: Lemmings.SpriteTypes.POSTCLIMBING, actionName: 'hoist' });
     }
 
     triggerLemAction(lem) {
@@ -18,9 +11,7 @@ class ActionHoistSystem {
     }
 
     draw(gameDisplay, lem) {
-        const ani = ActionHoistSystem.sprites.get(lem.getDirection());
-        const frame = ani.getFrame(lem.frameIndex);
-        gameDisplay.drawFrame(frame, lem.x, lem.y);
+        super.draw(gameDisplay, lem);
     }
 
     // y+1, x+1 & y+1, x+2 & y+2?

--- a/js/ActionJumpSystem.js
+++ b/js/ActionJumpSystem.js
@@ -17,17 +17,27 @@ class ActionJumpSystem extends ActionBaseSystem {
     process(level, lem) {
         lem.frameIndex++;
         lem.x += (lem.lookRight ? 1 : -1);
-        let i = 0;
-        for (; i < 2; i++) {
-            if (!level.hasGroundAt(lem.x, lem.y - i - 1)) {
-                break;
-            }
+
+        if (lem.state == null) {
+            lem.state = 0; // how far we've jumped so far
         }
-        lem.y -= i;
-        if (i < 2) { // stop jumping
+
+        let moved = 0;
+        while (lem.state < 2 && moved < 2 && level.hasGroundAt(lem.x, lem.y - 1)) {
+            lem.y--;
+            lem.state++;
+            moved++;
+        }
+
+        if (lem.state >= 2 || !level.hasGroundAt(lem.x, lem.y - 1)) {
+            if (lem.y < Lemmings.Lemming.LEM_MIN_Y) {
+                lem.y = Lemmings.Lemming.LEM_MIN_Y;
+            }
+            lem.state = 0;
             return Lemmings.LemmingStateType.WALKING;
         }
-        return Lemmings.LemmingStateType.NO_STATE_TYPE; // this.check_top_collision(lem); <no idea what this is for
+
+        return Lemmings.LemmingStateType.JUMPING;
     }
 }
 

--- a/js/ActionJumpSystem.js
+++ b/js/ActionJumpSystem.js
@@ -1,16 +1,9 @@
 import { Lemmings } from './LemmingsNamespace.js';
+import { ActionBaseSystem } from './ActionBaseSystem.js';
 
-class ActionJumpSystem {
-    static sprites = new Map();
+class ActionJumpSystem extends ActionBaseSystem {
     constructor(sprites) {
-        if (ActionJumpSystem.sprites.size == 0) {
-            ActionJumpSystem.sprites.set("left", sprites.getAnimation(Lemmings.SpriteTypes.JUMPING, false));
-            ActionJumpSystem.sprites.set("right", sprites.getAnimation(Lemmings.SpriteTypes.JUMPING, true));
-        }
-    }
-
-    getActionName() {
-        return "jump";
+        super({ sprites, spriteType: Lemmings.SpriteTypes.JUMPING, actionName: 'jump' });
     }
 
     triggerLemAction(lem) {
@@ -18,9 +11,7 @@ class ActionJumpSystem {
     }
 
     draw(gameDisplay, lem) {
-        const ani = ActionJumpSystem.sprites.get(lem.getDirection());
-        const frame = ani.getFrame(lem.frameIndex);
-        gameDisplay.drawFrame(frame, lem.x, lem.y);
+        super.draw(gameDisplay, lem);
     }
 
     process(level, lem) {

--- a/js/ActionMineSystem.js
+++ b/js/ActionMineSystem.js
@@ -1,36 +1,22 @@
 import { Lemmings } from './LemmingsNamespace.js';
+import { ActionBaseSystem } from './ActionBaseSystem.js';
 
-class ActionMineSystem {
-    static sprites = new Map();
-    static masks = new Map();
+class ActionMineSystem extends ActionBaseSystem {
     constructor(sprites, masks) {
-        if (ActionMineSystem.sprites.size == 0) {
-            ActionMineSystem.sprites.set("left", sprites.getAnimation(Lemmings.SpriteTypes.MINING, false));
-            ActionMineSystem.sprites.set("right", sprites.getAnimation(Lemmings.SpriteTypes.MINING, true));
-        }
-        if (ActionMineSystem.masks.size == 0) {
-            ActionMineSystem.masks.set("left", masks.GetMask(Lemmings.MaskTypes.MINING_L));
-            ActionMineSystem.masks.set("right", masks.GetMask(Lemmings.MaskTypes.MINING_R));
-        }
-    }
-    draw(gameDisplay, lem) {
-        const ani = ActionMineSystem.sprites.get(lem.getDirection());
-        const frame = ani.getFrame(lem.frameIndex);
-        gameDisplay.drawFrame(frame, lem.x, lem.y);
-    }
-    getActionName() {
-        return "mining";
-    }
-    triggerLemAction(lem) {
-        lem.setAction(this);
-        return true;
+        super({
+            sprites,
+            spriteType: Lemmings.SpriteTypes.MINING,
+            masks,
+            maskTypes: { left: Lemmings.MaskTypes.MINING_L, right: Lemmings.MaskTypes.MINING_R },
+            actionName: 'mining'
+        });
     }
     process(level, lem) {
         lem.frameIndex = (lem.frameIndex + 1) % 24;
         switch (lem.frameIndex) {
         case 1:
         case 2:
-            let mask = ActionMineSystem.masks.get(lem.getDirection());
+            let mask = this.masks.get(lem.getDirection());
             let maskIndex = lem.frameIndex - 1;
             let subMask   = mask.GetMask(maskIndex);
             if (level.hasSteelUnderMask(subMask, lem.x, lem.y)) {

--- a/js/ActionOhNoSystem.js
+++ b/js/ActionOhNoSystem.js
@@ -1,15 +1,9 @@
 import { Lemmings } from './LemmingsNamespace.js';
+import { ActionBaseSystem } from './ActionBaseSystem.js';
     
-class ActionOhNoSystem {
-    static sprites = new Map();
+class ActionOhNoSystem extends ActionBaseSystem {
     constructor(sprites) {
-        if (ActionOhNoSystem.sprites.size == 0) {
-            ActionOhNoSystem.sprites.set("both", sprites.getAnimation(Lemmings.SpriteTypes.OHNO, false));
-        }
-    }
-
-    getActionName() {
-        return "oh-no";
+        super({ sprites, spriteType: Lemmings.SpriteTypes.OHNO, singleSprite: true, actionName: 'oh-no' });
     }
 
     triggerLemAction(lem) {
@@ -17,8 +11,7 @@ class ActionOhNoSystem {
     }
 
     draw(gameDisplay, lem) {
-        const frame = ActionOhNoSystem.sprites.get("both").getFrame(lem.frameIndex);
-        gameDisplay.drawFrame(frame, lem.x, lem.y);
+        super.draw(gameDisplay, lem);
         if (lem.frameIndex >= 15) {
             lemmings.game.lemmingManager.miniMap.addDeath(lem.x, lem.y);
         }

--- a/js/ActionShrugSystem.js
+++ b/js/ActionShrugSystem.js
@@ -1,16 +1,9 @@
 import { Lemmings } from './LemmingsNamespace.js';
+import { ActionBaseSystem } from './ActionBaseSystem.js';
 
-class ActionShrugSystem {
-    static sprites = new Map();
+class ActionShrugSystem extends ActionBaseSystem {
     constructor(sprites) {
-        if (ActionShrugSystem.sprites.size == 0) {
-            ActionShrugSystem.sprites.set("left", sprites.getAnimation(Lemmings.SpriteTypes.SHRUGGING, false));
-            ActionShrugSystem.sprites.set("right", sprites.getAnimation(Lemmings.SpriteTypes.SHRUGGING, true));
-        }
-    }
-
-    getActionName() {
-        return "shrugging";
+        super({ sprites, spriteType: Lemmings.SpriteTypes.SHRUGGING, actionName: 'shrugging' });
     }
 
     triggerLemAction(lem) {
@@ -18,8 +11,7 @@ class ActionShrugSystem {
     }
 
     draw(gameDisplay, lem) {
-        const frame = ActionShrugSystem.sprites.get(lem.getDirection()).getFrame(lem.frameIndex);
-        gameDisplay.drawFrame(frame, lem.x, lem.y);
+        super.draw(gameDisplay, lem);
     }
 
     process(level, lem) {

--- a/js/ActionSplatterSystem.js
+++ b/js/ActionSplatterSystem.js
@@ -1,19 +1,15 @@
 import { Lemmings } from './LemmingsNamespace.js';
+import { ActionBaseSystem } from './ActionBaseSystem.js';
         
-class ActionSplatterSystem {
-        static sprites = new Map();
+class ActionSplatterSystem extends ActionBaseSystem {
         constructor(sprites) {
-            ActionSplatterSystem.sprites.set("both", sprites.getAnimation(Lemmings.SpriteTypes.SPLATTING, false));
-        }
-        getActionName() {
-            return "splatter";
+            super({ sprites, spriteType: Lemmings.SpriteTypes.SPLATTING, singleSprite: true, actionName: 'splatter' });
         }
         triggerLemAction(lem) {
             return false;
         }
         draw(gameDisplay, lem) {
-            const frame = ActionSplatterSystem.sprites.get("both").getFrame(lem.frameIndex);
-            gameDisplay.drawFrame(frame, lem.x, lem.y);
+            super.draw(gameDisplay, lem);
             if (lem.frameIndex >= 15) {
                 lemmings.game.lemmingManager.miniMap.addDeath(lem.x, lem.y);
             }

--- a/js/ActionWalkSystem.js
+++ b/js/ActionWalkSystem.js
@@ -1,18 +1,9 @@
 import { Lemmings } from './LemmingsNamespace.js';
+import { ActionBaseSystem } from './ActionBaseSystem.js';
 
-class ActionWalkSystem {
-        static sprites = new Map();
+class ActionWalkSystem extends ActionBaseSystem {
         constructor(sprites) {
-            ActionWalkSystem.sprites.set("left", sprites.getAnimation(Lemmings.SpriteTypes.WALKING, false));
-            ActionWalkSystem.sprites.set("right", sprites.getAnimation(Lemmings.SpriteTypes.WALKING, true));
-        }
-        draw(gameDisplay, lem) {
-            const ani = ActionWalkSystem.sprites.get(lem.getDirection());
-            const frame = ani.getFrame(lem.frameIndex);
-            gameDisplay.drawFrame(frame, lem.x, lem.y);
-        }
-        getActionName() {
-            return "walk";
+            super({ sprites, spriteType: Lemmings.SpriteTypes.WALKING, actionName: 'walk' });
         }
         triggerLemAction(lem) {
             return false;

--- a/js/ActionWalkSystem.js
+++ b/js/ActionWalkSystem.js
@@ -8,7 +8,7 @@ class ActionWalkSystem extends ActionBaseSystem {
         triggerLemAction(lem) {
             return false;
         }
-        getGroundStepDelta(groundMask, x, y) {
+        getGroundStepHeight(groundMask, x, y) {
             for (let i = 0; i < 8; i++) {
                 if (!groundMask.hasGroundAt(x, y - i)) {
                     return i;
@@ -16,7 +16,8 @@ class ActionWalkSystem extends ActionBaseSystem {
             }
             return 8;
         }
-        getGroudGapDelta(groundMask, x, y) {
+
+        getGroundGapDepth(groundMask, x, y) {
             for (let i = 1; i < 4; i++) {
                 if (groundMask.hasGroundAt(x, y + i)) {
                     return i;
@@ -27,35 +28,34 @@ class ActionWalkSystem extends ActionBaseSystem {
         process(level, lem) {
             lem.frameIndex++;
             lem.x += (lem.lookRight ? 1 : -1);
+
             const groundMask = level.getGroundMaskLayer();
-            const upDelta = this.getGroundStepDelta(groundMask, lem.x, lem.y);
+            const upDelta = this.getGroundStepHeight(groundMask, lem.x, lem.y);
             if (upDelta == 8) {
                 // collision with obstacle
                 if (lem.canClimb) {
-                    // start climbing
                     return Lemmings.LemmingStateType.CLIMBING;
                 } else {
-                    // turn around
                     lem.lookRight = !lem.lookRight;
                     return Lemmings.LemmingStateType.NO_STATE_TYPE;
                 }
             } else if (upDelta > 0) {
                 lem.y -= upDelta - 1;
                 if (upDelta > 3) {
-                    // jump
-                    return Lemmings.LemmingStateType.NO_STATE_TYPE;
+                    lem.state = 0;
+                    return Lemmings.LemmingStateType.JUMPING;
                 } else {
-                    // walk with small jump up
+                    if (lem.y < Lemmings.Lemming.LEM_MIN_Y) {
+                        lem.y = Lemmings.Lemming.LEM_MIN_Y;
+                    }
                     return Lemmings.LemmingStateType.NO_STATE_TYPE;
                 }
             } else {
-                // walk or fall
-                let downDelta = this.getGroudGapDelta(groundMask, lem.x, lem.y);
+                let downDelta = this.getGroundGapDepth(groundMask, lem.x, lem.y);
                 lem.y += downDelta;
                 if (downDelta == 4) {
                     return Lemmings.LemmingStateType.FALLING;
                 } else {
-                    // walk with small jump down
                     return Lemmings.LemmingStateType.NO_STATE_TYPE;
                 }
             }

--- a/js/BinaryReader.js
+++ b/js/BinaryReader.js
@@ -5,7 +5,7 @@ import { Lemmings } from './LemmingsNamespace.js';
  * Used for game/resource file decoding.
  * @class
  */
-class BinaryReader {
+class BinaryReader extends Lemmings.BaseLogger {
   /** @type {Uint8Array} Backing store for bytes */
   #data;
 
@@ -24,8 +24,6 @@ class BinaryReader {
   /** @type {string} Folder name (for logging/debug) */
   foldername;
 
-  /** @type {Lemmings.LogHandler} Logger */
-  #log;
 
   /**
    * @param {Uint8Array|ArrayBuffer|BinaryReader|null} dataArray - Backing data (or another BinaryReader).
@@ -35,37 +33,37 @@ class BinaryReader {
    * @param {string} [foldername='[unknown]'] - Folder name for debug/logging.
    */
   constructor(dataArray, offset = 0, length, filename = "[unknown]", foldername = "[unknown]") {
+    super();
     this.filename = filename;
     this.foldername = foldername;
-    this.#log = new Lemmings.LogHandler("BinaryReader");
 
     let dataLength = 0;
     if (dataArray == null) {
       this.#data = new Uint8Array(0);
       dataLength = 0;
-      this.#log.log("BinaryReader from NULL; size: 0");
+      this.log.log("BinaryReader from NULL; size: 0");
     } else if (dataArray instanceof BinaryReader) {
       this.#data = dataArray.data;
       dataLength = dataArray.length;
-      this.#log.log("BinaryReader from BinaryReader; size: " + dataLength);
+      this.log.log("BinaryReader from BinaryReader; size: " + dataLength);
     } else if (dataArray instanceof Uint8Array) {
       this.#data = dataArray;
       dataLength = dataArray.byteLength;
-      this.#log.log("BinaryReader from Uint8Array; size: " + dataLength);
+      this.log.log("BinaryReader from Uint8Array; size: " + dataLength);
     } else if (dataArray instanceof ArrayBuffer) {
       this.#data = new Uint8Array(dataArray);
       dataLength = dataArray.byteLength;
-      this.#log.log("BinaryReader from ArrayBuffer; size: " + dataLength);
+      this.log.log("BinaryReader from ArrayBuffer; size: " + dataLength);
     } else if (typeof Blob !== 'undefined' && dataArray instanceof Blob) {
       // Modern browsers: Blobs must be async-read; fallback for now
       this.#data = new Uint8Array(0);
       dataLength = 0;
-      this.#log.log("BinaryReader from Blob: async not implemented; size: 0");
+      this.log.log("BinaryReader from Blob: async not implemented; size: 0");
     } else {
       // Generic object: treat as array-like
       this.#data = new Uint8Array(dataArray);
       dataLength = this.#data.length;
-      this.#log.log("BinaryReader from unknown: " + dataArray + "; size:" + dataLength);
+      this.log.log("BinaryReader from unknown: " + dataArray + "; size:" + dataLength);
     }
 
     if (length == null) length = dataLength - offset;
@@ -105,7 +103,7 @@ class BinaryReader {
       this.#pos = (offset + this.#hiddenOffset);
     }
     if (this.#pos < 0 || this.#pos >= this.#data.length) {
-      this.#log.log(`read out of data: ${this.filename} - size: ${this.#data.length} @ ${this.#pos}`);
+      this.log.log(`read out of data: ${this.filename} - size: ${this.#data.length} @ ${this.#pos}`);
       return 0;
     }
     return this.#data[this.#pos++];

--- a/js/BitReader.js
+++ b/js/BitReader.js
@@ -105,7 +105,7 @@ class BitReader {
    * @returns {boolean}
    */
   eof() {
-    return this.#bufferLen === 0 && this.#pos < 0;
+    return this.#bufferLen === 0 && this.#pos <= 0;
   }
 }
 

--- a/js/BitWriter.js
+++ b/js/BitWriter.js
@@ -5,7 +5,7 @@ import { Lemmings } from './LemmingsNamespace.js';
  * Copies raw data or references already-written bytes using a BitReader.
  * @class
  */
-class BitWriter {
+class BitWriter extends Lemmings.BaseLogger {
   /** @type {Uint8Array} Output buffer (write backwards from end) */
   #outData;
 
@@ -15,21 +15,19 @@ class BitWriter {
   /** @type {Lemmings.BitReader} Input reader for compressed data */
   #bitReader;
 
-  /** @type {Lemmings.LogHandler} Logger */
-  #log;
 
   /**
    * @param {Lemmings.BitReader} bitReader - Source of compressed bits.
    * @param {number} outLength - Total length of output buffer.
    */
   constructor(bitReader, outLength) {
+    super();
     if (!bitReader || typeof bitReader.read !== 'function') {
       throw new TypeError('bitReader must have a .read() method');
     }
     if (!Number.isInteger(outLength) || outLength <= 0) {
       throw new RangeError('outLength must be a positive integer');
     }
-    this.#log = new Lemmings.LogHandler('BitWriter');
     this.#outData = new Uint8Array(outLength);
     this.#outPos = outLength; // Write head walks *backwards*
     this.#bitReader = bitReader;
@@ -60,7 +58,7 @@ class BitWriter {
     const reader = this.#bitReader;
 
     if (outPos - length < 0) {
-      this.#log.log('copyRawData: out of out buffer');
+      this.log.log('copyRawData: out of out buffer');
       length = outPos;
     }
 
@@ -82,11 +80,11 @@ class BitWriter {
     const offset = this.#bitReader.read(offsetBitCount) + 1;
 
     if (outPos + offset > outData.length) {
-      this.#log.log('copyReferencedData: offset out of range');
+      this.log.log('copyReferencedData: offset out of range');
       return;
     }
     if (outPos - length < 0) {
-      this.#log.log('copyReferencedData: out of out buffer');
+      this.log.log('copyReferencedData: out of out buffer');
       length = outPos;
     }
 

--- a/js/CommandManager.js
+++ b/js/CommandManager.js
@@ -1,8 +1,8 @@
 import { Lemmings } from './LemmingsNamespace.js';
 
-class CommandManager {
+class CommandManager extends Lemmings.BaseLogger {
     constructor(game, gameTimer) {
-        this.log = new Lemmings.LogHandler("CommandManager");
+        super();
         if (game == null || gameTimer == null) {
             this.log.log("error! game/timer is null");
             return;

--- a/js/CommandSelectSkill.js
+++ b/js/CommandSelectSkill.js
@@ -1,9 +1,10 @@
 import { Lemmings } from './LemmingsNamespace.js';
 
-class CommandSelectSkill {
+class CommandSelectSkill extends Lemmings.BaseLogger {
     constructor(skill) {
+        super();
         if (!skill) {
-            console.log("error, skill is null");
+            this.log.log("error, skill is null");
             return;
         }
         this.skill = skill;

--- a/js/ConfigReader.js
+++ b/js/ConfigReader.js
@@ -1,8 +1,8 @@
 import { Lemmings } from './LemmingsNamespace.js';
 
-class ConfigReader {
+class ConfigReader extends Lemmings.BaseLogger {
         constructor(configFile) {
-            this.log = new Lemmings.LogHandler("ConfigReader");
+            super();
             this.configs = new Promise((resolve, reject) => {
                 configFile.then((jsonString) => {
                     let configJson = this.parseConfig(jsonString);

--- a/js/DisplayImage.js
+++ b/js/DisplayImage.js
@@ -17,8 +17,9 @@ const cyrb53 = (str, seed = 0) => {
     return 4294967296 * (2097151 & h2) + (h1 >>> 0);
 };
 
-class DisplayImage {
+class DisplayImage extends Lemmings.BaseLogger {
     constructor(stage) {
+        super();
         this.stage = stage;
         this.onMouseUp = new Lemmings.EventHandler();
         this.onMouseDown = new Lemmings.EventHandler();
@@ -63,7 +64,7 @@ class DisplayImage {
             this.buffer32.set(groundImage);
         } else {
             // Fallback (ArrayLike)
-            console.log("error: setBackground fallback")
+            this.log.log("error: setBackground fallback");
             // this.imgData.data.set(groundImage);
         }
         this.groundMask = groundMask;
@@ -111,6 +112,54 @@ class DisplayImage {
         const color32 = 0xFF000000 | (b & 0xFF) << 16 | (g & 0xFF) << 8 | (r & 0xFF);
         let idx = y * w + x1;
         for (let x = x1; x <= x2; x++, idx++) this.buffer32[idx] = color32;
+    }
+
+    /**
+     * Draw rectangle outline using a "marching ants" effect.
+     * @param {number} x      Top left x position
+     * @param {number} y      Top left y position
+     * @param {number} width  Rectangle width
+     * @param {number} height Rectangle height
+     * @param {number} dashLen Length of each dash segment (in pixels)
+     * @param {number} offset  Offset of the dash pattern
+     */
+    drawMarchingAntRect(
+        x,
+        y,
+        width,
+        height,
+        dashLen = 3,
+        offset = 0,
+        color1 = 0xFFFFFFFF,
+        color2 = 0xFF000000
+    ) {
+        if (!this.buffer32) return;
+        const { width: w } = this.imgData;
+        const pattern = dashLen * 2;
+        let pos = ((offset % pattern) + pattern) % pattern;
+        const set = (px, py) => {
+            const useFirst = Math.floor(pos / dashLen) % 2 === 0;
+            this.buffer32[py * w + px] = useFirst ? color1 : color2;
+            pos = (pos + 1) % pattern;
+        };
+
+        for (let dx = 0; dx <= width; dx++) set(x + dx, y);
+        for (let dy = 1; dy <= height; dy++) set(x + width, y + dy);
+        for (let dx = 1; dx <= width; dx++) set(x + width - dx, y + height);
+        for (let dy = 1; dy < height; dy++) set(x, y + height - dy);
+    }
+
+    /** Draw a stippled rectangle fill (simple checkerboard pattern). */
+    drawStippleRect(x, y, width, height, r = 128, g = 128, b = 128) {
+        if (!this.buffer32) return;
+        const { width: w } = this.imgData;
+        const color32 = 0xFF000000 | (b & 0xFF) << 16 | (g & 0xFF) << 8 | (r & 0xFF);
+        for (let dy = 0; dy <= height; dy++) {
+            let idx = (y + dy) * w + x;
+            for (let dx = 0; dx <= width; dx++, idx++) {
+                if (((dx + dy) & 1) === 0) this.buffer32[idx] = color32;
+            }
+        }
     }
 
     /* ---------- blitting helpers ---------- */

--- a/js/EventHandler.js
+++ b/js/EventHandler.js
@@ -19,7 +19,7 @@ class EventHandler {
 
   // Remove all callbacks
   dispose () {
-    this.handlers.length = 0;
+    this.handlers.clear();
   }
 
   // Run every handler with `arg`.  No `.slice()` → no transient allocations

--- a/js/FileProvider.js
+++ b/js/FileProvider.js
@@ -3,10 +3,10 @@ import { Lemmings } from './LemmingsNamespace.js';
 /**
  * FileProvider with transparent in‑memory caching.
  */
-class FileProvider {
+class FileProvider extends Lemmings.BaseLogger {
   constructor(rootPath) {
+    super();
     this.rootPath = rootPath;
-    this.log = new Lemmings.LogHandler('FileProvider');
 
     /**
      * Cache mapping full URL → Promise<BinaryReader> or Promise<string>.
@@ -34,33 +34,18 @@ class FileProvider {
       return this._cache.get(url);
     }
 
-    this.log.debug('loading: ' + url);
+    let promise;
+    if (!opts.forceReload) {
+      const cached = this._loadFromLocalStorage(url, 'binary', path);
+      if (cached) {
+        promise = Promise.resolve(cached.value);
+      }
+    }
 
-    const promise = new Promise((resolve, reject) => {
-      const xhr = new XMLHttpRequest();
-      xhr.onload = () => {
-        if (xhr.status >= 200 && xhr.status < 300) {
-          const reader = new Lemmings.BinaryReader(
-            xhr.response,
-            0,
-            null,
-            this._filenameFromUrl(url),
-            path,
-          );
-          resolve(reader);
-        } else {
-          this.log.log('error load file:' + url);
-          reject({ status: xhr.status, statusText: xhr.statusText });
-        }
-      };
-      xhr.onerror = () => {
-        this.log.log('error load file:' + url);
-        reject({ status: xhr.status, statusText: xhr.statusText });
-      };
-      xhr.open('GET', url);
-      xhr.responseType = 'arraybuffer';
-      xhr.send();
-    });
+    if (!promise) {
+      this.log.debug('loading: ' + url);
+      promise = this._fetchBinary(url, path);
+    }
 
     if (!opts.forceReload) {
       this._cache.set(url, promise);
@@ -76,19 +61,18 @@ class FileProvider {
       return this._cache.get(url);
     }
 
-    // this.log.debug('loading text: ' + url);
+    let promise;
+    if (!opts.forceReload) {
+      const cached = this._loadFromLocalStorage(url, 'text');
+      if (cached) {
+        promise = Promise.resolve(cached.value);
+      }
+    }
 
-    const promise = new Promise((resolve, reject) => {
-      const xhr = new XMLHttpRequest();
-      xhr.onload = () => resolve(xhr.response);
-      xhr.onerror = () => {
-        this.log.log('error load file:' + url);
-        reject({ status: xhr.status, statusText: xhr.statusText });
-      };
-      xhr.open('GET', url, true);
-      xhr.responseType = 'text';
-      xhr.send(null);
-    });
+    if (!promise) {
+      // this.log.debug('loading text: ' + url);
+      promise = this._fetchText(url);
+    }
 
     if (!opts.forceReload) {
       this._cache.set(url, promise);
@@ -108,6 +92,158 @@ class FileProvider {
     if (!url) return '';
     url = url.split('#')[0].split('?')[0];
     return url.substring(url.lastIndexOf('/') + 1);
+  }
+
+  _loadFromLocalStorage(url, type, path = '') {
+    try {
+      const item = localStorage.getItem('lem-cache:' + url);
+      if (!item) return null;
+      const entry = JSON.parse(item);
+
+      // kick off async validation of cache
+      this._verifyCache(url, entry);
+
+      let value;
+      if (type === 'binary') {
+        const buf = this._base64ToArrayBuffer(entry.data);
+        value = new Lemmings.BinaryReader(buf, 0, null, this._filenameFromUrl(url), path);
+      } else {
+        value = entry.data;
+      }
+      return { value, entry };
+    } catch (e) {
+      return null;
+    }
+  }
+
+  async _verifyCache(url, entry) {
+    const head = await this._fetchHead(url);
+    if (!head) return;
+    if (entry.etag && head.etag && entry.etag === head.etag) return;
+    if (entry.lastModified && head.lastModified && entry.lastModified === head.lastModified) return;
+    try {
+      if (entry.type === 'binary') {
+        await this._fetchBinary(url, '');
+      } else {
+        await this._fetchText(url);
+      }
+    } catch (e) {
+      console.log('cache update error', e);
+    }
+  }
+
+  async _fetchBinary(url, path) {
+    const data = await new Promise((resolve, reject) => {
+      const xhr = new XMLHttpRequest();
+      xhr.onload = () => {
+        if (xhr.status >= 200 && xhr.status < 300) {
+          const headers = {
+            etag: typeof xhr.getResponseHeader === 'function' ? xhr.getResponseHeader('ETag') : null,
+            lastModified: typeof xhr.getResponseHeader === 'function' ? xhr.getResponseHeader('Last-Modified') : null,
+          };
+          resolve({ buffer: xhr.response, headers });
+        } else {
+          const err = new Error('error load file: ' + url);
+          this.log.log(err.message);
+          reject(err);
+        }
+      };
+      xhr.onerror = () => {
+        const err = new Error('error load file: ' + url);
+        this.log.log(err.message);
+        reject(err);
+      };
+      xhr.open('GET', url);
+      xhr.responseType = 'arraybuffer';
+      xhr.send();
+    });
+
+    const buf = data.buffer;
+    const reader = new Lemmings.BinaryReader(buf, 0, null, this._filenameFromUrl(url), path);
+    const hash = await this._hashBuffer(buf);
+    this._storeInLocalStorage(url, { type: 'binary', data: this._arrayBufferToBase64(buf), hash, ...data.headers });
+    return reader;
+  }
+
+  async _fetchText(url) {
+    const data = await new Promise((resolve, reject) => {
+      const xhr = new XMLHttpRequest();
+      xhr.onload = () => {
+        if (xhr.status >= 200 && xhr.status < 300) {
+          const headers = {
+            etag: typeof xhr.getResponseHeader === 'function' ? xhr.getResponseHeader('ETag') : null,
+            lastModified: typeof xhr.getResponseHeader === 'function' ? xhr.getResponseHeader('Last-Modified') : null,
+          };
+          resolve({ text: xhr.response, headers });
+        } else {
+          const err = new Error('error load file: ' + url);
+          this.log.log(err.message);
+          reject(err);
+        }
+      };
+      xhr.onerror = () => {
+        const err = new Error('error load file: ' + url);
+        this.log.log(err.message);
+        reject(err);
+      };
+      xhr.open('GET', url);
+      xhr.responseType = 'text';
+      xhr.send();
+    });
+
+    const text = data.text;
+    const hash = await this._hashString(text);
+    this._storeInLocalStorage(url, { type: 'text', data: text, hash, ...data.headers });
+    return text;
+  }
+
+  async _fetchHead(url) {
+    if (typeof fetch !== 'function') return null;
+    try {
+      const resp = await fetch(url, { method: 'HEAD' });
+      return { etag: resp.headers.get('ETag'), lastModified: resp.headers.get('Last-Modified') };
+    } catch (e) {
+      return null;
+    }
+  }
+
+  _storeInLocalStorage(url, entry) {
+    try {
+      localStorage.setItem('lem-cache:' + url, JSON.stringify(entry));
+    } catch (e) {
+      console.log('cache write error', e);
+    }
+  }
+
+  async _hashBuffer(buffer) {
+    const hashBuf = await crypto.subtle.digest('SHA-256', buffer);
+    return Array.from(new Uint8Array(hashBuf))
+      .map(b => b.toString(16).padStart(2, '0'))
+      .join('');
+  }
+
+  async _hashString(str) {
+    const enc = new TextEncoder();
+    return this._hashBuffer(enc.encode(str));
+  }
+
+  _arrayBufferToBase64(buffer) {
+    let binary = '';
+    const bytes = new Uint8Array(buffer);
+    for (let i = 0; i < bytes.byteLength; i++) {
+      binary += String.fromCharCode(bytes[i]);
+    }
+    return btoa(binary);
+  }
+
+  _base64ToArrayBuffer(base64) {
+    const binary = atob(base64);
+    const len = binary.length;
+    const bytes = new Uint8Array(len);
+    for (let i = 0; i < len; i++) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes.buffer;
   }
 }
 

--- a/js/Game.js
+++ b/js/Game.js
@@ -1,8 +1,8 @@
 import { Lemmings } from './LemmingsNamespace.js';
 
-class Game {
+class Game extends Lemmings.BaseLogger {
   constructor (gameResources) {
-    this.log           = new Lemmings.LogHandler('Game');
+    super();
     this.gameResources = gameResources;
 
     // runtime refs (null until loadLevel resolves)

--- a/js/GameGui.js
+++ b/js/GameGui.js
@@ -50,8 +50,13 @@ class GameGui {
                     this.nukePrepared = false;
                 }
             }
-            this.backgroundChanged = true;
-            this._guiRafId = window.requestAnimationFrame(this._guiBound);
+            if (((this.gameTimer.getGameTime()|0) % 2) == 0) {
+                this.backgroundChanged = true;
+            }
+
+            if (this._guiRafId == 0) {
+                this._guiRafId = window.requestAnimationFrame(this._guiBound);
+            }
         })
 
         skills.onCountChanged.on(() => {
@@ -148,7 +153,6 @@ class GameGui {
                     if (speedFac < 10) {
                         this.gameTimer.speedFactor++;
                         this.drawSpeedChange(true);
-
                         return;
                     }
                 }
@@ -260,6 +264,7 @@ class GameGui {
         if (this._guiRafId) {
             window.cancelAnimationFrame(this._guiRafId);
             this._guiRafId = 0;
+            this.gameTimer.eachGameSecond.off();
         }
         if (this.display && this._displayListeners) {
             for (const [event, handler] of this._displayListeners) {
@@ -286,19 +291,20 @@ class GameGui {
             this.gameTimeChanged = this.skillsCountChangd = this.skillSelectionChanged = this.releaseRateChanged = this.gameSpeedChanged = true;
         }
 
-        if (this.gameTimeChanged || lemmings.debugOrBench) {
+        if (this.gameTimeChanged) {
             this.gameTimeChanged = false;
-            this.drawGreenString(d, 'Time ' + this.gameTimer.getGameLeftTimeString() + '-00', 248, 0);
-
+            
             if (lemmings.bench == false) {
+                this.drawGreenString(d, 'Time ' + this.gameTimer.getGameLeftTimeString() + '-00', 248, 0);
                 const outCount = this.gameVictoryCondition.getOutCount();
                 if (outCount >= 0) {
                     this.drawGreenString(d, 'Out ' + this.gameVictoryCondition.getOutCount() + '  ', 112, 0);
                 }
-            } else if (lemmings.bench == true) {
-                this.drawGreenString(d, ' ' + lemmings.laggedOut + '  ', 112, 0);
+                this.drawGreenString(d, 'In'  + this._pad(this.gameVictoryCondition.getSurvivorPercentage(), 3) + '%', 186, 0);
+            } else if (lemmings.bench == true && this.gameSpeedChanged) {
+                this.drawGreenString(d, ' L' + lemmings.laggedOut + '  ', 112, 0);
+                this.drawGreenString(d, ' T' + lemmings.steps + '  ', 0, 0);
             }
-            this.drawGreenString(d, 'In'  + this._pad(this.gameVictoryCondition.getSurvivorPercentage(), 3) + '%', 186, 0);
         }
 
         if (this.gameSpeedChanged) {

--- a/js/GameGui.js
+++ b/js/GameGui.js
@@ -15,7 +15,7 @@ class GameGui {
 
         /* change-tracking flags (original names) */
         this.gameTimeChanged       = true;
-        this.skillsCountChangd     = true;
+        this.skillsCountChanged    = true;
         this.skillSelectionChanged = true;
         this.backgroundChanged     = true;
         this.releaseRateChanged    = true;
@@ -34,6 +34,18 @@ class GameGui {
         this.display          = null;
         this.miniMap          = null;
         this.deltaReleaseRate = 0;
+
+        /* marching ants selection animation settings */
+        this.selectionDashLen   = 4;   // length of dash segments (1px longer)
+        this.selectionAnimDelay = 60;  // frames between offset increments (slower)
+        this.selectionAnimStep  = 1;   // pixels per animation step
+        this._selectionOffset   = 0;
+        this._selectionCounter  = 0;
+
+        /* hover state */
+        this._hoverPanelIdx   = -1;
+        this._hoverSpeedUp    = false;
+        this._hoverSpeedDown  = false;
 
         this._guiBound = this._guiLoop.bind(this);
         this._guiRafId        = 0;
@@ -64,7 +76,8 @@ class GameGui {
         });
 
         skills.onSelectionChanged.on(() => {
-            this.backgroundChanged     = true;
+            this.backgroundChanged = true;
+            this._selectionOffset  = 0;
         });
     }
 
@@ -101,11 +114,17 @@ class GameGui {
 
         if (panelIndex === 0 || panelIndex === 1) {
             const step = panelIndex === 0 ? -3 : +3;
+            const min = this.gameVictoryCondition.getMinReleaseRate?.() ?? 0;
+            const max = this.gameVictoryCondition.getMaxReleaseRate?.() ?? 99;
+            const cur = this.gameVictoryCondition.getCurrentReleaseRate();
+            if ((step < 0 && cur <= min) || (step > 0 && cur >= max)) {
+                if (this.skills.clearSelectedSkill()) {
+                    this.skillSelectionChanged = true;
+                }
+                return;
+            }
             if (this.gameTimer.isRunning?.()) {
-                const min = this.gameVictoryCondition.getMinReleaseRate?.() ?? 0;
-                const max = this.gameVictoryCondition.getMaxReleaseRate?.() ?? 99;
-                const cur = this.gameVictoryCondition.getCurrentReleaseRate();
-                let   neu = cur + step;
+                let neu = cur + step;
                 if (neu < min) neu = min;
                 if (neu > max) neu = max;
                 this.lastGameSpeed = neu;
@@ -166,16 +185,22 @@ class GameGui {
             if (this.nukePrepared) {
                 this.game.queueCommand(new Lemmings.CommandNuke());
                 this.nukePrepared = false;
-            }
-            else {
+            } else {
                 this.nukePrepared = true;
+            }
+            if (this.skills.clearSelectedSkill()) {
+                this.skillSelectionChanged = true;
             }
             this.skillSelectionChanged = true;
             return;
         }
         const newSkill = this.getSkillByPanelIndex(panelIndex);
         if (newSkill === Lemmings.SkillTypes.UNKNOWN) return;
-            this.skills.setSelectedSkill(newSkill);
+        if (this.skills.getSkill(newSkill) <= 0) {
+            if (this.skills.clearSelectedSkill()) this.skillSelectionChanged = true;
+            return;
+        }
+        this.skills.setSelectedSkill(newSkill);
         this.game.queueCommand(new Lemmings.CommandSelectSkill(newSkill));
     }
 
@@ -219,6 +244,46 @@ class GameGui {
             this.game.queueCommand(new Lemmings.CommandNuke());
     }
 
+    handleMouseMove(e) {
+        const rawIdx = e.y > 15 ? Math.trunc(e.x / 16) : -1;
+        let idx = rawIdx;
+
+        if (!this.gameTimer.isRunning?.() && rawIdx !== 11) {
+            idx = -1;
+        }
+
+        if (rawIdx === 0 || rawIdx === 1) {
+            const rrMin = this.gameVictoryCondition.getMinReleaseRate?.() ?? 0;
+            const rrMax = this.gameVictoryCondition.getMaxReleaseRate?.() ?? 99;
+            const rrCur = this.gameVictoryCondition.getCurrentReleaseRate?.() ?? 0;
+            if ((rawIdx === 0 && rrCur <= rrMin) || (rawIdx === 1 && rrCur >= rrMax)) {
+                idx = -1;
+            }
+        } else if (rawIdx >= 2 && rawIdx <= 9) {
+            const skill = this.getSkillByPanelIndex(rawIdx);
+            if (this.skills.getSkill(skill) <= 0) idx = -1;
+        }
+
+        const wasIdx = this._hoverPanelIdx;
+        if (idx !== wasIdx) {
+            this._hoverPanelIdx = idx;
+            this.backgroundChanged = true;
+        }
+
+        let up = false, down = false;
+        if (rawIdx === 10 && e.y >= 32) {
+            const pauseIndex = Math.trunc((e.x - 159) / 9);
+            const speedFac = this.gameTimer.speedFactor;
+            if (pauseIndex === 1 && speedFac < 120) up = true;
+            if (pauseIndex === 0 && speedFac > 0.1) down = true;
+        }
+        if (up !== this._hoverSpeedUp || down !== this._hoverSpeedDown) {
+            this._hoverSpeedUp = up;
+            this._hoverSpeedDown = down;
+            this.gameSpeedChanged = true;
+        }
+    }
+
     setGuiDisplay(display) {
         if (this.display && this._displayListeners) {
             for (const [event, handler] of this._displayListeners) {
@@ -236,13 +301,13 @@ class GameGui {
             ['onMouseRightDown', e => { if (e.y > 15) this.handleSkillMouseRightDown(e); }],
             ['onMouseRightUp', () => { }],
             ['onDoubleClick', e => { if (e.y > 15) this.handleSkillDoubleClick(e); }],
-            ['onMouseMove', e => { /*this.handleMouseMove(e);*/ }],
+            ['onMouseMove', e => { this.handleMouseMove(e); }],
         ];
         for (const [event, handler] of this._displayListeners) {
             display[event].on(handler);
         }
 
-        this.gameTimeChanged = this.skillsCountChangd = this.skillSelectionChanged = this.backgroundChanged = this.releaseRateChanged = true;
+        this.gameTimeChanged = this.skillsCountChanged = this.skillSelectionChanged = this.backgroundChanged = this.releaseRateChanged = true;
 
 
         this._guiRafId = window.requestAnimationFrame(this._guiBound);
@@ -288,7 +353,7 @@ class GameGui {
             d.initSize(this._panelSprite.width, this._panelSprite.height);
             d.setBackground(this._panelSprite.getData());
 
-            this.gameTimeChanged = this.skillsCountChangd = this.skillSelectionChanged = this.releaseRateChanged = this.gameSpeedChanged = true;
+            this.gameTimeChanged = this.skillsCountChanged = this.skillSelectionChanged = this.releaseRateChanged = this.gameSpeedChanged = true;
         }
 
         if (this.gameTimeChanged) {
@@ -342,35 +407,76 @@ class GameGui {
                 d.drawFrameResized(small, 164, 33, 8, 6);
                 d.drawHorizontalLine(169, 33, 175, 0, 0, 0);
             }
+
+            if (this._hoverSpeedUp) {
+                d.drawHorizontalLine(172, 32, 175, 0, 166, 0);
+                d.drawHorizontalLine(172, 38, 175, 0, 166, 0);
+            } else if (this._hoverSpeedDown) {
+                d.drawHorizontalLine(161, 32, 164, 0, 166, 0);
+                d.drawHorizontalLine(161, 38, 164, 0, 166, 0);
+            }
         }
 
 
-        if (this.skillsCountChangd) {
-            this.skillsCountChangd = false;
-            for (let s = 1; s < Object.keys(Lemmings.SkillTypes).length; ++s)
-                this.drawPanelNumber(d, this.skills.getSkill(s), this.getPanelIndexBySkill(s));
+        if (this.skillsCountChanged) {
+            this.skillsCountChanged = false;
+            for (let s = 1; s < Object.keys(Lemmings.SkillTypes).length; ++s) {
+                const panel = this.getPanelIndexBySkill(s);
+                const count = this.skills.getSkill(s);
+                this.drawPanelNumber(d, count, panel);
+            }
+        }
+        for (let s = 1; s < Object.keys(Lemmings.SkillTypes).length; ++s) {
+            if (this.skills.getSkill(s) <= 0) {
+                const panel = this.getPanelIndexBySkill(s);
+                d.drawStippleRect(panel * 16, 16, 16, 23, 160, 160, 160);
+            }
         }
         if (this.skillSelectionChanged) {
             this.skillSelectionChanged = false;
-            this.drawSelection(d, this.getPanelIndexBySkill(this.skills.getSelectedSkill()));
-            if (this.nukePrepared) {
-                this.drawNukeConfirm(d);
+        }
+
+        if (!this.gameTimer.isRunning?.()) {
+            this.drawPaused(d);
+        }
+        if (this.nukePrepared) {
+            this.drawNukeConfirm(d);
+        }
+
+        if (this._hoverPanelIdx >= 0) {
+            if (this._hoverPanelIdx === 11 && this.nukePrepared) {
+                this.drawNukeHover(d);
+            } else if (this._hoverPanelIdx === 11) {
+                this.drawSkillHover(d, this._hoverPanelIdx, 255, 128, 0);
+            } else {
+                this.drawSkillHover(d, this._hoverPanelIdx);
             }
         }
+
+        // update marching ants animation
+        if (++this._selectionCounter >= this.selectionAnimDelay) {
+            this._selectionCounter = 0;
+            this._selectionOffset += this.selectionAnimStep;
+        }
+
+        this.drawSelection(d, this.getPanelIndexBySkill(this.skills.getSelectedSkill()));
         if (this.releaseRateChanged) {
             this.releaseRateChanged = false;
             this.drawPanelNumber(d, this.gameVictoryCondition.getMinReleaseRate(),     0);
             this.drawPanelNumber(d, this.gameVictoryCondition.getCurrentReleaseRate(), 1);
         }
 
+        const rrMin = this.gameVictoryCondition.getMinReleaseRate?.() ?? 0;
+        const rrMax = this.gameVictoryCondition.getMaxReleaseRate?.() ?? 99;
+        const rrCur = this.gameVictoryCondition.getCurrentReleaseRate?.() ?? 0;
+        if (rrCur <= rrMin) d.drawStippleRect(0, 16, 16, 23, 160, 160, 160);
+        if (rrCur >= rrMax) d.drawStippleRect(16, 16, 16, 23, 160, 160, 160);
+
         if (this.miniMap) {
             const viewX = this.game.level.screenPositionX;
             const viewW = d.getWidth();
             this.miniMap.render(viewX, viewW);
         }
-                    if (!this.gameTimer.isRunning?.()) {
-                this.drawPaused(d);
-            }
     }
 
     _pad(v, len) { const s = String(v); return s.length >= len ? s : ' '.repeat(len - s.length) + s; }
@@ -392,16 +498,36 @@ class GameGui {
         }
     }
 
-    drawSelection(d, panelIdx) { 
-        d.drawRect(16 * panelIdx, 16, 16, 23, 255, 255, 255); 
+    drawSelection(d, panelIdx) {
+        if (panelIdx < 0) return;
+        d.drawMarchingAntRect(
+            16 * panelIdx,
+            16,
+            16,
+            23,
+            this.selectionDashLen,
+            this._selectionOffset
+        );
     }
 
-    drawPaused(d) { 
-        d.drawRect(16 * 10, 16, 16, 23, 255, 255, 255); 
+    drawPaused(d) {
+        d.drawMarchingAntRect(
+            16 * 10,
+            16,
+            16,
+            23,
+            this.selectionDashLen,
+            this._selectionOffset
+        );
+    }
+
+    drawSkillHover(d, panelIdx, r = 255, g = 255, b = 0) {
+        if (panelIdx < 0) return;
+        d.drawRect(16 * panelIdx, 16, 16, 23, r, g, b);
     }
 
     drawSpeedChange(upDown, reset = false) {
-        if (reset == false) {
+        if (!reset) {
             if (upDown) {
                 this.display.drawHorizontalLine(172, 32, 175, 0, 166, 0);
                 this.display.drawHorizontalLine(172, 38, 175, 0, 166, 0);
@@ -413,11 +539,33 @@ class GameGui {
             this.display.drawHorizontalLine(161, 32, 175, 111, 0, 0);
             this.display.drawHorizontalLine(161, 38, 175, 111, 0, 0);
         }
+
+        if (this._hoverSpeedUp) {
+            this.display.drawHorizontalLine(172, 32, 175, 0, 166, 0);
+            this.display.drawHorizontalLine(172, 38, 175, 0, 166, 0);
+        } else if (this._hoverSpeedDown) {
+            this.display.drawHorizontalLine(161, 32, 164, 0, 166, 0);
+            this.display.drawHorizontalLine(161, 38, 164, 0, 166, 0);
+        }
+
         this.gameSpeedChanged = true;
     }
 
-    drawNukeConfirm(d) { 
-        d.drawRect(16 * 11, 16, 16, 23, 255, 0, 0); 
+    drawNukeConfirm(d) {
+        d.drawRect(16 * 11, 16, 16, 23, 255, 0, 0);
+    }
+
+    drawNukeHover(d) {
+        d.drawMarchingAntRect(
+            16 * 11,
+            16,
+            16,
+            23,
+            this.selectionDashLen,
+            this._selectionOffset,
+            0xFF0080FF,
+            0xFF00FFFF
+        );
     }
 
     drawPanelNumber(d, num, panelIdx) { 

--- a/js/GameSkills.js
+++ b/js/GameSkills.js
@@ -6,6 +6,16 @@ class GameSkills {
             this.onCountChanged = new Lemmings.EventHandler();
             this.onSelectionChanged = new Lemmings.EventHandler();
             this.skills = level.skills;
+            this.selectFirstAvailable();
+        }
+
+        selectFirstAvailable() {
+            for (let i = Lemmings.SkillTypes.CLIMBER; i <= Lemmings.SkillTypes.DIGGER; i++) {
+                if (this.skills[i] > 0) {
+                    this.selectedSkill = i;
+                    break;
+                }
+            }
         }
         /** return true if the skill can be reused / used */
         canReuseSkill(type) {
@@ -16,6 +26,9 @@ class GameSkills {
                 return false;
             this.skills[type]--;
             this.onCountChanged.trigger(type);
+            if (this.skills[type] <= 0 && this.selectedSkill === type) {
+                this.selectFirstAvailable();
+            }
             return true;
         }
         getSkill(type) {
@@ -43,6 +56,15 @@ class GameSkills {
                 this.skills[i] = 99;
                 this.onCountChanged.trigger(i);
             }
+        }
+
+        clearSelectedSkill() {
+            if (this.selectedSkill !== Lemmings.SkillTypes.UNKNOWN) {
+                this.selectedSkill = Lemmings.SkillTypes.UNKNOWN;
+                this.onSelectionChanged.trigger();
+                return true;
+            }
+            return false;
         }
     }
     Lemmings.GameSkills = GameSkills;

--- a/js/GameView.js
+++ b/js/GameView.js
@@ -17,6 +17,7 @@ class GameView {
         this.scale = 0; // zoom 
         this.laggedOut = 0;
         this.extraLemmings = 0;
+        this.steps = 0;
         this.applyQuery();
         this.elementGameState = null;
 

--- a/js/GameView.js
+++ b/js/GameView.js
@@ -1,8 +1,9 @@
 import { Lemmings } from './LemmingsNamespace.js';
+import './KeyboardShortcuts.js';
 
-class GameView {
+class GameView extends Lemmings.BaseLogger {
     constructor() {
-        this.log = new Lemmings.LogHandler("GameView");
+        super();
         this.gameType = null;
         this.levelIndex = 0;
         this.levelGroupIndex = 0;
@@ -17,14 +18,24 @@ class GameView {
         this.scale = 0; // zoom 
         this.laggedOut = 0;
         this.extraLemmings = 0;
+        this.perfMetrics = false;
         this.steps = 0;
         this.applyQuery();
         this.elementGameState = null;
+        this.autoMoveTimer = null;
+        this.elementSelectGameType = null;
+        this.elementSelectLevelGroup = null;
+        this.elementSelectLevel = null;
+        this.configs = null;
+        this.shortcuts = new Lemmings.KeyboardShortcuts(this);
 
         this.log.log("selected level: " + Lemmings.GameTypes.toString(this.gameType) + " : " + this.levelIndex + " / " + this.levelGroupIndex);
     }
 
     set gameCanvas(el) {
+        if (this.stage && this.stage.dispose) {
+            this.stage.dispose();
+        }
         this.stage = new Lemmings.Stage(el);
     }
 
@@ -59,7 +70,7 @@ class GameView {
         this.changeHtmlText(this.elementGameState, Lemmings.GameStateTypes.toString(gameResult.state));
         this.stage.startFadeOut();
         console.dir(gameResult);
-        window.setTimeout(() => {
+        this.autoMoveTimer = window.setTimeout(() => {
             if (gameResult.state == Lemmings.GameStateTypes.SUCCEEDED) {
                 /// move to next level
                 this.moveToLevel(1);
@@ -67,6 +78,7 @@ class GameView {
                 /// redo this level
                 this.moveToLevel(0);
             }
+            this.autoMoveTimer = null;
         }, 2500);
     }
 
@@ -168,121 +180,97 @@ async moveToLevel(moveInterval = 0) {
                 this.levelGroupIndex = 0;
                 this.levelIndex = 0;
             }
-
-            this.changeHtmlText(this.elementLevelNumber, (this.levelIndex + 1).toString());
             await this.loadLevel();
         } finally {
             this.inMoveToLevel = false;
         }
     }
-    /** return the url hash for the present game/group/level-index */
+    /** helper to parse a numeric query value */
+    parseNumber(query, names, def, min, max, multiplier = 1) {
+        for (const name of names) {
+            const raw = query.get(name);
+            if (raw !== null) {
+                const val = parseFloat(raw);
+                if (!isNaN(val) && val >= min && val <= max) {
+                    return val * multiplier;
+                }
+            }
+        }
+        return def;
+    }
+
+    /** helper to parse a boolean query value */
+    parseBool(query, names, def = false) {
+        for (const name of names) {
+            if (query.has(name)) {
+                return query.get(name) === "true";
+            }
+        }
+        return def;
+    }
+
+    /** read parameters from the current URL */
     applyQuery() {
         this.gameType = 1;
-        let query = new URLSearchParams(window.location.search);
-        if (query.get("version") || query.get("v")) {
-            let queryVersion = parseInt(query.get("version") || query.get("v"), 10);
-            if (!isNaN(queryVersion) && queryVersion >= 1 && queryVersion <= 6) {
-                this.gameType = queryVersion;
-            }
-        }
-        this.levelGroupIndex = 0;
-        if (query.get("difficulty") || query.get("d")) {
-            let queryDifficulty = parseInt(query.get("difficulty") || query.get("d"), 10);
-            if (!isNaN(queryDifficulty) && queryDifficulty >= 1 && queryDifficulty <= 5) {
-                this.levelGroupIndex = queryDifficulty - 1;
-            }
-        }
-        this.levelIndex = 0;
-        if (query.get("level") || query.get("l")) {
-            let queryLevel = parseInt(query.get("level") || query.get("l"), 10);
-            if (!isNaN(queryLevel) && queryLevel >= 1 && queryLevel <= 30) {
-                this.levelIndex = queryLevel - 1;
-            }
-        }
-        this.gameSpeedFactor = 1;
-        if (query.get("speed") || query.get("s")) {
-            let querySpeed = parseFloat(query.get("speed") || query.get("s"));
-            if (!isNaN(querySpeed) && querySpeed > 0 && querySpeed <= 100) {
-                this.gameSpeedFactor = querySpeed;
-            }
-        }
-        this.cheat = false;
-        if (query.get("cheat") || query.get("c")) {
-            this.cheat = (query.get("cheat") || query.get("c")) === "true";
-        }
-        this.debug = false;
-        if (query.get("debug") || query.get("dbg")) {
-            this.debug = (query.get("debug") || query.get("dbg")) === "true";
-        }
-        this.bench = false;
-        if (query.get("bench") || query.get("b")) {
-            this.bench = (query.get("bench") || query.get("b")) === "true";
-        }
-        this.endless = false;
-        if (query.get("endless") || query.get("e")) {
-            this.endless = (query.get("endless") || query.get("e")) === "true";
-        }
-        this.nukeAfter = 0;
-        if (query.get("nukeAfter") || query.get("na")) {
-            const nukeAfter = parseInt(query.get("nukeAfter") || query.get("na"), 10);
-            if (!isNaN(nukeAfter) && nukeAfter >= 1 && nukeAfter <= 60) {
-                this.nukeAfter = nukeAfter*10;
-            }
-        }
-        this.extraLemmings = 0;
-        if (query.get("extra") || query.get("ex")) {
-            const extraLemmings = parseInt(query.get("extra") || query.get("ex"), 10);
-            if (!isNaN(extraLemmings) && extraLemmings >= 1 && extraLemmings <= 1000) {
-                this.extraLemmings = extraLemmings;
-            }
-        }
-        this.scale = 0;
-        if (query.get("scale") || query.get("sc")) {
-            const scale = parseFloat(query.get("scale") || query.get("sc"));
-            if (!isNaN(scale) && scale >= 0.0125 && scale <= 5) {
-                this.scale = scale;
-            }
-        }
+        const query = new URLSearchParams(window.location.search);
+        this.gameType = this.parseNumber(query, ["version", "v"], 1, 1, 6);
+        this.levelGroupIndex = this.parseNumber(query, ["difficulty", "d"], 1, 1, 5) - 1;
+        this.levelIndex = this.parseNumber(query, ["level", "l"], 1, 1, 30) - 1;
+        this.gameSpeedFactor = this.parseNumber(query, ["speed", "s"], 1, 0, 100);
+        this.cheat = this.parseBool(query, ["cheat", "c"]);
+        this.debug = this.parseBool(query, ["debug", "dbg"]);
+        this.bench = this.parseBool(query, ["bench", "b"]);
+        this.endless = this.parseBool(query, ["endless", "e"]);
+        this.nukeAfter = this.parseNumber(query, ["nukeAfter", "na"], 0, 1, 60, 10);
+        this.extraLemmings = this.parseNumber(query, ["extra", "ex"], 0, 1, 1000);
+        this.scale = this.parseNumber(query, ["scale", "sc"], 0, 0.0125, 5);
         this.laggedOut = 0;
         
         this.shortcut = false;
         if (query.get("shortcut") || query.get("_")) {
             this.shortcut = (query.get("shortcut") || query.get("_")) === "true";
         }
-    }
-    updateQuery() {
-        if (this.shortcut) {
-            this.setHistoryState({
-                v: this.gameType,
-                d: this.levelGroupIndex + 1,
-                l: this.levelIndex + 1,
-                s: this.gameSpeedFactor,
-                c: !!this.cheat,
-                _: true
-            });
-        } else {
-            this.setHistoryState({
-                version: this.gameType,
-                difficulty: this.levelGroupIndex + 1,
-                level: this.levelIndex + 1,
-                speed: this.gameSpeedFactor,
-                cheat: !!this.cheat
-            });
+        this.perfMetrics = false;
+        if (query.get("perfMetrics") || query.get("pm")) {
+            this.perfMetrics = (query.get("perfMetrics") || query.get("pm")) === "true";
         }
     }
-    setHistoryState(state) {
-        history.replaceState(
-            null,
-            null,
-            "?" +
-            Object.keys(state)
-            .map((key) => key + "=" + state[key])
-            .join("&")
-        );
+    updateQuery() {
+        const params = new URLSearchParams(window.location.search);
+        const setParam = (longName, shortName, value, def, always) => {
+            params.delete(longName);
+            params.delete(shortName);
+            if (always || (value !== undefined && value !== def)) {
+                params.set(this.shortcut ? shortName : longName, value);
+            }
+        };
+
+        // main game state should always remain visible
+        setParam('version', 'v', this.gameType, undefined, true);
+        setParam('difficulty', 'd', this.levelGroupIndex + 1, undefined, true);
+        setParam('level', 'l', this.levelIndex + 1, undefined, true);
+        setParam('speed', 's', this.gameSpeedFactor, undefined, true);
+        setParam('cheat', 'c', this.cheat, undefined, true);
+
+        // optional flags only appear when non-default
+        setParam('debug', 'dbg', this.debug, false);
+        setParam('bench', 'b', this.bench, false);
+        setParam('endless', 'e', this.endless, false);
+        setParam('nukeAfter', 'na', this.nukeAfter ? this.nukeAfter / 10 : undefined);
+        setParam('extra', 'ex', this.extraLemmings, 0);
+        setParam('scale', 'sc', this.scale, 0);
+
+        if (this.shortcut) {
+            params.set('_', true);
+        } else {
+            params.delete('_');
+        }
+
+        this.setHistoryState(params);
     }
-    /** convert a string to a number */
-    strToNum(str) {
-        return Number(str) | 0;
+    setHistoryState(params) {
+        const query = params instanceof URLSearchParams ? params : new URLSearchParams(params);
+        history.replaceState(null, null, "?" + query.toString());
     }
     /** change the the text of a html element */
     changeHtmlText(htmlElement, value) {
@@ -290,6 +278,10 @@ async moveToLevel(moveInterval = 0) {
             return;
         }
         htmlElement.innerText = value;
+    }
+    /** prefix items with an increasing index */
+    prefixNumbers(list) {
+        return list.map((item, idx) => `${idx + 1} - ${item}`);
     }
     /** remove items of a <select> */
     clearHtmlList(htmlList) {
@@ -311,21 +303,65 @@ async moveToLevel(moveInterval = 0) {
             htmlList.appendChild(el);
         }
     }
+    /** fill the level select with the names for the current group */
+    async populateLevelSelect() {
+        if (!this.elementSelectLevel || !this.gameResources) return;
+        const config = await this.gameFactory.getConfig(this.gameType);
+        const groupLength = config.level.getGroupLength(this.levelGroupIndex);
+        const list = [];
+        for (let i = 0; i < groupLength; i++) {
+            const lvl = await this.gameResources.getLevel(this.levelGroupIndex, i);
+            if (!lvl) continue;
+            list.push((i + 1) + ": " + lvl.name);
+        }
+        this.arrayToSelect(this.elementSelectLevel, list);
+        this.elementSelectLevel.selectedIndex = this.levelIndex;
+    }
     /** switch the selected level group */
-    selectLevelGroup(newLevelGroupIndex) {
+    async selectLevelGroup(newLevelGroupIndex) {
         this.levelGroupIndex = newLevelGroupIndex;
+        this.levelIndex = 0;
+        await this.populateLevelSelect();
+        this.loadLevel();
+    }
+    /** switch the selected game type */
+    async selectGameType(newGameType) {
+        this.gameType = newGameType;
+        this.levelGroupIndex = 0;
+        this.levelIndex = 0;
+        const newGameResources = await this.gameFactory.getGameResources(this.gameType);
+        this.gameResources = newGameResources;
+        this.arrayToSelect(this.elementSelectLevelGroup, this.prefixNumbers(this.gameResources.getLevelGroups()));
+        this.elementSelectLevelGroup.selectedIndex = this.levelGroupIndex;
+        await this.populateLevelSelect();
+        this.loadLevel();
+    }
+    /** select a specific level */
+    selectLevel(newLevelIndex) {
+        this.levelIndex = newLevelIndex;
         this.loadLevel();
     }
     /** select a game type */
     async setup() {
         this.applyQuery();
+        this.configs = await this.gameFactory.configReader.configs;
+        this.arrayToSelect(this.elementSelectGameType, this.configs.map(c => c.name));
+        const typeIndex = this.configs.findIndex(c => c.gametype === this.gameType);
+        if (typeIndex >= 0 && this.elementSelectGameType)
+            this.elementSelectGameType.selectedIndex = typeIndex;
         const newGameResources = await this.gameFactory.getGameResources(this.gameType);
         this.gameResources = newGameResources;
-        this.arrayToSelect(this.elementSelectLevelGroup, this.gameResources.getLevelGroups());
+        this.arrayToSelect(this.elementSelectLevelGroup, this.prefixNumbers(this.gameResources.getLevelGroups()));
+        this.elementSelectLevelGroup.selectedIndex = this.levelGroupIndex;
+        await this.populateLevelSelect();
         await this.loadLevel();
     }
     /** load a level and render it to the display */
     async loadLevel() {
+        if (this.autoMoveTimer !== null) {
+            window.clearTimeout(this.autoMoveTimer);
+            this.autoMoveTimer = null;
+        }
         if (!this.gameResources) return;
         if (this.game) {
             this.game.stop();
@@ -334,7 +370,12 @@ async moveToLevel(moveInterval = 0) {
         this.changeHtmlText(this.elementGameState, Lemmings.GameStateTypes[Lemmings.GameStateTypes.UNKNOWN]);
         const level = await this.gameResources.getLevel(this.levelGroupIndex, this.levelIndex);
         if (!level) return;
-        this.changeHtmlText(this.elementLevelName, level.name);
+        if (this.elementSelectGameType && this.configs) {
+            const idx = this.configs.findIndex(c => c.gametype === this.gameType);
+            if (idx >= 0) this.elementSelectGameType.selectedIndex = idx;
+        }
+        if (this.elementSelectLevelGroup) this.elementSelectLevelGroup.selectedIndex = this.levelGroupIndex;
+        if (this.elementSelectLevel) this.elementSelectLevel.selectedIndex = this.levelIndex;
         if (this.stage) {
             let gameDisplay = this.stage.getGameDisplay();
             gameDisplay.clear();
@@ -344,7 +385,7 @@ async moveToLevel(moveInterval = 0) {
             gameDisplay.redraw();
         }
         this.updateQuery();
-        console.dir(level);
+        this.log.debug(level);
         return this.start();
     }
 }

--- a/js/GroundReader.js
+++ b/js/GroundReader.js
@@ -12,7 +12,7 @@ class GroundReader {
    * @param {Lemmings.FileReader} vgaTerrain  – slice of VGAGx.DAT (terrain)
    * @param {Lemmings.FileReader} vgaObject   – slice of VGAGx.DAT (objects)
    */
-  constructor (groundFile, vgaTerrar, vgaObject) {
+  constructor (groundFile, vgaTerrain, vgaObject) {
     this.log = new Lemmings.LogHandler('GroundReader');
     if (groundFile.length !== 1056) {
       this.log.log(`groundFile ${groundFile.filename} has wrong size: ${groundFile.length}`);
@@ -38,7 +38,7 @@ class GroundReader {
 
     // Decode bitmaps – these calls can be parallelised in WebWorkers later.
     this._readImages(this.imgObjects, vgaObject, /*bpp=*/4);
-    this._readImages(this.imgTerrain, vgaTerrar, /*bpp=*/3);
+    this._readImages(this.imgTerrain, vgaTerrain, /*bpp=*/3);
   }
 
   getTerrainImages() { return this.imgTerrain;  }

--- a/js/KeyboardShortcuts.js
+++ b/js/KeyboardShortcuts.js
@@ -1,0 +1,302 @@
+import { Lemmings } from './LemmingsNamespace.js';
+
+class KeyboardShortcuts {
+    constructor(view) {
+        this.view = view;
+        this._down = this._onKeyDown.bind(this);
+        this._up = this._onKeyUp.bind(this);
+        window.addEventListener('keydown', this._down);
+        window.addEventListener('keyup', this._up);
+        this.mod = { shift:false };
+        this.pan = { left:false,right:false,up:false,down:false,vx:0,vy:0 };
+        this.zoom = { dir:0,v:0,reset:null };
+        this._raf = null;
+        this._last = 0;
+    }
+
+    dispose() {
+        window.removeEventListener('keydown', this._down);
+        window.removeEventListener('keyup', this._up);
+    }
+
+    _startLoop() {
+        if (!this._raf) {
+            this._last = performance.now();
+            this._raf = requestAnimationFrame((t) => this._step(t));
+        }
+    }
+
+    _step(t) {
+        const stage = this.view.stage;
+        let again = false;
+        const dt = Math.min(60, t - this._last) / 16.666;
+        this._last = t;
+        if (stage) {
+            const img = stage.gameImgProps;
+            const vp = img.viewPoint;
+            const scale = vp.scale;
+            // hold shift to pan much further per frame
+            const shiftMul = this.mod.shift ? 2.5 : 1;
+
+            // ----- panning -----
+            // tweak distance per frame; previous values felt too large
+            const baseX = 25 * scale;
+            const baseY = 12 * scale;
+            // slow the acceleration a touch for smoother motion
+            const accel = 0.05 / scale * dt;
+            const targetVX = (this.pan.right - this.pan.left) * baseX * shiftMul;
+            const targetVY = (this.pan.down - this.pan.up)   * baseY * shiftMul;
+            this.pan.vx += (targetVX - this.pan.vx) * accel;
+            this.pan.vy += (targetVY - this.pan.vy) * accel;
+            // extend easing so velocity decays more gradually
+            this.pan.vx *= 0.9;
+            this.pan.vy *= 0.9;
+            const dx = this.pan.vx;
+            const dy = this.pan.vy;
+            if (Math.abs(dx) > 0.05 || Math.abs(dy) > 0.05) {
+                stage.updateViewPoint(img, dx, dy, 0);
+                stage.redraw();
+                again = true;
+            } else {
+                this.pan.vx = this.pan.vy = 0;
+            }
+
+            // ----- zooming -----
+            // anchor zooming around the current screen centre without
+            // drifting the viewpoint. Using updateViewPoint() directly was
+            // causing the camera to slide left as the scale changed.
+            const cx = img.width / 2;
+            const cy = img.height / 2;
+            const centerX = vp.x + cx / vp.scale;
+            const centerY = vp.y + cy / vp.scale;
+            let targetZ = 0;
+            if (this.zoom.reset !== null) {
+                targetZ = (this.zoom.reset - vp.scale) * 0.2;
+            } else {
+                // smaller default zoom step; shift increases it only modestly
+                const baseZ = 20 * (this.mod.shift ? 1.5 : 1);
+                targetZ = this.zoom.dir * baseZ;
+            }
+            // gentler acceleration for zooming
+            this.zoom.v += (targetZ - this.zoom.v) * 0.07 * dt;
+            this.zoom.v *= 0.9;
+            const dz = this.zoom.v;
+            if (Math.abs(dz) > 0.001) {
+                const newScale = Math.max(0.25, Math.min(4, vp.scale * (1 + dz / 1500)));
+                const nx = centerX - cx / newScale;
+                const ny = centerY - cy / newScale;
+                const maxX = img.display.getWidth()  - img.width  / newScale;
+                const maxY = img.display.getHeight() - img.height / newScale;
+                vp.x = Math.min(Math.max(0, nx), maxX);
+                vp.y = Math.min(Math.max(0, ny), maxY);
+                vp.scale = newScale;
+                stage.redraw();
+                again = true;
+            } else if (this.zoom.reset !== null) {
+                vp.scale = this.zoom.reset;
+                this.zoom.reset = null;
+                stage.redraw();
+                this.zoom.v = 0;
+            } else {
+                this.zoom.v = 0;
+            }
+        }
+        if (again) {
+            this._raf = requestAnimationFrame((tt) => this._step(tt));
+        } else {
+            this._raf = null;
+        }
+    }
+
+    _cycleSkill() {
+        const skills = this.view.game.getGameSkills();
+        let next = skills.getSelectedSkill() + 1;
+        if (next > Lemmings.SkillTypes.DIGGER) next = Lemmings.SkillTypes.CLIMBER;
+        this.view.game.queueCommand(new Lemmings.CommandSelectSkill(next));
+        this.view.game.gameGui.skillSelectionChanged = true;
+    }
+
+    _instantNuke() {
+        const mgr = this.view.game.getLemmingManager?.();
+        if (!mgr || !mgr.lemmings) return;
+        for (const lem of mgr.lemmings) {
+            mgr.setLemmingState(lem, Lemmings.LemmingStateType.EXPLODING);
+        }
+    }
+
+    _changeSpeed(dir, isShift) {
+        const timer = this.view.game.getGameTimer();
+        const gui = this.view.game.gameGui;
+        // Shift should noticeably speed things up
+        const steps = isShift ? 5 : 1;
+        for (let i=0;i<steps;i++) {
+            if (dir > 0) {
+                if (timer.speedFactor < 1) {
+                    timer.speedFactor = Math.round((timer.speedFactor + 0.1) * 100) / 100;
+                    gui.drawSpeedChange(true);
+                } else if (timer.speedFactor < 120) {
+                    timer.speedFactor += 1;
+                    gui.drawSpeedChange(true);
+                }
+            } else {
+                if (timer.speedFactor > 1) {
+                    timer.speedFactor -= 1;
+                    gui.drawSpeedChange(false);
+                } else if (timer.speedFactor > 0.1) {
+                    timer.speedFactor = Math.round((timer.speedFactor - 0.1) * 100) / 100;
+                    gui.drawSpeedChange(false);
+                }
+            }
+        }
+    }
+
+    _onKeyDown(e) {
+        const game = this.view.game;
+        if (!game || e.ctrlKey || e.metaKey) return;
+        let handled = true;
+        switch (e.code) {
+            case 'Digit1':
+                if (e.shiftKey) {
+                    const diff = game.getVictoryCondition().getCurrentReleaseRate() - game.getVictoryCondition().getMinReleaseRate();
+                    if (diff > 0) game.queueCommand(new Lemmings.CommandReleaseRateDecrease(diff));
+                } else {
+                    game.queueCommand(new Lemmings.CommandReleaseRateDecrease(1));
+                }
+                game.gameGui.releaseRateChanged = true;
+                break;
+            case 'Digit2':
+                if (e.shiftKey) {
+                    const vc = game.getVictoryCondition();
+                    const max = vc.getMaxReleaseRate?.() ?? Lemmings.GameVictoryCondition.maxReleaseRate;
+                    const diff = max - vc.getCurrentReleaseRate();
+                    if (diff > 0) game.queueCommand(new Lemmings.CommandReleaseRateIncrease(diff));
+                } else {
+                    game.queueCommand(new Lemmings.CommandReleaseRateIncrease(1));
+                }
+                game.gameGui.releaseRateChanged = true;
+                break;
+            case 'Digit3':
+                game.queueCommand(new Lemmings.CommandSelectSkill(Lemmings.SkillTypes.CLIMBER));
+                game.gameGui.skillSelectionChanged = true;
+                break;
+            case 'Digit4':
+                game.queueCommand(new Lemmings.CommandSelectSkill(Lemmings.SkillTypes.FLOATER));
+                game.gameGui.skillSelectionChanged = true;
+                break;
+            case 'Digit5':
+                game.queueCommand(new Lemmings.CommandSelectSkill(Lemmings.SkillTypes.BOMBER));
+                game.gameGui.skillSelectionChanged = true;
+                break;
+            case 'Digit6':
+                game.queueCommand(new Lemmings.CommandSelectSkill(Lemmings.SkillTypes.BLOCKER));
+                game.gameGui.skillSelectionChanged = true;
+                break;
+            case 'KeyQ':
+                game.queueCommand(new Lemmings.CommandSelectSkill(Lemmings.SkillTypes.BUILDER));
+                game.gameGui.skillSelectionChanged = true;
+                break;
+            case 'KeyW':
+                game.queueCommand(new Lemmings.CommandSelectSkill(Lemmings.SkillTypes.BASHER));
+                game.gameGui.skillSelectionChanged = true;
+                break;
+            case 'KeyE':
+                game.queueCommand(new Lemmings.CommandSelectSkill(Lemmings.SkillTypes.MINER));
+                game.gameGui.skillSelectionChanged = true;
+                break;
+            case 'KeyR':
+                game.queueCommand(new Lemmings.CommandSelectSkill(Lemmings.SkillTypes.DIGGER));
+                game.gameGui.skillSelectionChanged = true;
+                break;
+            case 'Space':
+                game.getGameTimer().toggle();
+                game.gameGui.skillSelectionChanged = true;
+                break;
+            case 'KeyT':
+                if (e.shiftKey) this._instantNuke();
+                else game.queueCommand(new Lemmings.CommandNuke());
+                break;
+            case 'Backspace':
+                this.view.moveToLevel(0);
+                break;
+            case 'ArrowLeft':
+                if (this.pan.vx > 0) this.pan.vx = 0;
+                this.pan.left = true; this._startLoop();
+                break;
+            case 'ArrowRight':
+                if (this.pan.vx < 0) this.pan.vx = 0;
+                this.pan.right = true; this._startLoop();
+                break;
+            case 'ArrowUp':
+                if (this.pan.vy > 0) this.pan.vy = 0;
+                this.pan.up = true; this._startLoop();
+                break;
+            case 'ArrowDown':
+                if (this.pan.vy < 0) this.pan.vy = 0;
+                this.pan.down = true; this._startLoop();
+                break;
+            case 'KeyZ':
+                this.zoom.dir = 1; this._startLoop();
+                break;
+            case 'KeyX':
+                this.zoom.dir = -1; this._startLoop();
+                break;
+            case 'KeyV':
+                this.zoom.reset = 2; this._startLoop();
+                break;
+            case 'Tab':
+                this._cycleSkill();
+                break;
+            case 'Backslash':
+                game.showDebug = !game.showDebug;
+                break;
+            case 'Minus':
+            case 'NumpadSubtract':
+                this._changeSpeed(-1, e.shiftKey);
+                break;
+            case 'Equal':
+            case 'NumpadAdd':
+                this._changeSpeed(1, e.shiftKey);
+                break;
+            case 'Comma':
+                if (e.shiftKey) {
+                    if (this.view.levelGroupIndex > 0) this.view.selectLevelGroup(this.view.levelGroupIndex - 1);
+                } else {
+                    this.view.moveToLevel(-1);
+                }
+                break;
+            case 'Period':
+                if (e.shiftKey) {
+                    this.view.selectLevelGroup(this.view.levelGroupIndex + 1);
+                } else {
+                    this.view.moveToLevel(1);
+                }
+                break;
+            case 'ShiftLeft':
+            case 'ShiftRight':
+                this.mod.shift = true; this._startLoop();
+                handled = false; // allow others maybe
+                break;
+            default:
+                handled = false;
+        }
+        if (handled) e.preventDefault();
+    }
+
+    _onKeyUp(e) {
+        switch (e.code) {
+            case 'ArrowLeft': this.pan.left = false; break;
+            case 'ArrowRight': this.pan.right = false; break;
+            case 'ArrowUp': this.pan.up = false; break;
+            case 'ArrowDown': this.pan.down = false; break;
+            case 'KeyZ': if (this.zoom.dir > 0) this.zoom.dir = 0; break;
+            case 'KeyX': if (this.zoom.dir < 0) this.zoom.dir = 0; break;
+            case 'ShiftLeft':
+            case 'ShiftRight':
+                this.mod.shift = false; break;
+        }
+        this._startLoop();
+    }
+}
+
+Lemmings.KeyboardShortcuts = KeyboardShortcuts;
+export { KeyboardShortcuts };

--- a/js/Lemming.js
+++ b/js/Lemming.js
@@ -1,7 +1,8 @@
 import { Lemmings } from './LemmingsNamespace.js';
 
-class Lemming {
+class Lemming extends Lemmings.BaseLogger {
     constructor(x = 0, y = 0, id) {
+        super();
         this.lookRight = true;
         this.frameIndex = 0;
         this.canClimb = false;
@@ -95,7 +96,7 @@ class Lemming {
             return returnedState;
         }
         // prevent falling through function without returning a type
-        console.log("lemming state falling through, fix it");
+        this.log.log("lemming state falling through, fix it");
         return Lemmings.LemmingStateType.NO_STATE_TYPE;
     }
 

--- a/js/LemmingManager.js
+++ b/js/LemmingManager.js
@@ -1,12 +1,26 @@
 import { Lemmings } from './LemmingsNamespace.js';
 
-class LemmingManager {
+class LemmingManager extends Lemmings.BaseLogger {
     constructor(level, lemmingsSprite, triggerManager, gameVictoryCondition, masks, particleTable) {
-        // const start = performance.now();
-        this.lemmings = [];
-        this.minimapDots = [];
+        super();
+        Lemmings.withPerformance(
+            'LemmingManager constructor',
+            {
+                track: 'LemmingManager',
+                trackGroup: 'Game State',
+                color: 'primary',
+                tooltipText: 'LemmingManager constructor'
+            },
+            () => {
+        if (!lemmings.bench && (lemmings.extraLemmings | 0) === 0) {
+            this.lemmings = new Array(gameVictoryCondition.getReleaseCount());
+            this.lemmings.length = 0;
+        } else {
+            this.lemmings = [];
+        }
+        this.minimapDots = new Uint8Array(0);
         if (!LemmingManager.log) {
-            LemmingManager.log = new Lemmings.LogHandler("LemmingManager");
+            LemmingManager.log = this.log;
         }
         this.level = level;
         this.triggerManager = triggerManager;
@@ -48,7 +62,7 @@ class LemmingManager {
         this.skillActions[Lemmings.SkillTypes.BOMBER]  = new Lemmings.ActionCountdownSystem(masks);
 
         this.releaseTickIndex = this.gameVictoryCondition.getCurrentReleaseRate() - 30;
-        // performance.measure("LemmingManager constructor", { start, detail: { devtools: { track: "LemmingManager", trackGroup: "Game State", color: "primary", tooltipText: `LemmingManager constructor` } } });
+            })();
     }
 
     setMiniMap(miniMap) {
@@ -62,7 +76,16 @@ class LemmingManager {
     }
 
     tick() {
-        // const start = performance.now();
+        const tickNum = this.mmTickCounter;
+        Lemmings.withPerformance(
+            'tick',
+            {
+                track: 'LemmingManager',
+                trackGroup: 'Game State',
+                color: 'tertiary-dark',
+                tooltipText: `tick ${tickNum}`
+            },
+            () => {
         this.addNewLemmings();
         const lems = this.lemmings;
         const count = lems.length;
@@ -83,40 +106,57 @@ class LemmingManager {
         }
         if (lemmings.bench) {
             lemmings.laggedOut = count;
-            return;
         }
         if (this.miniMap && ((++this.mmTickCounter % 10) === 0)) {
-            const dots = this.minimapDots;
-            dots.length = 0;
+            const lemsCount = lems.length;
+            const dots = new Uint8Array(lemsCount * 2);
+            const visited = new Set();
+            const scaleX = this.miniMap.scaleX;
+            const scaleY = this.miniMap.scaleY;
+            let idx = 0;
             for (const lem of lems) {
-                const pos = { x: lem.x, y: lem.y };
-                if (!lem.removed && !lem.disabled) {
-                    dots.push(pos);
-                }
+                if (lem.removed || lem.disabled) continue;
+                const x = (lem.x * scaleX) | 0;
+                const y = (lem.y * scaleY) | 0;
+                const key = (y << 8) | x;
+                if (visited.has(key)) continue;
+                visited.add(key);
+                dots[idx++] = x;
+                dots[idx++] = y;
             }
-            this.miniMap.setLiveDots(dots);
+            this.minimapDots = dots.subarray(0, idx);
+            this.miniMap.setLiveDots(this.minimapDots);
         }
-        // const tick = this.mmTickCounter;
-        // performance.measure(`tick ${tick}`, { start, detail: { devtools: 
-        //     { track: "LemmingManager", trackGroup: "Game State", color: "tertiary-dark", 
-        //         properties: [["Lems", `${this.lemmings.length}`], ["Tick", `${tick}`]], 
-        //         tooltipText: `tick ${tick} (${this.lemmings.length} lems)` } } });
+        })();
     }
 
     addLemming(x, y) {
-        // const start = performance.now();
+        Lemmings.withPerformance(
+            'addLemming',
+            {
+                track: 'LemmingManager',
+                trackGroup: 'Game State',
+                color: 'primary-light',
+                tooltipText: `addLemming ${x},${y}`
+            },
+            () => {
         const startingLemLength = this.lemmings.length;
         const lem = new Lemmings.Lemming(x, y, startingLemLength);
         this.setLemmingState(lem, Lemmings.LemmingStateType.FALLING);
         this.lemmings.push(lem);
-        if (lemmings.extraLemmings > 0) {
-            for (let i = 0; i < 1 * lemmings.extraLemmings; i++) {
-                const extraLem = new Lemmings.Lemming(x, y, startingLemLength+1+i);
-                this.setLemmingState(extraLem, Lemmings.LemmingStateType.FALLING);
-                this.lemmings.push(extraLem);
+
+        const extraCount = lemmings.extraLemmings | 0;
+        if (extraCount > 0) {
+            const action = this.actions[Lemmings.LemmingStateType.FALLING];
+            const extras = new Array(extraCount);
+            for (let i = 0; i < extraCount; i++) {
+                const extra = new Lemmings.Lemming(x, y, startingLemLength + 1 + i);
+                extra.setAction(action);
+                extras[i] = extra;
             }
+            Array.prototype.push.apply(this.lemmings, extras);
         }
-        // performance.measure(`addLemming ${this.lemmings.length}`, { start, detail: { devtools: { track: "LemmingManager", trackGroup: "Game State", color: "primary-light", properties: ["Position", `${x},${y}`], tooltipText: `addLemming ${this.lemmings.length}` } } });
+        })();
     }
 
     addNewLemmings() {
@@ -168,11 +208,19 @@ class LemmingManager {
     }
 
     render(gameDisplay) {
-        // const start = performance.now();
+        Lemmings.withPerformance(
+            'render',
+            {
+                track: 'LemmingManager',
+                trackGroup: 'Render',
+                color: 'tertiary-dark',
+                tooltipText: 'render'
+            },
+            () => {
         for (const lem of this.lemmings) {
             lem.render(gameDisplay);
         }
-        // performance.measure("render", { start, detail: { devtools: { track: "LemmingManager", trackGroup: "Render", color: "tertiary-dark", tooltipText: `render` } } });
+            })();
     }
 
     renderDebug(gameDisplay) {
@@ -215,7 +263,15 @@ class LemmingManager {
     }
 
     setLemmingState(lem, stateType) {
-        // const start = performance.now();
+        Lemmings.withPerformance(
+            'setLemmingState',
+            {
+                track: 'LemmingManager',
+                trackGroup: 'Game State',
+                color: 'secondary-light',
+                tooltipText: `setLemmingState ${lem.id}`
+            },
+            () => {
         if (lem.countdown > 0) {
             const lethal =
                 stateType === Lemmings.LemmingStateType.DROWNING   ||
@@ -227,9 +283,19 @@ class LemmingManager {
             }
         }
         if (stateType == Lemmings.LemmingStateType.OUT_OF_LEVEL) {
-            lem.remove();
-            this.gameVictoryCondition.removeOne();
-            // performance.measure("removeOne", { start, detail: { devtools: { track: "LemmingManager", trackGroup: "Game State", color: "secondary-dark", tooltipText: `removeOne ${lem.id}` } } });
+            Lemmings.withPerformance(
+                'removeOne',
+                {
+                    track: 'LemmingManager',
+                    trackGroup: 'Game State',
+                    color: 'secondary-dark',
+                    tooltipText: `removeOne ${lem.id}`
+                },
+                () => {
+                    lem.remove();
+                    this.gameVictoryCondition.removeOne();
+                }
+            )();
             return;
         }
         const actionSystem = this.actions[stateType];
@@ -238,14 +304,24 @@ class LemmingManager {
             this.logging.log(lem.id + " Action: Error not an action: " + Lemmings.LemmingStateType[stateType]);
             return;
         } else {
-            this.logging.debug(lem.id + " Action: " + actionSystem.getActionName());
+            if (this.lemmings.length <= 50 && (lemmings?.gameSpeedFactor ?? 1) <= 1) {
+                this.logging.debug(lem.id + " Action: " + actionSystem.getActionName());
+            }
         }
-        // performance.measure(`${actionSystem.getActionName()}`, { start, detail: { devtools: { track: "LemmingManager", trackGroup: "Game State", color: "secondary-light", tooltipText: `setAction ${lem.id} ${actionSystem.getActionName()}` } } });
         lem.setAction(actionSystem);
+            })();
     }
 
     doLemmingAction(lem, skillType) {
-        // const start = performance.now();
+        return Lemmings.withPerformance(
+            'doLemmingAction',
+            {
+                track: 'LemmingManager',
+                trackGroup: 'Game State',
+                color: 'secondary-dark',
+                tooltipText: `doLemmingAction ${skillType}`
+            },
+            () => {
         if (!lem) {
             return false;
         }
@@ -287,8 +363,9 @@ class LemmingManager {
                 this.triggerManager.removeByOwner(lem);
             }
         }
-        // performance.measure(`${actionSystem.getActionName()}`, { start, detail: { devtools: { track: "LemmingManager", trackGroup: "Game State", color: "secondary-dark", tooltipText: `${lem.id} ${actionSystem.getActionName()}` } } });
-        return ok;
+        const result = ok;
+        return result;
+            }).call(this);
     }
 
     isNuking() { return this.nextNukingLemmingsIndex >= 0; }
@@ -297,17 +374,33 @@ class LemmingManager {
     dispose() {
         const start = performance.now();
         if (this.lemmings) this.lemmings.length = 0;
-        if (this.minimapDots) this.minimapDots.length = 0;
+        if (this.minimapDots) this.minimapDots = new Uint8Array(0);
         this.level = null;
         this.triggerManager = null;
         this.gameVictoryCondition = null;
         this.skillActions.length = 0;
         this.releaseTickIndex = null;
-        this.logging = new Lemmings.LogHandler("LemmingManager");
+        this.logging = new Lemmings.Logger("LemmingManager");
         this.miniMap = null;
         this.mmTickCounter = null;
         this.nextNukingLemmingsIndex = null;
-        performance.measure(`LemmingManager Dispose`, { start, detail: { devtools: { track: "LemmingManager", trackGroup: "Game State", color: "error", tooltipText: `LemmingManager Dispose` } } });
+        if (typeof lemmings !== 'undefined' &&
+            lemmings.perfMetrics === true &&
+            lemmings.debug === true &&
+            typeof performance !== 'undefined' &&
+            typeof performance.measure === 'function') {
+            performance.measure(`LemmingManager Dispose`, {
+                start,
+                detail: {
+                    devtools: {
+                        track: 'LemmingManager',
+                        trackGroup: 'Game State',
+                        color: 'error',
+                        tooltipText: 'LemmingManager Dispose'
+                    }
+                }
+            });
+        }
     }
 }
 

--- a/js/LemmingsBootstrap.js
+++ b/js/LemmingsBootstrap.js
@@ -1,5 +1,7 @@
 import { Lemmings } from './LemmingsNamespace.js';
 
+import './LogHandler.js';
+
 import './ActionBashSystem.js';
 import './ActionBlockerSystem.js';
 import './ActionBuildSystem.js';
@@ -65,7 +67,6 @@ import './LevelIndexType.js';
 import './LevelLoader.js';
 import './LevelProperties.js';
 import './LevelReader.js';
-import './LogHandler.js';
 import './MapObject.js';
 import './Mask.js';
 import './MaskList.js';

--- a/js/Level.js
+++ b/js/Level.js
@@ -1,7 +1,8 @@
 import { Lemmings } from './LemmingsNamespace.js';
 
-class Level {
+class Level extends Lemmings.BaseLogger {
   constructor(width, height) {
+    super();
     this.width = width | 0;
     this.height = height | 0;
     this.groundMask = new Lemmings.SolidLayer(this.width, this.height);
@@ -26,7 +27,15 @@ class Level {
   }
 
   setMapObjects(objects, objectImg) {
-    // const start = performance.now();
+    Lemmings.withPerformance(
+      'setMapObjects',
+      {
+        track: 'Level',
+        trackGroup: 'Game State',
+        color: 'primary-light',
+        tooltipText: 'setMapObjects'
+      },
+      () => {
     this.objects.length = 0;
     this.entrances.length = 0;
     this.triggers.length = 0;
@@ -75,7 +84,7 @@ class Level {
     if (arrowRects.length > 0) {
       this.setArrowAreas(arrowRects);
     }
-    // performance.measure(`setMapObjects`, { start, detail: { devtools: { track: "Level", trackGroup: "Game State", color: "primary-light", properties: [["Objects", `${this.objects.length}`],["Entrances", `${this.entrances.length}`],["Triggers", `${this.triggers.length}`]], tooltipText: `setMapObjects` } } });
+      })();
   }
 
   getGroundMaskLayer() { return this.groundMask; }
@@ -163,6 +172,15 @@ class Level {
   }
 
   newSetSteelAreas(levelReader, terrainImages) {
+    Lemmings.withPerformance(
+      'newSetSteelAreas',
+      {
+        track: 'Level',
+        trackGroup: 'Game State',
+        color: 'secondary-light',
+        tooltipText: 'newSetSteelAreas'
+      },
+      () => {
     if (!this.steelMask || this.steelMask.width !== this.width || this.steelMask.height !== this.height) {
       this.steelMask = new Lemmings.SolidLayer(this.width, this.height);
     } else {
@@ -195,6 +213,7 @@ class Level {
       this.steelRanges = new Int32Array(0);
       this.setSteelAreas(newSteelRanges);
     }
+      })();
   }
 
   setSteelAreas(ranges = []) {

--- a/js/LevelConfig.js
+++ b/js/LevelConfig.js
@@ -9,8 +9,9 @@ class LevelConfig {
             /** the names of the level groups */
             this.groups = [];
             /** sort order of the levels for each group
-             *   every entry is a number where:
-             *     ->  (FileId * 10 + FilePart) * (useOddTabelEntry? -1 : 1)
+             *   each entry is calculated as:
+             *     (FileId * 10 + FilePart) * (useOddTableEntry ? -1 : 1)
+             *   where a negative value means the odd table should be used
              */
             this.order = [];
         }

--- a/js/LevelLoader.js
+++ b/js/LevelLoader.js
@@ -72,6 +72,7 @@ class LevelLoader {
     // 4 · Decode terrain / objects and render background                      //
     // ----------------------------------------------------------------------- //
     const vgaContainer = new Lemmings.FileContainer(vgagrBuf);
+    await Lemmings.loadSteelSprites();
     const groundReader = new Lemmings.GroundReader(
                              groundBuf,
                              vgaContainer.getPart(0),

--- a/js/LevelReader.js
+++ b/js/LevelReader.js
@@ -1,8 +1,9 @@
 import { Lemmings } from './LemmingsNamespace.js';
 
-class LevelReader {
+class LevelReader extends Lemmings.BaseLogger {
     /// Load a Level
     constructor(fr) {
+        super();
         this.levelWidth = 1600;
         this.levelHeight = 160;
         this.levelProperties = new Lemmings.LevelProperties();
@@ -15,7 +16,6 @@ class LevelReader {
         this.objects = [];
         this.terrains = [];
         this.steel = [];
-        this.log = new Lemmings.LogHandler("LevelReader");
         this.readLevelInfo(fr);
         this.readLevelObjects(fr);
         this.readLevelTerrain(fr);

--- a/js/LogHandler.js
+++ b/js/LogHandler.js
@@ -1,34 +1,101 @@
 import { Lemmings } from './LemmingsNamespace.js';
 
-class LogHandler {
+class Logger {
     constructor(moduleName) {
         this._moduleName = moduleName;
     }
+
+    _enabled() {
+        return typeof lemmings !== 'undefined' &&
+            lemmings.game && lemmings.game.showDebug === true;
+    }
+
     /** log an error */
-    log(msg, exeption) {
-        if (!lemmings == false) {
-            if (!lemmings.game == false && lemmings.game.showDebug == true) {
-                console.log(this._moduleName + "\t" + msg);
-                if (exeption) {
-                    console.log(this._moduleName + "\t" + exeption.message);
-                }
+    log(msg, exception) {
+        if (this._enabled()) {
+            console.log(`${this._moduleName}\t${msg}`);
+            if (exception) {
+                console.log(`${this._moduleName}\t${exception.message}`);
             }
         }
-
     }
+
     /** write a debug message. If [msg] is not a String it is displayed: as {prop:value} */
     debug(msg) {
-        if (!lemmings.game == false) {
-            if (!lemmings.game == false && lemmings.game.showDebug == true) {
-                if (typeof msg === 'string') {
-                    console.log(this._moduleName + "\t" + msg);
-                } else {
-                    console.dir(msg);
-                }
-            }
+        if (!this._enabled()) return;
+        if (typeof msg === 'string') {
+            console.log(`${this._moduleName}\t${msg}`);
+        } else {
+            console.dir(msg);
         }
     }
 }
-Lemmings.LogHandler = LogHandler;
 
-export { LogHandler };
+class BaseLogger {
+    constructor(name) {
+        this.log = new Logger(name || this.constructor.name);
+    }
+
+    /**
+     * Start a performance measurement and return a function that records the
+     * measure when invoked.
+     * @param {string} name
+     * @param {object} devtools
+     * @returns {Function}
+     */
+    startMeasure(name, devtools = {}) {
+        if (!(typeof lemmings !== 'undefined' &&
+              lemmings.perfMetrics === true &&
+              lemmings.debug === true) ||
+            typeof performance === 'undefined' ||
+            typeof performance.now !== 'function' ||
+            typeof performance.measure !== 'function') {
+            return () => {};
+        }
+        const start = performance.now();
+        return () => {
+            try {
+                performance.measure(name, {
+                    start,
+                    detail: { devtools }
+                });
+            } catch {
+                /* ignored */
+            }
+        };
+    }
+}
+
+function withPerformance(name, devtools = {}, fn) {
+    return function(...args) {
+        if (!(typeof lemmings !== 'undefined' &&
+              lemmings.perfMetrics === true &&
+              lemmings.debug === true) ||
+            typeof performance === 'undefined' ||
+            typeof performance.now !== 'function' ||
+            typeof performance.measure !== 'function') {
+            return fn.apply(this, args);
+        }
+        const start = performance.now();
+        try {
+            return fn.apply(this, args);
+        } finally {
+            try {
+                performance.measure(name, {
+                    start,
+                    detail: { devtools }
+                });
+            } catch {
+                /* ignored */
+            }
+        }
+    };
+}
+
+Lemmings.Logger = Logger;
+Lemmings.BaseLogger = BaseLogger;
+Lemmings.withPerformance = withPerformance;
+// Backwards compatibility
+Lemmings.LogHandler = Logger;
+
+export { Logger, BaseLogger, withPerformance };

--- a/js/MaskList.js
+++ b/js/MaskList.js
@@ -2,20 +2,21 @@ import { Lemmings } from './LemmingsNamespace.js';
 
 class MaskList {
         constructor(fr, width, height, count, offsetX, offsetY) {
+            this.frames = [];
             if (fr != null) {
                 this.loadFromFile(fr, width, height, count, offsetX, offsetY);
             }
         }
         get length() {
-            return frames.length;
+            return this.frames.length;
         }
         GetMask(index) {
             return this.frames[index];
         }
         loadFromFile(fr, width, height, count, offsetX, offsetY) {
-            this.frames = [];
+            this.frames.length = 0;
             for (let i = 0; i < count; i++) {
-                let mask = new Lemmings.Mask(fr, width, height, offsetX, offsetY);
+                const mask = new Lemmings.Mask(fr, width, height, offsetX, offsetY);
                 this.frames.push(mask);
             }
         }

--- a/js/MiniMap.js
+++ b/js/MiniMap.js
@@ -21,7 +21,8 @@ class MiniMap {
         // dynamic state
         this.fog = new Uint8Array(this.size); // 0 = unseen
         this.fog.fill(1); // disabled
-        this.liveDots = new Set(); // {x,y} sampled every x ticks
+        // typed array storing [x1,y1,x2,y2,...] scaled to minimap
+        this.liveDots = new Uint8Array(0);
         this.deadDots = []; // {x,y,ttl}
 
         // render target (drawn into the GUI canvas once per frame)
@@ -190,6 +191,7 @@ class MiniMap {
     }
 
     setLiveDots(arr) {
+        // arr is a Uint8Array of scaled [x1,y1,x2,y2,...]
         this.liveDots = arr;
     }
 
@@ -222,8 +224,11 @@ class MiniMap {
             frame.mask[idx] = 1;
         }
 
-        const vpX = (lemmings.stage.getGameViewRect().x * this.scaleX) | 0;
-        let vpW = (lemmings.stage.getGameViewRect().w * this.scaleX) | 0;
+        const viewRect = lemmings.stage.getGameViewRect();
+        const vpX = (viewRect.x * this.scaleX) | 0;
+        let vpW = (viewRect.w * this.scaleX) | 0;
+        const vpY = (viewRect.y * this.scaleY) | 0;
+        const vpH = (viewRect.h * this.scaleY) | 0;
         let vpXW = vpX + vpW;
         // dumb fix to keep right edge of viewport rect visible
         if (vpXW == this.width) {
@@ -232,6 +237,10 @@ class MiniMap {
         const vpRectColor = 0xFFFFFFFF;
         frame.drawRect(vpX, 0, 0, this.height - 1, vpRectColor, false, false);
         frame.drawRect(vpX + vpW, 0, 0, this.height - 1, vpRectColor, false, false);
+        if (vpH < this.height) {
+            frame.drawRect(vpX, vpY, vpW, 0, vpRectColor, false, false);
+            frame.drawRect(vpX, vpY + vpH, vpW, 0, vpRectColor, false, false);
+        }
 
         /* Entrances / Exits */
         for (const obj of this.level.objects) {
@@ -245,8 +254,10 @@ class MiniMap {
         }
 
         /* Live lemmings */
-        for (const p of this.liveDots) {
-            frame.setPixel((p.x * this.scaleX) | 0, (p.y * this.scaleY) | 0, 0x5500FFFF);
+        for (let i = 0; i < this.liveDots.length; i += 2) {
+            const x = this.liveDots[i];
+            const y = this.liveDots[i + 1];
+            frame.setPixel(x, y, 0x5500FFFF);
         }
 
         /* Death flashes */

--- a/js/OddTableReader.js
+++ b/js/OddTableReader.js
@@ -1,9 +1,9 @@
 import { Lemmings } from './LemmingsNamespace.js';
 
-class OddTableReader {
+class OddTableReader extends Lemmings.BaseLogger {
         constructor(oddfile) {
+            super();
             this.levelProperties = [];
-            this.log = new Lemmings.LogHandler("OddTableReader");
             this.read(oddfile);
         }
         /** return the Level for a given levelNumber - LevelNumber is counting all levels from first to last of the game

--- a/js/SkillPanelSprites.js
+++ b/js/SkillPanelSprites.js
@@ -57,6 +57,56 @@ class SkillPanelSprites {
         getNumberSpriteEmpty() {
             return this.emptyNumberSprite;
         }
+
+        /** extract a rectangular patch from the panel background */
+        getBackgroundPatch(x, y, w, h) {
+            const src = this.panelSprite;
+            const out = new Lemmings.Frame(w, h);
+            for (let yy = 0; yy < h; yy++) {
+                const srcRow = (y + yy) * src.width + x;
+                const dstRow = yy * w;
+                for (let xx = 0; xx < w; xx++) {
+                    out.data[dstRow + xx] = src.data[srcRow + xx];
+                    out.mask[dstRow + xx] = 1;
+                }
+            }
+            return out;
+        }
+
+        /** tile a patch across a larger area */
+        createTiledBackground(x, y, w, h, outW, outH) {
+            const patch = this.getBackgroundPatch(x, y, w, h);
+            const out = new Lemmings.Frame(outW, outH);
+            for (let yy = 0; yy < outH; yy++) {
+                for (let xx = 0; xx < outW; xx++) {
+                    const px = xx % w;
+                    const py = yy % h;
+                    const srcIdx = py * w + px;
+                    const dstIdx = yy * outW + xx;
+                    out.data[dstIdx] = patch.data[srcIdx];
+                    out.mask[dstIdx] = 1;
+                }
+            }
+            return out;
+        }
+
+        /** return a brightened copy of the specified button region */
+        getHighlightedButton(panelIndex) {
+            const x = panelIndex * 16;
+            const y = 16;
+            const w = 16;
+            const h = 23;
+            const patch = this.getBackgroundPatch(x, y, w, h);
+            for (let i = 0; i < patch.data.length; i++) {
+                let c = patch.data[i];
+                let r = Math.min(255, (c       & 0xFF) + 40);
+                let g = Math.min(255, ((c>>8)  & 0xFF) + 40);
+                let b = Math.min(255, ((c>>16) & 0xFF) + 40);
+                patch.data[i] = 0xFF000000 | (b<<16) | (g<<8) | r;
+                patch.mask[i] = 1;
+            }
+            return patch;
+        }
     }
     Lemmings.SkillPanelSprites = SkillPanelSprites;
 

--- a/js/SolidLayer.js
+++ b/js/SolidLayer.js
@@ -1,12 +1,13 @@
 import { Lemmings } from './LemmingsNamespace.js';
 
-class SolidLayer {
+class SolidLayer extends Lemmings.BaseLogger {
     /**
      * @param {number} width
      * @param {number} height
      * @param {Uint8Array|Int8Array|null} mask - Optional initial ground mask
      */
-    constructor(width, height, mask = null) {
+   constructor(width, height, mask = null) {
+        super();
         this.width = width;
         this.height = height;
         this.mask = mask ? new Uint8Array(mask) : new Uint8Array(width * height);
@@ -50,7 +51,15 @@ class SolidLayer {
      * @param {Function|null} skipTest - Optional (x, y) => true if pixel should not be cleared (e.g. steel check)
      */
     clearGroundWithMask(mask, x, y, skipTest = null) {
-        // const start = performance.now();
+        Lemmings.withPerformance(
+            'clearGroundWithMask',
+            {
+                track: 'SolidLayer',
+                trackGroup: 'Game State',
+                color: 'primary-dark',
+                tooltipText: `clearGroundWithMask ${x},${y}`
+            },
+            () => {
         const mx = mask.offsetX || 0, my = mask.offsetY || 0;
         for (let dy = 0; dy < mask.height; ++dy) {
             const mapY = y + my + dy;
@@ -66,7 +75,7 @@ class SolidLayer {
                 }
             }
         }
-        // performance.measure("clearGroundWithMask Complete", { start, detail: { devtools: { track: "SolidLayer", trackGroup: "Game State", color: "primary-dark", properties: [["Position", `${x},${y}`],["skipTest"], `${skipTest}`], tooltipText: "clearGroundWithMask" } } });
+            })();
     }
 
     /**
@@ -76,14 +85,22 @@ class SolidLayer {
      * @param {Function|null} skipTest - Optional (x, y) => true if pixel should not be cleared (e.g. steel check)
      */
     clearGroundWithMasks(masks, positions, skipTest = null) {
-        // const start = performance.now();
+        Lemmings.withPerformance(
+            'clearGroundWithMasks',
+            {
+                track: 'SolidLayer',
+                trackGroup: 'Game State',
+                color: 'primary-light',
+                tooltipText: `clearGroundWithMasks ${masks.length}`
+            },
+            () => {
         if (!Array.isArray(masks) || masks.length === 0) return;
         for (let i = 0; i < masks.length; ++i) {
             const mask = masks[i], pos = positions[i];
             if (!mask || !pos) continue;
             this.clearGroundWithMask(mask, pos[0], pos[1], skipTest);
         }
-        // performance.measure("clearGroundWithMasks Complete", { start, detail: { devtools: { track: "SolidLayer", trackGroup: "Game State", color: "primary-light", properties: [["Positions", `${positions}`],["skipTest"], `${skipTest}`], tooltipText: "clearGroundWithMasks" } } });
+            })();
     }
 }
 

--- a/js/Stage.js
+++ b/js/Stage.js
@@ -262,10 +262,18 @@ class Stage {
             this.resetFade();
             this.fadeTimer = setInterval(() => {
                 this.fadeAlpha = Math.min(this.fadeAlpha + 0.02, 1);
-                if (this.fadeAlpha <= 0) {
+                if (this.fadeAlpha >= 1) {
                     clearInterval(this.fadeTimer);
+                    this.fadeTimer = 0;
                 }
             }, 40);
+        }
+        dispose() {
+            this.resetFade();
+            if (this.controller && this.controller.dispose) {
+                this.controller.dispose();
+            }
+            this.controller = null;
         }
         /** draw everything to the stage/display */
         draw(display, img) {

--- a/js/Stage.js
+++ b/js/Stage.js
@@ -189,7 +189,6 @@ class Stage {
         }
         getGuiDisplay() {
             if (this.guiImgProps.display != null) {
-                this.guiImg
                 return this.guiImgProps.display;
             }
             this.guiImgProps.display = new Lemmings.DisplayImage(this);

--- a/js/TriggerManager.js
+++ b/js/TriggerManager.js
@@ -39,6 +39,10 @@ class TriggerManager {
 
     this._triggers = new Set();
 
+    /* debug bookkeeping */
+    this._lastCheckTick = new Uint32Array(slots);
+    this._lastHitTick   = new Uint32Array(slots);
+
     /* handy bounds */
     this._maxX = levelW;
     this._maxY = levelH;
@@ -81,15 +85,37 @@ class TriggerManager {
     const cell = this._grid[bucket];
     const tick = this.gameTimer.getGameTicks();
 
+    this._lastCheckTick[bucket] = tick;
+
     for (const trig of cell) {
       const val = trig.trigger(x, y, tick);
-      if (val !== Lemmings.TriggerTypes.NO_TRIGGER) return val;
+      if (val !== Lemmings.TriggerTypes.NO_TRIGGER) {
+        this._lastHitTick[bucket] = tick;
+        return val;
+      }
     }
     return Lemmings.TriggerTypes.NO_TRIGGER;
   }
 
   /** Draw rectangles in debug overlay */
   renderDebug (g) {
+    const cs   = this._cellSize;
+    const tick = this.gameTimer.getGameTicks();
+    for (let r = 0; r < this._rows; ++r) {
+      const base = r * this._cols;
+      for (let c = 0; c < this._cols; ++c) {
+        const idx = base + c;
+        if (this._lastHitTick[idx] === tick) {
+          g.drawRect(c * cs, r * cs, cs - 1, cs - 1, 255, 0, 0);
+        } else if (this._lastCheckTick[idx] === tick) {
+          g.drawRect(c * cs, r * cs, cs - 1, cs - 1, 255, 255, 255);
+        } else if (this._grid[idx].size === 0) {
+          g.drawRect(c * cs, r * cs, cs - 1, cs - 1, 128, 128, 128);
+        } else {
+          g.drawRect(c * cs, r * cs, cs - 1, cs - 1, 0, 0, 255);
+        }
+      }
+    }
     for (const tr of this._triggers) tr.draw(g);
   }
 

--- a/js/UserInputManager.js
+++ b/js/UserInputManager.js
@@ -38,39 +38,42 @@ class UserInputManager {
         this.onMouseRightUp = new Lemmings.EventHandler();
         this.onDoubleClick = new Lemmings.EventHandler();
         this.onZoom = new Lemmings.EventHandler();
-        listenElement.addEventListener("mousemove", (e) => {
-            let relativePos = this.getRelativePosition(listenElement, e.clientX, e.clientY);
+        this.listenElement = listenElement;
+        this._listeners = [];
+
+        this._addListener("mousemove", (e) => {
+            let relativePos = this.getRelativePosition(this.listenElement, e.clientX, e.clientY);
             this.handleMouseMove(relativePos);
             e.stopPropagation();
             e.preventDefault();
             return false;
         });
-        listenElement.addEventListener("touchmove", (e) => {
+        this._addListener("touchmove", (e) => {
             if (e.touches.length !== 1) {
                 e.preventDefault();
                 return;
             }
-            let relativePos = this.getRelativePosition(listenElement, e.touches[0].clientX, e.touches[0].clientY);
+            let relativePos = this.getRelativePosition(this.listenElement, e.touches[0].clientX, e.touches[0].clientY);
             this.handleMouseMove(relativePos);
             e.stopPropagation();
             e.preventDefault();
             return false;
         });
-        listenElement.addEventListener("touchstart", (e) => {
+        this._addListener("touchstart", (e) => {
             if (e.touches.length !== 1) {
                 e.preventDefault();
                 return;
             }
-            let relativePos = this.getRelativePosition(listenElement, e.touches[0].clientX, e.touches[0].clientY);
+            let relativePos = this.getRelativePosition(this.listenElement, e.touches[0].clientX, e.touches[0].clientY);
             this.handleMouseDown(relativePos);
             e.stopPropagation();
             e.preventDefault();
             return false;
         });
-        listenElement.addEventListener("mousedown", (e) => {
+        this._addListener("mousedown", (e) => {
             e.stopPropagation();
             e.preventDefault();
-            let relativePos = this.getRelativePosition(listenElement, e.clientX, e.clientY);
+            let relativePos = this.getRelativePosition(this.listenElement, e.clientX, e.clientY);
             if (e.button == 2) {
                 this.handleMouseRightDown(relativePos);
                 return false;
@@ -79,10 +82,10 @@ class UserInputManager {
 
             return false;
         });
-        listenElement.addEventListener("mouseup", (e) => {
+        this._addListener("mouseup", (e) => {
             e.stopPropagation();
             e.preventDefault();
-            let relativePos = this.getRelativePosition(listenElement, e.clientX, e.clientY);
+            let relativePos = this.getRelativePosition(this.listenElement, e.clientX, e.clientY);
             if (e.button == 2) {
                 this.handleMouseRightUp(relativePos);
                 return false;
@@ -90,40 +93,52 @@ class UserInputManager {
             this.handleMouseUp(relativePos);
             return false;
         });
-        listenElement.addEventListener("mouseleave", (e) => {
+        this._addListener("mouseleave", (e) => {
             this.handleMouseClear();
         });
-        listenElement.addEventListener("touchend", (e) => {
+        this._addListener("touchend", (e) => {
             if (e.changedTouches.length !== 1) {
                 e.preventDefault();
                 return;
             }
-            let relativePos = this.getRelativePosition(listenElement, e.changedTouches[0].clientX, e.changedTouches[0].clientY);
+            let relativePos = this.getRelativePosition(this.listenElement, e.changedTouches[0].clientX, e.changedTouches[0].clientY);
             this.handleMouseUp(relativePos);
             return false;
         });
-        listenElement.addEventListener("touchleave", (e) => {
+        this._addListener("touchleave", (e) => {
             this.handleMouseClear();
             return false;
         });
-        listenElement.addEventListener("touchcancel", (e) => {
+        this._addListener("touchcancel", (e) => {
             this.handleMouseClear();
             return false;
         });
-        listenElement.addEventListener("dblclick", (e) => {
-            let relativePos = this.getRelativePosition(listenElement, e.clientX, e.clientY);
+        this._addListener("dblclick", (e) => {
+            let relativePos = this.getRelativePosition(this.listenElement, e.clientX, e.clientY);
             this.handleMouseDoubleClick(relativePos);
             e.stopPropagation();
             e.preventDefault();
             return false;
         });
-        listenElement.addEventListener("wheel", (e) => {
-            let relativePos = this.getRelativePosition(listenElement, e.clientX, e.clientY);
+        this._addListener("wheel", (e) => {
+            let relativePos = this.getRelativePosition(this.listenElement, e.clientX, e.clientY);
             this.handleWheel(relativePos, e.deltaY);
             e.stopPropagation();
             e.preventDefault();
             return false;
         });
+    }
+
+    _addListener(type, handler) {
+        this.listenElement.addEventListener(type, handler);
+        this._listeners.push([type, handler]);
+    }
+
+    dispose() {
+        for (const [type, handler] of this._listeners) {
+            this.listenElement.removeEventListener(type, handler);
+        }
+        this._listeners.length = 0;
     }
     getRelativePosition(element, clientX, clientY) {
         var rect = element.getBoundingClientRect();

--- a/js/VGASpecReader.js
+++ b/js/VGASpecReader.js
@@ -4,7 +4,7 @@ import { Lemmings } from './LemmingsNamespace.js';
  * Decodes a VGASPEC-format ground file, including color palette and image buffer.
  * @class
  */
-class VGASpecReader {
+class VGASpecReader extends Lemmings.BaseLogger {
     /** @type {number} */
     #width;
     /** @type {number} */
@@ -13,7 +13,7 @@ class VGASpecReader {
     #groundPalette;
     /** @type {Lemmings.Frame} */
     #img;
-    /** @type {Lemmings.LogHandler} */
+    /** @type {Lemmings.Logger} */
     #log;
 
     /**
@@ -22,7 +22,8 @@ class VGASpecReader {
      * @param {number} height
      */
     constructor(vgaspecFile, width, height) {
-        this.#log = new Lemmings.LogHandler("VGASpecReader");
+        super();
+        this.#log = this.log;
         this.#width = width | 0;
         this.#height = height | 0;
         this.#groundPalette = new Lemmings.ColorPalette();

--- a/js/steelSprites.json
+++ b/js/steelSprites.json
@@ -1,0 +1,14 @@
+{
+  "lemmings": {
+    "GROUND0O.DAT": [22, 23, 24, 25, 26],
+    "GROUND1O.DAT": [12, 13, 14, 15, 16, 17],
+    "GROUND2O.DAT": [5, 57, 58, 59],
+    "GROUND3O.DAT": [27, 48, 49, 50],
+    "GROUND4O.DAT": [31, 32, 34]
+  },
+  "lemmings_ohNo": {
+    "GROUND0O.DAT": [51, 52, 53, 54],
+    "GROUND1O.DAT": [56, 57, 58, 59],
+    "GROUND2O.DAT": [29, 30, 31, 32]
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,63 @@
       "name": "lemmings-js",
       "version": "1.0.0",
       "devDependencies": {
-        "http-server": "^14.0.1"
+        "adm-zip": "^0.5.10",
+        "chai": "^4.3.7",
+        "http-server": "^14.0.1",
+        "mocha": "^11.5.0",
+        "pngjs": "^7.0.0"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
     "node_modules/ansi-styles": {
@@ -26,6 +82,23 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/async": {
       "version": "2.6.4",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
@@ -34,6 +107,13 @@
       "dependencies": {
         "lodash": "^4.17.14"
       }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/basic-auth": {
       "version": "2.0.1",
@@ -47,6 +127,23 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/call-bind": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -58,6 +155,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chai": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/chalk": {
@@ -74,6 +203,113 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/color-convert": {
@@ -103,6 +339,21 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/debug": {
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
@@ -112,11 +363,111 @@
         "ms": "^2.1.1"
       }
     },
+    "node_modules/decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/diff": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "dev": true
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "bin": {
+        "flat": "cli.js"
+      }
     },
     "node_modules/follow-redirects": {
       "version": "1.14.9",
@@ -138,11 +489,48 @@
         }
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/get-intrinsic": {
       "version": "1.1.1",
@@ -156,6 +544,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/has": {
@@ -265,11 +674,130 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
+    },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/mime": {
       "version": "1.6.0",
@@ -283,11 +811,37 @@
         "node": ">=4"
       }
     },
+    "node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/minimist": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
+    },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
     },
     "node_modules/mkdirp": {
       "version": "0.5.6",
@@ -299,6 +853,76 @@
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/mocha": {
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.5.0.tgz",
+      "integrity": "sha512-VKDjhy6LMTKm0WgNEdlY77YVsD49LZnPSXJAaPNL9NRYQADxvORsyG1DIQY6v53BKTnlNbEE2MbVCDbnxr4K3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browser-stdout": "^1.3.1",
+        "chokidar": "^4.0.1",
+        "debug": "^4.3.5",
+        "diff": "^7.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-up": "^5.0.0",
+        "glob": "^10.4.5",
+        "he": "^1.2.0",
+        "js-yaml": "^4.1.0",
+        "log-symbols": "^4.1.0",
+        "minimatch": "^9.0.5",
+        "ms": "^2.1.3",
+        "picocolors": "^1.1.1",
+        "serialize-javascript": "^6.0.2",
+        "strip-json-comments": "^3.1.1",
+        "supports-color": "^8.1.1",
+        "workerpool": "^6.5.1",
+        "yargs": "^17.7.2",
+        "yargs-parser": "^21.1.1",
+        "yargs-unparser": "^2.0.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/mocha/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mocha/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/ms": {
@@ -323,6 +947,109 @@
       "dev": true,
       "bin": {
         "opener": "bin/opener-bin.js"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.19.0"
       }
     },
     "node_modules/portfinder": {
@@ -354,6 +1081,40 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -378,6 +1139,39 @@
       "integrity": "sha1-8aAymzCLIh+uN7mXTz1XjQypmeM=",
       "dev": true
     },
+    "node_modules/serialize-javascript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -392,6 +1186,136 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -402,6 +1326,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/union": {
@@ -432,6 +1366,237 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/workerpool": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
+      "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,23 +1,34 @@
 {
-  "name": "lemmings-js",
-  "version": "1.0.0",
+  "name": "lemmings-js-midi",
+  "version": "0.0.1",
   "description": "Lemmings (JavaScript)",
   "main": "index.js",
   "directories": {
     "lib": "lib"
   },
   "scripts": {
-    "start": "http-server --cors=*"
+    "start": "http-server --cors=*",
+    "test": "mocha",
+    "export-panel-sprite": "node tools/exportPanelSprite.js",
+    "export-lemmings-sprites": "node tools/exportLemmingsSprites.js",
+    "export-ground-images": "node tools/exportGroundImages.js",
+    "export-all-sprites": "node tools/exportAllSprites.js",
+    "export-all-packs": "node tools/exportAllPacks.js"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/oklemenz/LemmingsJS.git"
+    "url": "git+https://github.com/doublemover/LemmingsJS-MIDI.git"
   },
   "bugs": {
-    "url": "https://github.com/oklemenz/LemmingsJS/issues"
+    "url": "https://github.com/doublemover/LemmingsJS-MIDI/issues"
   },
-  "homepage": "https://github.com/oklemenz/LemmingsJS#readme",
+  "homepage": "https://github.com/doublemover/LemmingsJS-MIDI#readme",
+  "type": "module",
   "devDependencies": {
-    "http-server": "^14.0.1"
+    "chai": "^4.3.7",
+    "http-server": "^14.0.1",
+    "mocha": "^11.5.0",
+    "pngjs": "^7.0.0",
+    "adm-zip": "^0.5.10"
   }
 }

--- a/test/bitreader.test.js
+++ b/test/bitreader.test.js
@@ -1,0 +1,24 @@
+import { expect } from 'chai';
+import { Lemmings } from '../js/LemmingsNamespace.js';
+import '../js/LogHandler.js';
+import { BinaryReader } from '../js/BinaryReader.js';
+import { BitReader } from '../js/BitReader.js';
+
+globalThis.lemmings = Lemmings;
+
+describe('BitReader', function() {
+  it('reads reversed bytes and tracks checksum', function() {
+    const bytes = new Uint8Array([0xAA, 0x55]);
+    const bin = new BinaryReader(bytes);
+    const reader = new BitReader(bin, 0, bin.length);
+
+    const first = reader.read(8);
+    expect(first).to.equal(0xAA);
+
+    const second = reader.read(8);
+    expect(second).to.equal(0x55);
+
+    expect(reader.getCurrentChecksum()).to.equal(0xFF);
+    expect(reader.eof()).to.equal(true);
+  });
+});

--- a/test/bitstream.test.js
+++ b/test/bitstream.test.js
@@ -1,0 +1,60 @@
+import assert from 'assert';
+import { Lemmings } from '../js/LemmingsNamespace.js';
+import '../js/LogHandler.js';
+import { BinaryReader } from '../js/BinaryReader.js';
+import { BitReader } from '../js/BitReader.js';
+import { BitWriter } from '../js/BitWriter.js';
+import { FileContainer } from '../js/FileContainer.js';
+import '../js/UnpackFilePart.js';
+import { readFileSync } from 'fs';
+
+globalThis.lemmings = { game: { showDebug: false } };
+
+describe('BitReader/BitWriter', function () {
+  it('decompresses raw bytes', function () {
+    const compressed = Uint8Array.from([0x10, 0x48, 0x58, 0x48]);
+    const br = new BinaryReader(compressed);
+    const bitReader = new BitReader(br, 0, compressed.length, 8);
+    const bitWriter = new BitWriter(bitReader, 3);
+
+    while (!bitWriter.eof() && !bitReader.eof()) {
+      if (bitReader.read(1) === 0) {
+        if (bitReader.read(1) === 0) {
+          bitWriter.copyRawData(bitReader.read(3) + 1);
+        } else {
+          bitWriter.copyReferencedData(2, 8);
+        }
+      } else {
+        switch (bitReader.read(2)) {
+          case 0:
+            bitWriter.copyReferencedData(3, 9);
+            break;
+          case 1:
+            bitWriter.copyReferencedData(4, 10);
+            break;
+          case 2:
+            bitWriter.copyReferencedData(bitReader.read(8) + 1, 12);
+            break;
+          case 3:
+            bitWriter.copyRawData(bitReader.read(8) + 9);
+            break;
+        }
+      }
+    }
+
+    const result = Array.from(bitWriter.outData);
+    assert.deepStrictEqual(result, [0x41, 0x42, 0x43]);
+  });
+
+  it('unpacks first chunk of LEVEL000.DAT', function () {
+    const data = readFileSync(new URL('../lemmings/LEVEL000.DAT', import.meta.url));
+    const br = new BinaryReader(new Uint8Array(data));
+    const fc = new FileContainer(br);
+    const part = fc.getPart(0);
+    const bytes = [];
+    for (let i = 0; i < 10; i++) {
+      bytes.push(part.readByte());
+    }
+    assert.deepStrictEqual(bytes, [0, 50, 0, 80, 0, 40, 0, 4, 0, 10]);
+  });
+});

--- a/test/bitwriter.test.js
+++ b/test/bitwriter.test.js
@@ -1,0 +1,36 @@
+import assert from 'assert';
+import { Lemmings } from '../js/LemmingsNamespace.js';
+import { BitWriter } from '../js/BitWriter.js';
+import { BinaryReader } from '../js/BinaryReader.js';
+import '../js/LogHandler.js';
+
+// minimal global used by LogHandler
+globalThis.lemmings = { game: { showDebug: false } };
+
+class StubReader {
+  constructor(values) {
+    this.values = values.slice();
+  }
+  read(bits) {
+    return this.values.shift();
+  }
+}
+
+describe('BitWriter', function () {
+  it('writes raw and referenced data', function () {
+    const stub = new StubReader([0x01, 0x02, 0x03, 0x04, 1]);
+    const writer = new BitWriter(stub, 6);
+
+    writer.copyRawData(4);
+    assert.deepStrictEqual(Array.from(writer.outData.slice(2)), [0x04, 0x03, 0x02, 0x01]);
+
+    writer.copyReferencedData(2, 2);
+    assert.deepStrictEqual(Array.from(writer.outData), [0x04, 0x03, 0x04, 0x03, 0x02, 0x01]);
+
+    const fr = writer.getFileReader();
+    assert.ok(fr instanceof BinaryReader);
+    assert.deepStrictEqual(Array.from(fr.data), Array.from(writer.outData));
+
+    assert.ok(writer.eof());
+  });
+});

--- a/test/filecontainer.test.js
+++ b/test/filecontainer.test.js
@@ -1,0 +1,62 @@
+import assert from 'assert';
+
+// Minimal environment for LogHandler
+global.lemmings = { game: { showDebug: false } };
+
+import { Lemmings } from '../js/LemmingsNamespace.js';
+import '../js/LogHandler.js';
+import '../js/BinaryReader.js';
+import '../js/BitReader.js';
+import '../js/BitWriter.js';
+import '../js/UnpackFilePart.js';
+import { FileContainer } from '../js/FileContainer.js';
+
+function buildBuffer(badChecksum = false) {
+  const compressed = Uint8Array.from([16, 8, 24, 8]);
+  let checksum = 0;
+  for (const b of compressed) checksum ^= b;
+  if (badChecksum) checksum ^= 0xFF;
+  const size = compressed.length + 10;
+  const header = Uint8Array.from([
+    5, checksum, 0, 0, 0, 3, 0, 0, 0, size
+  ]);
+  const buffer = new Uint8Array(size);
+  buffer.set(header, 0);
+  buffer.set(compressed, 10);
+  return { buffer, checksum, compressed };
+}
+
+function computeChecksum(part, source) {
+  let cs = 0;
+  const data = source.data.subarray(part.offset, part.offset + part.compressedSize);
+  for (const b of data) cs ^= b;
+  return cs;
+}
+
+function runTest(bad) {
+  const { buffer, checksum, compressed } = buildBuffer(bad);
+  const br = new Lemmings.BinaryReader(buffer, 0, buffer.length, 'buf');
+  const fc = new FileContainer(br);
+  assert.strictEqual(fc.count(), 1);
+  const part = fc.parts[0];
+  assert.strictEqual(part.initialBufferLen, 5);
+  assert.strictEqual(part.compressedSize, compressed.length);
+  assert.strictEqual(part.decompressedSize, 3);
+  assert.strictEqual(part.checksum, checksum);
+
+  const out = part.unpack();
+  assert.strictEqual(out.length, part.decompressedSize);
+  assert.deepStrictEqual(Array.from(out.data.slice(0, out.length)), [8, 16, 24]);
+
+  const calc = computeChecksum(part, br);
+  if (bad) {
+    assert.notStrictEqual(calc, part.checksum);
+  } else {
+    assert.strictEqual(calc, part.checksum);
+  }
+}
+
+runTest(false);
+runTest(true);
+
+console.log('All tests passed.');

--- a/test/fileprovider.test.js
+++ b/test/fileprovider.test.js
@@ -1,0 +1,154 @@
+import assert from 'assert';
+import { FileProvider } from '../js/FileProvider.js';
+import { Lemmings } from '../js/LemmingsNamespace.js';
+
+class MockBinaryReader {}
+class MockLogHandler {
+  constructor() {
+    this.logged = [];
+    this.debugged = [];
+  }
+  log(msg) {
+    this.logged.push(msg);
+  }
+  debug(msg) {
+    this.debugged.push(msg);
+  }
+}
+let origBR;
+let origLog;
+
+describe('FileProvider', function () {
+  const rootPath = '/base/';
+  let provider;
+  let requests;
+  let restore;
+  let origFetch;
+
+  beforeEach(function () {
+    origBR = Lemmings.BinaryReader;
+    origLog = Lemmings.LogHandler;
+    Lemmings.BinaryReader = MockBinaryReader;
+    Lemmings.LogHandler = MockLogHandler;
+    provider = new FileProvider(rootPath);
+    global.localStorage = new (class {
+      constructor() { this.store = new Map(); }
+      getItem(k) { return this.store.has(k) ? this.store.get(k) : null; }
+      setItem(k, v) { this.store.set(k, v); }
+      removeItem(k) { this.store.delete(k); }
+      clear() { this.store.clear(); }
+    })();
+    origFetch = global.fetch;
+    delete global.fetch; // disable HEAD requests
+    requests = [];
+    class FakeXHR {
+      constructor() {
+        this.status = 0;
+        this.response = null;
+        FakeXHR.instances.push(this);
+      }
+      open(method, url) {
+        this.method = method;
+        this.url = url;
+      }
+      send() {}
+      respond(status, body) {
+        this.status = status;
+        this.response = body;
+        if (status >= 200 && status < 300) {
+          if (this.onload) this.onload();
+        } else {
+          if (this.onerror) this.onerror();
+        }
+      }
+    }
+    FakeXHR.instances = [];
+    requests = FakeXHR.instances;
+    global.XMLHttpRequest = FakeXHR;
+    restore = () => {
+      delete global.XMLHttpRequest;
+    };
+  });
+
+  afterEach(function () {
+    restore();
+    delete global.localStorage;
+    if (origFetch) {
+      global.fetch = origFetch;
+    }
+    provider.clearCache();
+    Lemmings.BinaryReader = origBR;
+    Lemmings.LogHandler = origLog;
+  });
+
+  it('_buildUrl() joins rootPath, path and filename', function () {
+    const url = provider._buildUrl('path', 'file.bin');
+    assert.strictEqual(url, rootPath + 'path' + '/' + 'file.bin');
+  });
+
+  it('loadBinary caches identical requests', async function () {
+    const p1 = provider.loadBinary('data', 'file.bin');
+    const p2 = provider.loadBinary('data', 'file.bin');
+    assert.strictEqual(p1, p2);
+    assert.strictEqual(requests.length, 1);
+
+    const buffer = new ArrayBuffer(0);
+    requests[0].respond(200, buffer);
+    const result = await p1;
+    assert.ok(result instanceof MockBinaryReader);
+
+    const p3 = provider.loadBinary('data', 'file.bin');
+    assert.strictEqual(p1, p3);
+    assert.strictEqual(requests.length, 1);
+  });
+
+  it('loadString caches identical requests', async function () {
+    const url = rootPath + 'text.txt';
+    const p1 = provider.loadString(url);
+    const p2 = provider.loadString(url);
+    assert.strictEqual(p1, p2);
+    assert.strictEqual(requests.length, 1);
+
+    requests[0].respond(200, 'hello');
+    const result = await p1;
+    assert.strictEqual(result, 'hello');
+
+    const p3 = provider.loadString(url);
+    assert.strictEqual(p1, p3);
+    assert.strictEqual(requests.length, 1);
+  });
+
+  it('clearCache() empties the internal cache', async function () {
+    const url = rootPath + 'file.txt';
+    const p1 = provider.loadString(url);
+    requests[0].respond(200, 'ok');
+    await p1;
+    assert.strictEqual(provider._cache.size, 1);
+    provider.clearCache();
+    assert.strictEqual(provider._cache.size, 0);
+  });
+
+  it('stores data in localStorage and reuses it', async function () {
+    const url = rootPath + 'text.txt';
+    const p1 = provider.loadString(url);
+    requests[0].respond(200, 'hello');
+    const result1 = await p1;
+    assert.strictEqual(result1, 'hello');
+    const stored = global.localStorage.getItem('lem-cache:' + url);
+    assert.ok(stored, 'entry stored');
+
+    // new provider simulating page reload
+    provider = new FileProvider(rootPath);
+    const p2 = provider.loadString(url);
+    assert.strictEqual(requests.length, 1, 'no new XHR');
+    const result2 = await p2;
+    assert.strictEqual(result2, 'hello');
+  });
+
+  it('logs an error when binary load fails', async function () {
+    const p = provider.loadBinary('data', 'file.bin');
+    requests[0].respond(404, null);
+    await assert.rejects(p);
+    assert.ok(provider.log.logged.some(m => m.includes('error load file')));
+  });
+});

--- a/tools/NodeFileProvider.js
+++ b/tools/NodeFileProvider.js
@@ -1,0 +1,63 @@
+import { Lemmings } from '../js/LemmingsNamespace.js';
+import fs from 'fs';
+import path from 'path';
+import AdmZip from 'adm-zip';
+
+class NodeFileProvider {
+    constructor(rootPath = '.') {
+        this.rootPath = rootPath;
+        this.zipCache = new Map();
+    }
+
+    _getZip(zipPath) {
+        const abs = path.resolve(this.rootPath, zipPath);
+        let zip = this.zipCache.get(abs);
+        if (!zip) {
+            zip = new AdmZip(abs);
+            this.zipCache.set(abs, zip);
+        }
+        return zip;
+    }
+
+    _findZipEntry(zip, entryName) {
+        const lower = entryName.replace(/\\/g, '/').toLowerCase();
+        let entry = zip.getEntry(entryName) || zip.getEntry(lower);
+        if (!entry) {
+            entry = zip.getEntries().find(e => {
+                const eName = e.entryName.toLowerCase();
+                return eName === lower || eName.endsWith('/' + lower);
+            });
+        }
+        return entry;
+    }
+
+    loadBinary(dir, filename) {
+        if (/\.zip$/i.test(dir)) {
+            const zip = this._getZip(dir);
+            const entry = this._findZipEntry(zip, filename);
+            if (!entry) throw new Error(`File ${filename} not found in ${dir}`);
+            const data = entry.getData();
+            const arr = new Uint8Array(data);
+            return Promise.resolve(new Lemmings.BinaryReader(arr, 0, arr.length, filename, dir));
+        }
+        const fullPath = path.join(this.rootPath, dir, filename);
+        const data = fs.readFileSync(fullPath);
+        const arr = new Uint8Array(data);
+        return Promise.resolve(new Lemmings.BinaryReader(arr, 0, arr.length, filename, dir));
+    }
+
+    loadString(file) {
+        const m = file.match(/^(.*\.zip)\/(.+)$/i);
+        if (m) {
+            const zip = this._getZip(m[1]);
+            const entry = this._findZipEntry(zip, m[2]);
+            if (!entry) throw new Error(`File ${m[2]} not found in ${m[1]}`);
+            return Promise.resolve(entry.getData().toString('utf8'));
+        }
+        const fullPath = path.join(this.rootPath, file);
+        const txt = fs.readFileSync(fullPath, 'utf8');
+        return Promise.resolve(txt);
+    }
+}
+
+export { NodeFileProvider };

--- a/tools/exportAllPacks.js
+++ b/tools/exportAllPacks.js
@@ -1,0 +1,31 @@
+import { spawnSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+function loadConfig() {
+    try {
+        const cfgPath = path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'config.json');
+        const txt = fs.readFileSync(cfgPath, 'utf8');
+        return JSON.parse(txt);
+    } catch {
+        return [];
+    }
+}
+
+const defaultPacks = loadConfig().map(p => ({ name: p.name, path: p.path }));
+
+let packs;
+if (process.argv.length > 2) {
+    packs = process.argv.slice(2).map(p => ({ name: p, path: p }));
+} else if (defaultPacks.length) {
+    packs = defaultPacks;
+} else {
+    packs = [{ name: 'lemmings', path: 'lemmings' }];
+}
+
+for (const pack of packs) {
+    const outDir = `export_${pack.name.replace(/\W+/g, '_')}`;
+    fs.mkdirSync(outDir, { recursive: true });
+    console.log(`Exporting ${pack.path} -> ${outDir}`);
+    spawnSync('node', ['tools/exportAllSprites.js', pack.path, outDir], { stdio: 'inherit' });
+}

--- a/tools/exportAllSprites.js
+++ b/tools/exportAllSprites.js
@@ -1,0 +1,122 @@
+import { Lemmings } from '../js/LemmingsNamespace.js';
+import '../js/LemmingsBootstrap.js';
+import { NodeFileProvider } from './NodeFileProvider.js';
+import fs from 'fs';
+import path from 'path';
+import { PNG } from 'pngjs';
+
+function loadDefaultPack() {
+    try {
+        const cfgPath = path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'config.json');
+        const txt = fs.readFileSync(cfgPath, 'utf8');
+        const cfg = JSON.parse(txt);
+        return cfg[0]?.path || 'lemmings';
+    } catch {
+        return 'lemmings';
+    }
+}
+
+function frameToPNG(frame) {
+    const png = new PNG({ width: frame.width, height: frame.height });
+    for (let y = 0; y < frame.height; y++) {
+        for (let x = 0; x < frame.width; x++) {
+            const idx = y * frame.width + x;
+            const rgba = frame.data[idx];
+            const p = idx * 4;
+            png.data[p    ] = rgba & 0xFF;
+            png.data[p + 1] = (rgba >> 8) & 0xFF;
+            png.data[p + 2] = (rgba >> 16) & 0xFF;
+            png.data[p + 3] = (rgba >> 24) & 0xFF;
+        }
+    }
+    return png;
+}
+
+(async () => {
+    const dataPath = process.argv[2] || loadDefaultPack();
+    const outDir   = process.argv[3] || `${dataPath.replace(/\W+/g, '_')}_all`;
+    fs.mkdirSync(outDir, { recursive: true });
+
+    const provider = new NodeFileProvider('.');
+    const res = new Lemmings.GameResources(provider, { path: dataPath, level: { groups: [] }});
+    const pal = new Lemmings.ColorPalette();
+
+    // --- Panel background and letters/numbers ---
+    const panelSprites = await res.getSkillPanelSprite(pal);
+
+    const panel = panelSprites.getPanelSprite();
+    frameToPNG(panel).pack().pipe(fs.createWriteStream(`${outDir}/panel.png`));
+
+    const letters = ['%', '0','1','2','3','4','5','6','7','8','9','-','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z',' '];
+    for (const letter of letters) {
+        const frame = panelSprites.getLetterSprite(letter);
+        const safe = encodeURIComponent(letter === ' ' ? 'space' : letter);
+        frameToPNG(frame).pack().pipe(fs.createWriteStream(`${outDir}/letter_${safe}.png`));
+    }
+
+    for (let i = 0; i < 10; i++) {
+        frameToPNG(panelSprites.getNumberSpriteLeft(i))
+            .pack().pipe(fs.createWriteStream(`${outDir}/num_left_${i}.png`));
+        frameToPNG(panelSprites.getNumberSpriteRight(i))
+            .pack().pipe(fs.createWriteStream(`${outDir}/num_right_${i}.png`));
+    }
+
+    // --- Lemming sprites ---
+    const spriteSet = await res.getLemmingsSprite(pal);
+    for (const [name, id] of Object.entries(Lemmings.SpriteTypes)) {
+        for (const dir of [true, false]) {
+            const anim = spriteSet.getAnimation(id, dir);
+            if (!anim || !anim.frames || anim.frames.length === 0) continue;
+            const dirName = dir ? 'right' : 'left';
+            const sheet = new PNG({ width: anim.frames[0].width * anim.frames.length, height: anim.frames[0].height });
+            for (let i = 0; i < anim.frames.length; i++) {
+                const frame = anim.getFrame(i);
+                const png = frameToPNG(frame);
+                await new Promise(res => png.pack().pipe(fs.createWriteStream(`${outDir}/${name}_${dirName}_${i}.png`)).on('finish', res));
+                for (let y = 0; y < frame.height; y++) {
+                    for (let x = 0; x < frame.width; x++) {
+                        const idx = (y * frame.width + x) * 4;
+                        const dest = ((y * sheet.width) + x + i * frame.width) * 4;
+                        sheet.data[dest    ] = png.data[idx];
+                        sheet.data[dest + 1] = png.data[idx + 1];
+                        sheet.data[dest + 2] = png.data[idx + 2];
+                        sheet.data[dest + 3] = png.data[idx + 3];
+                    }
+                }
+            }
+            await new Promise(res => sheet.pack().pipe(fs.createWriteStream(`${outDir}/${name}_${dirName}_sheet.png`)).on('finish', res));
+        }
+    }
+
+    // --- Map object sprites from ground files ---
+    for (let g = 0; g < 5; g++) {
+        const groundFile = `GROUND${g}O.DAT`;
+        const vgaFile    = `VGAGR${g}.DAT`;
+        let groundBuf, vgaBuf;
+        try {
+            groundBuf = await provider.loadBinary(dataPath, groundFile);
+            vgaBuf    = await provider.loadBinary(dataPath, vgaFile);
+        } catch {
+            continue;
+        }
+        fs.mkdirSync(`${outDir}/ground${g}`, { recursive: true });
+        const vgaContainer = new Lemmings.FileContainer(vgaBuf);
+        const groundReader = new Lemmings.GroundReader(
+            groundBuf,
+            vgaContainer.getPart(0),
+            vgaContainer.getPart(1)
+        );
+        const objects = groundReader.getObjectImages();
+        for (let i = 0; i < objects.length; i++) {
+            const img = objects[i];
+            if (!img) continue;
+            for (let f = 0; f < img.frameCount; f++) {
+                const frameBuf = img.frames[f];
+                const frame = new Lemmings.Frame(img.width, img.height);
+                frame.drawPaletteImage(frameBuf, img.width, img.height, img.palette, 0, 0);
+                const png = frameToPNG(frame);
+                await new Promise(res => png.pack().pipe(fs.createWriteStream(`${outDir}/ground${g}/object_${i}_${f}.png`)).on('finish', res));
+            }
+        }
+    }
+})();

--- a/tools/exportGroundImages.js
+++ b/tools/exportGroundImages.js
@@ -1,0 +1,81 @@
+import { Lemmings } from '../js/LemmingsNamespace.js';
+import '../js/LemmingsBootstrap.js';
+import { NodeFileProvider } from './NodeFileProvider.js';
+import fs from 'fs';
+import path from 'path';
+import { PNG } from 'pngjs';
+
+function loadDefaultPack() {
+    try {
+        const cfgPath = path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'config.json');
+        const txt = fs.readFileSync(cfgPath, 'utf8');
+        const cfg = JSON.parse(txt);
+        return cfg[0]?.path || 'lemmings';
+    } catch {
+        return 'lemmings';
+    }
+}
+
+function bufToFrame(buf, width, height, palette) {
+    const frame = new Lemmings.Frame(width, height);
+    frame.drawPaletteImage(buf, width, height, palette, 0, 0);
+    return frame;
+}
+
+function frameToPNG(frame) {
+    const png = new PNG({ width: frame.width, height: frame.height });
+    for (let y = 0; y < frame.height; y++) {
+        for (let x = 0; x < frame.width; x++) {
+            const idx = y * frame.width + x;
+            const rgba = frame.data[idx];
+            const p = (y * frame.width + x) * 4;
+            png.data[p    ] = rgba & 0xFF;
+            png.data[p + 1] = (rgba >> 8) & 0xFF;
+            png.data[p + 2] = (rgba >> 16) & 0xFF;
+            png.data[p + 3] = (rgba >> 24) & 0xFF;
+        }
+    }
+    return png;
+}
+
+(async () => {
+    const dataPath = process.argv[2] || loadDefaultPack();
+    const index = parseInt(process.argv[3] || '0', 10);
+    const outDir = process.argv[4] || `${dataPath.replace(/\W+/g, '_')}_ground_${index}`;
+    fs.mkdirSync(outDir, { recursive: true });
+
+    const provider = new NodeFileProvider('.');
+    const groundBuf = await provider.loadBinary(dataPath, `GROUND${index}O.DAT`);
+    const vgagrBuf = await provider.loadBinary(dataPath, `VGAGR${index}.DAT`);
+    const vgaContainer = new Lemmings.FileContainer(vgagrBuf);
+    const groundReader = new Lemmings.GroundReader(
+        groundBuf,
+        vgaContainer.getPart(0),
+        vgaContainer.getPart(1)
+    );
+
+    const terrains = groundReader.getTerrainImages();
+    const objects  = groundReader.getObjectImages();
+
+    for (let i = 0; i < terrains.length; i++) {
+        const img = terrains[i];
+        if (!img) continue;
+        for (let f = 0; f < img.frameCount; f++) {
+            const frame = bufToFrame(img.frames[f], img.width, img.height, img.palette);
+            const png = frameToPNG(frame);
+            const file = `${outDir}/terrain_${i}_${f}.png`;
+            await new Promise(res => png.pack().pipe(fs.createWriteStream(file)).on('finish', res));
+        }
+    }
+
+    for (let i = 0; i < objects.length; i++) {
+        const img = objects[i];
+        if (!img) continue;
+        for (let f = 0; f < img.frameCount; f++) {
+            const frame = bufToFrame(img.frames[f], img.width, img.height, img.palette);
+            const png = frameToPNG(frame);
+            const file = `${outDir}/object_${i}_${f}.png`;
+            await new Promise(res => png.pack().pipe(fs.createWriteStream(file)).on('finish', res));
+        }
+    }
+})();

--- a/tools/exportLemmingsSprites.js
+++ b/tools/exportLemmingsSprites.js
@@ -1,0 +1,76 @@
+import { Lemmings } from '../js/LemmingsNamespace.js';
+import '../js/LemmingsBootstrap.js';
+import { NodeFileProvider } from './NodeFileProvider.js';
+import fs from 'fs';
+import path from 'path';
+import { PNG } from 'pngjs';
+
+function loadDefaultPack() {
+    try {
+        const cfgPath = path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'config.json');
+        const txt = fs.readFileSync(cfgPath, 'utf8');
+        const cfg = JSON.parse(txt);
+        return cfg[0]?.path || 'lemmings';
+    } catch {
+        return 'lemmings';
+    }
+}
+
+function frameToPNG(frame) {
+    const png = new PNG({ width: frame.width, height: frame.height });
+    for (let y = 0; y < frame.height; y++) {
+        for (let x = 0; x < frame.width; x++) {
+            const idx = y * frame.width + x;
+            const rgba = frame.data[idx];
+            const p = (y * frame.width + x) * 4;
+            png.data[p    ] = rgba & 0xFF;
+            png.data[p + 1] = (rgba >> 8) & 0xFF;
+            png.data[p + 2] = (rgba >> 16) & 0xFF;
+            png.data[p + 3] = (rgba >> 24) & 0xFF;
+        }
+    }
+    return png;
+}
+
+(async () => {
+    const dataPath = process.argv[2] || loadDefaultPack();
+    const outDir = process.argv[3] || `${dataPath.replace(/\W+/g, '_')}_sprites`;
+    fs.mkdirSync(outDir, { recursive: true });
+
+    const provider = new NodeFileProvider('.');
+    const res = new Lemmings.GameResources(provider, { path: dataPath, level: { groups: [] }});
+    const pal = new Lemmings.ColorPalette();
+    const spriteSet = await res.getLemmingsSprite(pal);
+
+    for (const [name, id] of Object.entries(Lemmings.SpriteTypes)) {
+        for (const dir of [true, false]) {
+            const anim = spriteSet.getAnimation(id, dir);
+            if (!anim || !anim.frames || anim.frames.length === 0) continue;
+
+            const dirName = dir ? 'right' : 'left';
+            const sheet = new PNG({ width: anim.frames[0].width * anim.frames.length, height: anim.frames[0].height });
+
+            for (let i = 0; i < anim.frames.length; i++) {
+                const frame = anim.getFrame(i);
+                const png = frameToPNG(frame);
+                const file = `${outDir}/${name}_${dirName}_${i}.png`;
+                await new Promise(res => png.pack().pipe(fs.createWriteStream(file)).on('finish', res));
+
+                // blit into sheet
+                for (let y = 0; y < frame.height; y++) {
+                    for (let x = 0; x < frame.width; x++) {
+                        const idx = (y * frame.width + x) * 4;
+                        const dest = ((y * sheet.width) + x + i * frame.width) * 4;
+                        sheet.data[dest    ] = png.data[idx];
+                        sheet.data[dest + 1] = png.data[idx + 1];
+                        sheet.data[dest + 2] = png.data[idx + 2];
+                        sheet.data[dest + 3] = png.data[idx + 3];
+                    }
+                }
+            }
+
+            const sheetFile = `${outDir}/${name}_${dirName}_sheet.png`;
+            await new Promise(res => sheet.pack().pipe(fs.createWriteStream(sheetFile)).on('finish', res));
+        }
+    }
+})();

--- a/tools/exportPanelSprite.js
+++ b/tools/exportPanelSprite.js
@@ -1,0 +1,42 @@
+import { Lemmings } from '../js/LemmingsNamespace.js';
+import '../js/LemmingsBootstrap.js';
+import { NodeFileProvider } from './NodeFileProvider.js';
+import fs from 'fs';
+import path from 'path';
+import { PNG } from 'pngjs';
+
+function loadDefaultPack() {
+    try {
+        const cfgPath = path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'config.json');
+        const txt = fs.readFileSync(cfgPath, 'utf8');
+        const cfg = JSON.parse(txt);
+        return cfg[0]?.path || 'lemmings';
+    } catch {
+        return 'lemmings';
+    }
+}
+
+(async () => {
+    const pack = process.argv[2] || loadDefaultPack();
+    const outDir = process.argv[3] || 'panel_export';
+    const provider = new NodeFileProvider('.');
+    const res = new Lemmings.GameResources(provider, { path: pack, level: { groups: [] }});
+    const pal = new Lemmings.ColorPalette();
+    const sprites = await res.getSkillPanelSprite(pal);
+    const panel = sprites.getPanelSprite();
+    const png = new PNG({ width: panel.width, height: panel.height });
+    for (let y = 0; y < panel.height; y++) {
+        for (let x = 0; x < panel.width; x++) {
+            const idx = y * panel.width + x;
+            const rgba = panel.data[idx];
+            const pidx = idx * 4;
+            png.data[pidx  ] = rgba & 0xFF;
+            png.data[pidx+1] = (rgba >> 8) & 0xFF;
+            png.data[pidx+2] = (rgba >> 16) & 0xFF;
+            png.data[pidx+3] = (rgba >> 24) & 0xFF;
+        }
+    }
+    fs.mkdirSync(outDir, { recursive: true });
+    const outFile = `${outDir}/panelSprite.png`;
+    png.pack().pipe(fs.createWriteStream(outFile));
+})();


### PR DESCRIPTION
## Summary
- use a new caching system in `ActionBaseSystem`
- accept `actionName` in the base class constructor
- remove duplicated sprite drawing logic from many action systems
- use `super.draw` for simple draws
- pass `actionName` from each action class and drop redundant fields

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683fe3abb6a0832d95ba609ccf04846e