### PR TITLE
Remove unused level number update

### DIFF
--- a/js/GameView.js
+++ b/js/GameView.js
@@ -168,8 +168,6 @@ async moveToLevel(moveInterval = 0) {
                 this.levelGroupIndex = 0;
                 this.levelIndex = 0;
             }
-
-            this.changeHtmlText(this.elementLevelNumber, (this.levelIndex + 1).toString());
             await this.loadLevel();
         } finally {
             this.inMoveToLevel = false;


### PR DESCRIPTION
## Summary
- clean up GameView.moveToLevel by deleting leftover level number UI update
- ensure file has no trailing blank line after removal

## Testing
- `npm test` *(fails: Missing script)*
- `npm start` *(manual check; server launches at http://127.0.0.1:8080)*

------
https://chatgpt.com/codex/tasks/task_e_683feaad68f0832d965e2c78f6cf439f