### PR TITLE
Fix Stage fade-out timer

### DIFF
--- a/js/LogHandler.js
+++ b/js/LogHandler.js
@@ -5,12 +5,12 @@ class LogHandler {
         this._moduleName = moduleName;
     }
     /** log an error */
-    log(msg, exeption) {
+    log(msg, exception) {
         if (!lemmings == false) {
             if (!lemmings.game == false && lemmings.game.showDebug == true) {
                 console.log(this._moduleName + "\t" + msg);
-                if (exeption) {
-                    console.log(this._moduleName + "\t" + exeption.message);
+                if (exception) {
+                    console.log(this._moduleName + "\t" + exception.message);
                 }
             }
         }

--- a/js/Stage.js
+++ b/js/Stage.js
@@ -189,7 +189,6 @@ class Stage {
         }
         getGuiDisplay() {
             if (this.guiImgProps.display != null) {
-                this.guiImg
                 return this.guiImgProps.display;
             }
             this.guiImgProps.display = new Lemmings.DisplayImage(this);
@@ -263,8 +262,9 @@ class Stage {
             this.resetFade();
             this.fadeTimer = setInterval(() => {
                 this.fadeAlpha = Math.min(this.fadeAlpha + 0.02, 1);
-                if (this.fadeAlpha <= 0) {
+                if (this.fadeAlpha >= 1) {
                     clearInterval(this.fadeTimer);
+                    this.fadeTimer = 0;
                 }
             }, 40);
         }


### PR DESCRIPTION
## Summary
- fix Stage fade-out timer stop condition
- previous cleanup retained (getGuiDisplay, LogHandler)

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683fe00f89bc832d9b4900290f71cfb1