### PR TITLE
Fix level reload on fade-out

### DIFF
--- a/js/GameView.js
+++ b/js/GameView.js
@@ -20,6 +20,7 @@ class GameView {
         this.steps = 0;
         this.applyQuery();
         this.elementGameState = null;
+        this.autoMoveTimer = null;
 
         this.log.log("selected level: " + Lemmings.GameTypes.toString(this.gameType) + " : " + this.levelIndex + " / " + this.levelGroupIndex);
     }
@@ -59,7 +60,7 @@ class GameView {
         this.changeHtmlText(this.elementGameState, Lemmings.GameStateTypes.toString(gameResult.state));
         this.stage.startFadeOut();
         console.dir(gameResult);
-        window.setTimeout(() => {
+        this.autoMoveTimer = window.setTimeout(() => {
             if (gameResult.state == Lemmings.GameStateTypes.SUCCEEDED) {
                 /// move to next level
                 this.moveToLevel(1);
@@ -67,6 +68,7 @@ class GameView {
                 /// redo this level
                 this.moveToLevel(0);
             }
+            this.autoMoveTimer = null;
         }, 2500);
     }
 
@@ -324,6 +326,10 @@ async moveToLevel(moveInterval = 0) {
     }
     /** load a level and render it to the display */
     async loadLevel() {
+        if (this.autoMoveTimer !== null) {
+            window.clearTimeout(this.autoMoveTimer);
+            this.autoMoveTimer = null;
+        }
         if (!this.gameResources) return;
         if (this.game) {
             this.game.stop();


### PR DESCRIPTION
## Summary
- prevent stage auto reload if user changes level during fade-out

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683ffe8e792c832d8c352e3f287779d3