### PR TITLE
Load steel sprite list from JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ The goal is to create a solid, performant port first. Then build out the sequenc
   - Traps animate, are deadly, and have cooldowns
   - Frying, Jumping, Hoisting animations
   - Improved Steel terrain
-    - Using magic numbers based on level pack & ground#.dat to flag steel images and calculate opaque size for precise placement
+    - Steel sprite indexes are stored in `js/steelSprites.json` by game and pack
+      to calculate opaque size for precise placement
   - Arrow Walls function
   - Minimap
     - Accumulates ground at full resolution for enhanced accuracy

--- a/js/GroundReader.js
+++ b/js/GroundReader.js
@@ -1,4 +1,5 @@
 import { Lemmings } from './LemmingsNamespace.js';
+import steelSprites from './steelSprites.json' assert { type: 'json' };
 
 const OBJECT_COUNT          = 16;
 const TERRAIN_COUNT         = 64;
@@ -161,60 +162,18 @@ class GroundReader {
       img.palette  = palette;
       img.frameCount = 1; // terrains never animate
 
-      let filename = fr.filename;
-      let foldername = fr.foldername;
-      if (foldername == "[unknown]") {
-        console.log("folder name for " + filename + " is unknown, unable to use magic numbers to make perfect steel");
-      }
-      else if (foldername == "lemmings") {
-        if (filename == "GROUND0O.DAT") { // normal maps
-          if (i >= 22 && i <= 26) {
-            img.isSteel = true;
-          }
-          if (i == 19) {
-            // this one writes black over steel
-          }
-        } 
-        else if (filename == "GROUND1O.DAT") { // dungeon maps 
-          if (i >= 12 && i <= 17) {
-            img.isSteel = true;
-          }
-        } 
-        else if (filename == "GROUND2O.DAT") { // pink maps
-          if (i == 5 || i >= 57 && i <= 59) { 
-            img.isSteel = true;
-          }
-        } 
-        else if (filename == "GROUND3O.DAT") { // desert maps
-          if (i == 27) { 
-            img.isSteel = true;
-          }
-          if ( i >= 48 && i <= 50) {
-            img.isSteel = true;
-          }
-        } 
-        else if (filename == "GROUND4O.DAT") { // crystal maps
-          if (i >= 31 && i <= 32 || i == 34) {
-            img.isSteel = true;
-          }
+      const filename = fr.filename;
+      const foldername = fr.foldername;
+      if (foldername === "[unknown]") {
+        console.log(
+          "folder name for " + filename + " is unknown, unable to use magic numbers to make perfect steel"
+        );
+      } else {
+        const gameData = steelSprites[foldername];
+        const steelList = gameData ? gameData[filename] : null;
+        if (steelList && steelList.includes(i)) {
+          img.isSteel = true;
         }
-      } 
-      else if (foldername == "lemmings_ohNo") {
-        if (filename == "GROUND0O.DAT") { // brick maps
-          if (i >= 51 && i <= 54) {
-            img.isSteel = true;
-          }
-        } 
-        else if (filename == "GROUND1O.DAT") { // jungle maps 
-          if (i >= 56 && i <= 59) {
-            img.isSteel = true;
-          }
-        } 
-        else if (filename == "GROUND2O.DAT") { // ice maps
-          if (i >= 29 && i <= 32) { 
-            img.isSteel = true;
-          }
-        } 
       }
 
       if (fr.eof()) {

--- a/js/GroundReader.js
+++ b/js/GroundReader.js
@@ -1,5 +1,16 @@
 import { Lemmings } from './LemmingsNamespace.js';
-import steelSprites from './steelSprites.json' assert { type: 'json' };
+let steelSprites = null;
+
+async function loadSteelSprites() {
+  if (!steelSprites) {
+    const url = new URL('./steelSprites.json', import.meta.url);
+    const res = await fetch(url);
+    steelSprites = await res.json();
+  }
+  return steelSprites;
+}
+
+Lemmings.loadSteelSprites = loadSteelSprites;
 
 const OBJECT_COUNT          = 16;
 const TERRAIN_COUNT         = 64;

--- a/js/LevelLoader.js
+++ b/js/LevelLoader.js
@@ -72,6 +72,7 @@ class LevelLoader {
     // 4 · Decode terrain / objects and render background                      //
     // ----------------------------------------------------------------------- //
     const vgaContainer = new Lemmings.FileContainer(vgagrBuf);
+    await Lemmings.loadSteelSprites();
     const groundReader = new Lemmings.GroundReader(
                              groundBuf,
                              vgaContainer.getPart(0),

--- a/js/steelSprites.json
+++ b/js/steelSprites.json
@@ -1,0 +1,14 @@
+{
+  "lemmings": {
+    "GROUND0O.DAT": [22, 23, 24, 25, 26],
+    "GROUND1O.DAT": [12, 13, 14, 15, 16, 17],
+    "GROUND2O.DAT": [5, 57, 58, 59],
+    "GROUND3O.DAT": [27, 48, 49, 50],
+    "GROUND4O.DAT": [31, 32, 34]
+  },
+  "lemmings_ohNo": {
+    "GROUND0O.DAT": [51, 52, 53, 54],
+    "GROUND1O.DAT": [56, 57, 58, 59],
+    "GROUND2O.DAT": [29, 30, 31, 32]
+  }
+}


### PR DESCRIPTION
## Summary
- move steel sprite magic numbers into `steelSprites.json`
- lookup sprite indices from JSON when reading terrain
- document the new file in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840047001a8832d8a680a5dc1cee01e