### PR TITLE
Implement marching ants selection in GameGui

### DIFF
--- a/js/DisplayImage.js
+++ b/js/DisplayImage.js
@@ -122,14 +122,23 @@ class DisplayImage {
      * @param {number} dashLen Length of each dash segment (in pixels)
      * @param {number} offset  Offset of the dash pattern
      */
-    drawMarchingAntRect(x, y, width, height, dashLen = 3, offset = 0) {
+    drawMarchingAntRect(
+        x,
+        y,
+        width,
+        height,
+        dashLen = 3,
+        offset = 0,
+        color1 = 0xFFFFFFFF,
+        color2 = 0xFF000000
+    ) {
         if (!this.buffer32) return;
         const { width: w } = this.imgData;
         const pattern = dashLen * 2;
         let pos = ((offset % pattern) + pattern) % pattern;
         const set = (px, py) => {
-            const useWhite = Math.floor(pos / dashLen) % 2 === 0;
-            this.buffer32[py * w + px] = useWhite ? 0xFFFFFFFF : 0xFF000000;
+            const useFirst = Math.floor(pos / dashLen) % 2 === 0;
+            this.buffer32[py * w + px] = useFirst ? color1 : color2;
             pos = (pos + 1) % pattern;
         };
 

--- a/js/DisplayImage.js
+++ b/js/DisplayImage.js
@@ -122,7 +122,7 @@ class DisplayImage {
      * @param {number} dashLen Length of each dash segment (in pixels)
      * @param {number} offset  Offset of the dash pattern
      */
-    drawMarchingAntRect(x, y, width, height, dashLen = 2, offset = 0) {
+    drawMarchingAntRect(x, y, width, height, dashLen = 3, offset = 0) {
         if (!this.buffer32) return;
         const { width: w } = this.imgData;
         const pattern = dashLen * 2;

--- a/js/GameGui.js
+++ b/js/GameGui.js
@@ -425,6 +425,13 @@ class GameGui {
             this.skillSelectionChanged = false;
         }
 
+        if (!this.gameTimer.isRunning?.()) {
+            this.drawPaused(d);
+        }
+        if (this.nukePrepared) {
+            this.drawNukeConfirm(d);
+        }
+
         if (this._hoverPanelIdx >= 0) {
             if (this._hoverPanelIdx === 11 && this.nukePrepared) {
                 this.drawNukeHover(d);
@@ -442,9 +449,6 @@ class GameGui {
         }
 
         this.drawSelection(d, this.getPanelIndexBySkill(this.skills.getSelectedSkill()));
-        if (this.nukePrepared) {
-            this.drawNukeConfirm(d);
-        }
         if (this.releaseRateChanged) {
             this.releaseRateChanged = false;
             this.drawPanelNumber(d, this.gameVictoryCondition.getMinReleaseRate(),     0);
@@ -462,9 +466,6 @@ class GameGui {
             const viewW = d.getWidth();
             this.miniMap.render(viewX, viewW);
         }
-                    if (!this.gameTimer.isRunning?.()) {
-                this.drawPaused(d);
-            }
     }
 
     _pad(v, len) { const s = String(v); return s.length >= len ? s : ' '.repeat(len - s.length) + s; }

--- a/js/GameGui.js
+++ b/js/GameGui.js
@@ -36,8 +36,8 @@ class GameGui {
         this.deltaReleaseRate = 0;
 
         /* marching ants selection animation settings */
-        this.selectionDashLen   = 2;   // length of dash segments
-        this.selectionAnimDelay = 6;   // frames between offset increments
+        this.selectionDashLen   = 3;   // length of dash segments
+        this.selectionAnimDelay = 20;  // frames between offset increments
         this.selectionAnimStep  = 1;   // pixels per animation step
         this._selectionOffset   = 0;
         this._selectionCounter  = 0;
@@ -236,6 +236,10 @@ class GameGui {
         const rawIdx = e.y > 15 ? Math.trunc(e.x / 16) : -1;
         let idx = rawIdx;
 
+        if (!this.gameTimer.isRunning?.() && rawIdx !== 11) {
+            idx = -1;
+        }
+
         if (rawIdx === 0 || rawIdx === 1) {
             const rrMin = this.gameVictoryCondition.getMinReleaseRate?.() ?? 0;
             const rrMax = this.gameVictoryCondition.getMaxReleaseRate?.() ?? 99;
@@ -390,20 +394,41 @@ class GameGui {
                 d.drawFrameResized(small, 164, 33, 8, 6);
                 d.drawHorizontalLine(169, 33, 175, 0, 0, 0);
             }
+
+            if (this._hoverSpeedUp) {
+                d.drawHorizontalLine(172, 32, 175, 0, 166, 0);
+                d.drawHorizontalLine(172, 38, 175, 0, 166, 0);
+            } else if (this._hoverSpeedDown) {
+                d.drawHorizontalLine(161, 32, 164, 0, 166, 0);
+                d.drawHorizontalLine(161, 38, 164, 0, 166, 0);
+            }
         }
 
 
         if (this.skillsCountChanged) {
             this.skillsCountChanged = false;
-            for (let s = 1; s < Object.keys(Lemmings.SkillTypes).length; ++s)
-                this.drawPanelNumber(d, this.skills.getSkill(s), this.getPanelIndexBySkill(s));
+            for (let s = 1; s < Object.keys(Lemmings.SkillTypes).length; ++s) {
+                const panel = this.getPanelIndexBySkill(s);
+                const count = this.skills.getSkill(s);
+                this.drawPanelNumber(d, count, panel);
+            }
+        }
+        for (let s = 1; s < Object.keys(Lemmings.SkillTypes).length; ++s) {
+            if (this.skills.getSkill(s) <= 0) {
+                const panel = this.getPanelIndexBySkill(s);
+                d.drawStippleRect(panel * 16, 16, 16, 23, 160, 160, 160);
+            }
         }
         if (this.skillSelectionChanged) {
             this.skillSelectionChanged = false;
         }
 
         if (this._hoverPanelIdx >= 0) {
-            this.drawSkillHover(d, this._hoverPanelIdx);
+            if (this._hoverPanelIdx === 11) {
+                this.drawSkillHover(d, this._hoverPanelIdx, 255, 128, 0);
+            } else {
+                this.drawSkillHover(d, this._hoverPanelIdx);
+            }
         }
 
         // update marching ants animation
@@ -472,9 +497,9 @@ class GameGui {
         d.drawRect(16 * 10, 16, 16, 23, 255, 255, 255);
     }
 
-    drawSkillHover(d, panelIdx) {
+    drawSkillHover(d, panelIdx, r = 255, g = 255, b = 0) {
         if (panelIdx < 0) return;
-        d.drawRect(16 * panelIdx, 16, 16, 23, 255, 255, 0);
+        d.drawRect(16 * panelIdx, 16, 16, 23, r, g, b);
     }
 
     drawSpeedChange(upDown, reset = false) {

--- a/js/GameGui.js
+++ b/js/GameGui.js
@@ -36,8 +36,8 @@ class GameGui {
         this.deltaReleaseRate = 0;
 
         /* marching ants selection animation settings */
-        this.selectionDashLen   = 3;   // length of dash segments
-        this.selectionAnimDelay = 20;  // frames between offset increments
+        this.selectionDashLen   = 4;   // length of dash segments (1px longer)
+        this.selectionAnimDelay = 60;  // frames between offset increments (slower)
         this.selectionAnimStep  = 1;   // pixels per animation step
         this._selectionOffset   = 0;
         this._selectionCounter  = 0;
@@ -188,7 +188,8 @@ class GameGui {
         }
         const newSkill = this.getSkillByPanelIndex(panelIndex);
         if (newSkill === Lemmings.SkillTypes.UNKNOWN) return;
-            this.skills.setSelectedSkill(newSkill);
+        if (this.skills.getSkill(newSkill) <= 0) return;
+        this.skills.setSelectedSkill(newSkill);
         this.game.queueCommand(new Lemmings.CommandSelectSkill(newSkill));
     }
 
@@ -261,8 +262,9 @@ class GameGui {
         let up = false, down = false;
         if (rawIdx === 10 && e.y >= 32) {
             const pauseIndex = Math.trunc((e.x - 159) / 9);
-            up   = pauseIndex === 1;
-            down = pauseIndex === 0;
+            const speedFac = this.gameTimer.speedFactor;
+            if (pauseIndex === 1 && speedFac < 120) up = true;
+            if (pauseIndex === 0 && speedFac > 0.1) down = true;
         }
         if (up !== this._hoverSpeedUp || down !== this._hoverSpeedDown) {
             this._hoverSpeedUp = up;
@@ -424,7 +426,9 @@ class GameGui {
         }
 
         if (this._hoverPanelIdx >= 0) {
-            if (this._hoverPanelIdx === 11) {
+            if (this._hoverPanelIdx === 11 && this.nukePrepared) {
+                this.drawNukeHover(d);
+            } else if (this._hoverPanelIdx === 11) {
                 this.drawSkillHover(d, this._hoverPanelIdx, 255, 128, 0);
             } else {
                 this.drawSkillHover(d, this._hoverPanelIdx);
@@ -527,8 +531,21 @@ class GameGui {
         this.gameSpeedChanged = true;
     }
 
-    drawNukeConfirm(d) { 
-        d.drawRect(16 * 11, 16, 16, 23, 255, 0, 0); 
+    drawNukeConfirm(d) {
+        d.drawRect(16 * 11, 16, 16, 23, 255, 0, 0);
+    }
+
+    drawNukeHover(d) {
+        d.drawMarchingAntRect(
+            16 * 11,
+            16,
+            16,
+            23,
+            this.selectionDashLen,
+            this._selectionOffset,
+            0xFF0080FF,
+            0xFF00FFFF
+        );
     }
 
     drawPanelNumber(d, num, panelIdx) { 

--- a/js/GameSkills.js
+++ b/js/GameSkills.js
@@ -57,6 +57,15 @@ class GameSkills {
                 this.onCountChanged.trigger(i);
             }
         }
+
+        clearSelectedSkill() {
+            if (this.selectedSkill !== Lemmings.SkillTypes.UNKNOWN) {
+                this.selectedSkill = Lemmings.SkillTypes.UNKNOWN;
+                this.onSelectionChanged.trigger();
+                return true;
+            }
+            return false;
+        }
     }
     Lemmings.GameSkills = GameSkills;
 

--- a/js/GameSkills.js
+++ b/js/GameSkills.js
@@ -6,6 +6,16 @@ class GameSkills {
             this.onCountChanged = new Lemmings.EventHandler();
             this.onSelectionChanged = new Lemmings.EventHandler();
             this.skills = level.skills;
+            this.selectFirstAvailable();
+        }
+
+        selectFirstAvailable() {
+            for (let i = Lemmings.SkillTypes.CLIMBER; i <= Lemmings.SkillTypes.DIGGER; i++) {
+                if (this.skills[i] > 0) {
+                    this.selectedSkill = i;
+                    break;
+                }
+            }
         }
         /** return true if the skill can be reused / used */
         canReuseSkill(type) {
@@ -16,6 +26,9 @@ class GameSkills {
                 return false;
             this.skills[type]--;
             this.onCountChanged.trigger(type);
+            if (this.skills[type] <= 0 && this.selectedSkill === type) {
+                this.selectFirstAvailable();
+            }
             return true;
         }
         getSkill(type) {

--- a/js/MiniMap.js
+++ b/js/MiniMap.js
@@ -224,8 +224,11 @@ class MiniMap {
             frame.mask[idx] = 1;
         }
 
-        const vpX = (lemmings.stage.getGameViewRect().x * this.scaleX) | 0;
-        let vpW = (lemmings.stage.getGameViewRect().w * this.scaleX) | 0;
+        const viewRect = lemmings.stage.getGameViewRect();
+        const vpX = (viewRect.x * this.scaleX) | 0;
+        let vpW = (viewRect.w * this.scaleX) | 0;
+        const vpY = (viewRect.y * this.scaleY) | 0;
+        const vpH = (viewRect.h * this.scaleY) | 0;
         let vpXW = vpX + vpW;
         // dumb fix to keep right edge of viewport rect visible
         if (vpXW == this.width) {
@@ -234,6 +237,10 @@ class MiniMap {
         const vpRectColor = 0xFFFFFFFF;
         frame.drawRect(vpX, 0, 0, this.height - 1, vpRectColor, false, false);
         frame.drawRect(vpX + vpW, 0, 0, this.height - 1, vpRectColor, false, false);
+        if (vpH < this.height) {
+            frame.drawRect(vpX, vpY, vpW, 0, vpRectColor, false, false);
+            frame.drawRect(vpX, vpY + vpH, vpW, 0, vpRectColor, false, false);
+        }
 
         /* Entrances / Exits */
         for (const obj of this.level.objects) {

--- a/js/SkillPanelSprites.js
+++ b/js/SkillPanelSprites.js
@@ -57,6 +57,56 @@ class SkillPanelSprites {
         getNumberSpriteEmpty() {
             return this.emptyNumberSprite;
         }
+
+        /** extract a rectangular patch from the panel background */
+        getBackgroundPatch(x, y, w, h) {
+            const src = this.panelSprite;
+            const out = new Lemmings.Frame(w, h);
+            for (let yy = 0; yy < h; yy++) {
+                const srcRow = (y + yy) * src.width + x;
+                const dstRow = yy * w;
+                for (let xx = 0; xx < w; xx++) {
+                    out.data[dstRow + xx] = src.data[srcRow + xx];
+                    out.mask[dstRow + xx] = 1;
+                }
+            }
+            return out;
+        }
+
+        /** tile a patch across a larger area */
+        createTiledBackground(x, y, w, h, outW, outH) {
+            const patch = this.getBackgroundPatch(x, y, w, h);
+            const out = new Lemmings.Frame(outW, outH);
+            for (let yy = 0; yy < outH; yy++) {
+                for (let xx = 0; xx < outW; xx++) {
+                    const px = xx % w;
+                    const py = yy % h;
+                    const srcIdx = py * w + px;
+                    const dstIdx = yy * outW + xx;
+                    out.data[dstIdx] = patch.data[srcIdx];
+                    out.mask[dstIdx] = 1;
+                }
+            }
+            return out;
+        }
+
+        /** return a brightened copy of the specified button region */
+        getHighlightedButton(panelIndex) {
+            const x = panelIndex * 16;
+            const y = 16;
+            const w = 16;
+            const h = 23;
+            const patch = this.getBackgroundPatch(x, y, w, h);
+            for (let i = 0; i < patch.data.length; i++) {
+                let c = patch.data[i];
+                let r = Math.min(255, (c       & 0xFF) + 40);
+                let g = Math.min(255, ((c>>8)  & 0xFF) + 40);
+                let b = Math.min(255, ((c>>16) & 0xFF) + 40);
+                patch.data[i] = 0xFF000000 | (b<<16) | (g<<8) | r;
+                patch.mask[i] = 1;
+            }
+            return patch;
+        }
     }
     Lemmings.SkillPanelSprites = SkillPanelSprites;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,11 @@
       "name": "lemmings-js",
       "version": "1.0.0",
       "devDependencies": {
+        "adm-zip": "^0.5.10",
         "chai": "^4.3.7",
         "http-server": "^14.0.1",
-        "mocha": "^11.5.0"
+        "mocha": "^11.5.0",
+        "pngjs": "^7.0.0"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -40,6 +42,16 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/ansi-regex": {
@@ -1029,6 +1041,16 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.19.0"
+      }
     },
     "node_modules/portfinder": {
       "version": "1.0.28",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,12 @@
   },
   "scripts": {
     "start": "http-server --cors=*",
-    "test": "mocha"
+    "test": "mocha",
+    "export-panel-sprite": "node tools/exportPanelSprite.js",
+    "export-lemmings-sprites": "node tools/exportLemmingsSprites.js",
+    "export-ground-images": "node tools/exportGroundImages.js",
+    "export-all-sprites": "node tools/exportAllSprites.js",
+    "export-all-packs": "node tools/exportAllPacks.js"
   },
   "repository": {
     "type": "git",
@@ -20,8 +25,10 @@
   "homepage": "https://github.com/oklemenz/LemmingsJS#readme",
   "type": "module",
   "devDependencies": {
+    "chai": "^4.3.7",
     "http-server": "^14.0.1",
     "mocha": "^11.5.0",
-    "chai": "^4.3.7"
+    "pngjs": "^7.0.0",
+    "adm-zip": "^0.5.10"
   }
 }

--- a/tools/NodeFileProvider.js
+++ b/tools/NodeFileProvider.js
@@ -1,0 +1,63 @@
+import { Lemmings } from '../js/LemmingsNamespace.js';
+import fs from 'fs';
+import path from 'path';
+import AdmZip from 'adm-zip';
+
+class NodeFileProvider {
+    constructor(rootPath = '.') {
+        this.rootPath = rootPath;
+        this.zipCache = new Map();
+    }
+
+    _getZip(zipPath) {
+        const abs = path.resolve(this.rootPath, zipPath);
+        let zip = this.zipCache.get(abs);
+        if (!zip) {
+            zip = new AdmZip(abs);
+            this.zipCache.set(abs, zip);
+        }
+        return zip;
+    }
+
+    _findZipEntry(zip, entryName) {
+        const lower = entryName.replace(/\\/g, '/').toLowerCase();
+        let entry = zip.getEntry(entryName) || zip.getEntry(lower);
+        if (!entry) {
+            entry = zip.getEntries().find(e => {
+                const eName = e.entryName.toLowerCase();
+                return eName === lower || eName.endsWith('/' + lower);
+            });
+        }
+        return entry;
+    }
+
+    loadBinary(dir, filename) {
+        if (/\.zip$/i.test(dir)) {
+            const zip = this._getZip(dir);
+            const entry = this._findZipEntry(zip, filename);
+            if (!entry) throw new Error(`File ${filename} not found in ${dir}`);
+            const data = entry.getData();
+            const arr = new Uint8Array(data);
+            return Promise.resolve(new Lemmings.BinaryReader(arr, 0, arr.length, filename, dir));
+        }
+        const fullPath = path.join(this.rootPath, dir, filename);
+        const data = fs.readFileSync(fullPath);
+        const arr = new Uint8Array(data);
+        return Promise.resolve(new Lemmings.BinaryReader(arr, 0, arr.length, filename, dir));
+    }
+
+    loadString(file) {
+        const m = file.match(/^(.*\.zip)\/(.+)$/i);
+        if (m) {
+            const zip = this._getZip(m[1]);
+            const entry = this._findZipEntry(zip, m[2]);
+            if (!entry) throw new Error(`File ${m[2]} not found in ${m[1]}`);
+            return Promise.resolve(entry.getData().toString('utf8'));
+        }
+        const fullPath = path.join(this.rootPath, file);
+        const txt = fs.readFileSync(fullPath, 'utf8');
+        return Promise.resolve(txt);
+    }
+}
+
+export { NodeFileProvider };

--- a/tools/exportAllPacks.js
+++ b/tools/exportAllPacks.js
@@ -1,18 +1,31 @@
 import { spawnSync } from 'child_process';
 import fs from 'fs';
+import path from 'path';
 
-const packs = process.argv.length > 2 ? process.argv.slice(2) : [
-    'lemmings',
-    'lemmings_ohNo',
-    'holiday93',
-    'holiday94',
-    'xmas91',
-    'xmas92'
-];
+function loadConfig() {
+    try {
+        const cfgPath = path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'config.json');
+        const txt = fs.readFileSync(cfgPath, 'utf8');
+        return JSON.parse(txt);
+    } catch {
+        return [];
+    }
+}
+
+const defaultPacks = loadConfig().map(p => ({ name: p.name, path: p.path }));
+
+let packs;
+if (process.argv.length > 2) {
+    packs = process.argv.slice(2).map(p => ({ name: p, path: p }));
+} else if (defaultPacks.length) {
+    packs = defaultPacks;
+} else {
+    packs = [{ name: 'lemmings', path: 'lemmings' }];
+}
 
 for (const pack of packs) {
-    const outDir = `export_${pack.replace(/\W+/g, '_')}`;
+    const outDir = `export_${pack.name.replace(/\W+/g, '_')}`;
     fs.mkdirSync(outDir, { recursive: true });
-    console.log(`Exporting ${pack} -> ${outDir}`);
-    spawnSync('node', ['tools/exportAllSprites.js', pack, outDir], { stdio: 'inherit' });
+    console.log(`Exporting ${pack.path} -> ${outDir}`);
+    spawnSync('node', ['tools/exportAllSprites.js', pack.path, outDir], { stdio: 'inherit' });
 }

--- a/tools/exportAllPacks.js
+++ b/tools/exportAllPacks.js
@@ -1,0 +1,18 @@
+import { spawnSync } from 'child_process';
+import fs from 'fs';
+
+const packs = process.argv.length > 2 ? process.argv.slice(2) : [
+    'lemmings',
+    'lemmings_ohNo',
+    'holiday93',
+    'holiday94',
+    'xmas91',
+    'xmas92'
+];
+
+for (const pack of packs) {
+    const outDir = `export_${pack.replace(/\W+/g, '_')}`;
+    fs.mkdirSync(outDir, { recursive: true });
+    console.log(`Exporting ${pack} -> ${outDir}`);
+    spawnSync('node', ['tools/exportAllSprites.js', pack, outDir], { stdio: 'inherit' });
+}

--- a/tools/exportAllSprites.js
+++ b/tools/exportAllSprites.js
@@ -2,7 +2,19 @@ import { Lemmings } from '../js/LemmingsNamespace.js';
 import '../js/LemmingsBootstrap.js';
 import { NodeFileProvider } from './NodeFileProvider.js';
 import fs from 'fs';
+import path from 'path';
 import { PNG } from 'pngjs';
+
+function loadDefaultPack() {
+    try {
+        const cfgPath = path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'config.json');
+        const txt = fs.readFileSync(cfgPath, 'utf8');
+        const cfg = JSON.parse(txt);
+        return cfg[0]?.path || 'lemmings';
+    } catch {
+        return 'lemmings';
+    }
+}
 
 function frameToPNG(frame) {
     const png = new PNG({ width: frame.width, height: frame.height });
@@ -21,8 +33,8 @@ function frameToPNG(frame) {
 }
 
 (async () => {
-    const dataPath = process.argv[2] || 'lemmings';
-    const outDir   = process.argv[3] || `${dataPath.replace(/\W+/g, '_')}_all`; 
+    const dataPath = process.argv[2] || loadDefaultPack();
+    const outDir   = process.argv[3] || `${dataPath.replace(/\W+/g, '_')}_all`;
     fs.mkdirSync(outDir, { recursive: true });
 
     const provider = new NodeFileProvider('.');

--- a/tools/exportAllSprites.js
+++ b/tools/exportAllSprites.js
@@ -1,0 +1,110 @@
+import { Lemmings } from '../js/LemmingsNamespace.js';
+import '../js/LemmingsBootstrap.js';
+import { NodeFileProvider } from './NodeFileProvider.js';
+import fs from 'fs';
+import { PNG } from 'pngjs';
+
+function frameToPNG(frame) {
+    const png = new PNG({ width: frame.width, height: frame.height });
+    for (let y = 0; y < frame.height; y++) {
+        for (let x = 0; x < frame.width; x++) {
+            const idx = y * frame.width + x;
+            const rgba = frame.data[idx];
+            const p = idx * 4;
+            png.data[p    ] = rgba & 0xFF;
+            png.data[p + 1] = (rgba >> 8) & 0xFF;
+            png.data[p + 2] = (rgba >> 16) & 0xFF;
+            png.data[p + 3] = (rgba >> 24) & 0xFF;
+        }
+    }
+    return png;
+}
+
+(async () => {
+    const dataPath = process.argv[2] || 'lemmings';
+    const outDir   = process.argv[3] || `${dataPath.replace(/\W+/g, '_')}_all`; 
+    fs.mkdirSync(outDir, { recursive: true });
+
+    const provider = new NodeFileProvider('.');
+    const res = new Lemmings.GameResources(provider, { path: dataPath, level: { groups: [] }});
+    const pal = new Lemmings.ColorPalette();
+
+    // --- Panel background and letters/numbers ---
+    const panelSprites = await res.getSkillPanelSprite(pal);
+
+    const panel = panelSprites.getPanelSprite();
+    frameToPNG(panel).pack().pipe(fs.createWriteStream(`${outDir}/panel.png`));
+
+    const letters = ['%', '0','1','2','3','4','5','6','7','8','9','-','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z',' '];
+    for (const letter of letters) {
+        const frame = panelSprites.getLetterSprite(letter);
+        const safe = encodeURIComponent(letter === ' ' ? 'space' : letter);
+        frameToPNG(frame).pack().pipe(fs.createWriteStream(`${outDir}/letter_${safe}.png`));
+    }
+
+    for (let i = 0; i < 10; i++) {
+        frameToPNG(panelSprites.getNumberSpriteLeft(i))
+            .pack().pipe(fs.createWriteStream(`${outDir}/num_left_${i}.png`));
+        frameToPNG(panelSprites.getNumberSpriteRight(i))
+            .pack().pipe(fs.createWriteStream(`${outDir}/num_right_${i}.png`));
+    }
+
+    // --- Lemming sprites ---
+    const spriteSet = await res.getLemmingsSprite(pal);
+    for (const [name, id] of Object.entries(Lemmings.SpriteTypes)) {
+        for (const dir of [true, false]) {
+            const anim = spriteSet.getAnimation(id, dir);
+            if (!anim || !anim.frames || anim.frames.length === 0) continue;
+            const dirName = dir ? 'right' : 'left';
+            const sheet = new PNG({ width: anim.frames[0].width * anim.frames.length, height: anim.frames[0].height });
+            for (let i = 0; i < anim.frames.length; i++) {
+                const frame = anim.getFrame(i);
+                const png = frameToPNG(frame);
+                await new Promise(res => png.pack().pipe(fs.createWriteStream(`${outDir}/${name}_${dirName}_${i}.png`)).on('finish', res));
+                for (let y = 0; y < frame.height; y++) {
+                    for (let x = 0; x < frame.width; x++) {
+                        const idx = (y * frame.width + x) * 4;
+                        const dest = ((y * sheet.width) + x + i * frame.width) * 4;
+                        sheet.data[dest    ] = png.data[idx];
+                        sheet.data[dest + 1] = png.data[idx + 1];
+                        sheet.data[dest + 2] = png.data[idx + 2];
+                        sheet.data[dest + 3] = png.data[idx + 3];
+                    }
+                }
+            }
+            await new Promise(res => sheet.pack().pipe(fs.createWriteStream(`${outDir}/${name}_${dirName}_sheet.png`)).on('finish', res));
+        }
+    }
+
+    // --- Map object sprites from ground files ---
+    for (let g = 0; g < 5; g++) {
+        const groundFile = `GROUND${g}O.DAT`;
+        const vgaFile    = `VGAGR${g}.DAT`;
+        let groundBuf, vgaBuf;
+        try {
+            groundBuf = await provider.loadBinary(dataPath, groundFile);
+            vgaBuf    = await provider.loadBinary(dataPath, vgaFile);
+        } catch {
+            continue;
+        }
+        fs.mkdirSync(`${outDir}/ground${g}`, { recursive: true });
+        const vgaContainer = new Lemmings.FileContainer(vgaBuf);
+        const groundReader = new Lemmings.GroundReader(
+            groundBuf,
+            vgaContainer.getPart(0),
+            vgaContainer.getPart(1)
+        );
+        const objects = groundReader.getObjectImages();
+        for (let i = 0; i < objects.length; i++) {
+            const img = objects[i];
+            if (!img) continue;
+            for (let f = 0; f < img.frameCount; f++) {
+                const frameBuf = img.frames[f];
+                const frame = new Lemmings.Frame(img.width, img.height);
+                frame.drawPaletteImage(frameBuf, img.width, img.height, img.palette, 0, 0);
+                const png = frameToPNG(frame);
+                await new Promise(res => png.pack().pipe(fs.createWriteStream(`${outDir}/ground${g}/object_${i}_${f}.png`)).on('finish', res));
+            }
+        }
+    }
+})();

--- a/tools/exportGroundImages.js
+++ b/tools/exportGroundImages.js
@@ -2,7 +2,19 @@ import { Lemmings } from '../js/LemmingsNamespace.js';
 import '../js/LemmingsBootstrap.js';
 import { NodeFileProvider } from './NodeFileProvider.js';
 import fs from 'fs';
+import path from 'path';
 import { PNG } from 'pngjs';
+
+function loadDefaultPack() {
+    try {
+        const cfgPath = path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'config.json');
+        const txt = fs.readFileSync(cfgPath, 'utf8');
+        const cfg = JSON.parse(txt);
+        return cfg[0]?.path || 'lemmings';
+    } catch {
+        return 'lemmings';
+    }
+}
 
 function bufToFrame(buf, width, height, palette) {
     const frame = new Lemmings.Frame(width, height);
@@ -27,7 +39,7 @@ function frameToPNG(frame) {
 }
 
 (async () => {
-    const dataPath = process.argv[2] || 'lemmings';
+    const dataPath = process.argv[2] || loadDefaultPack();
     const index = parseInt(process.argv[3] || '0', 10);
     const outDir = process.argv[4] || `${dataPath.replace(/\W+/g, '_')}_ground_${index}`;
     fs.mkdirSync(outDir, { recursive: true });

--- a/tools/exportGroundImages.js
+++ b/tools/exportGroundImages.js
@@ -1,0 +1,69 @@
+import { Lemmings } from '../js/LemmingsNamespace.js';
+import '../js/LemmingsBootstrap.js';
+import { NodeFileProvider } from './NodeFileProvider.js';
+import fs from 'fs';
+import { PNG } from 'pngjs';
+
+function bufToFrame(buf, width, height, palette) {
+    const frame = new Lemmings.Frame(width, height);
+    frame.drawPaletteImage(buf, width, height, palette, 0, 0);
+    return frame;
+}
+
+function frameToPNG(frame) {
+    const png = new PNG({ width: frame.width, height: frame.height });
+    for (let y = 0; y < frame.height; y++) {
+        for (let x = 0; x < frame.width; x++) {
+            const idx = y * frame.width + x;
+            const rgba = frame.data[idx];
+            const p = (y * frame.width + x) * 4;
+            png.data[p    ] = rgba & 0xFF;
+            png.data[p + 1] = (rgba >> 8) & 0xFF;
+            png.data[p + 2] = (rgba >> 16) & 0xFF;
+            png.data[p + 3] = (rgba >> 24) & 0xFF;
+        }
+    }
+    return png;
+}
+
+(async () => {
+    const dataPath = process.argv[2] || 'lemmings';
+    const index = parseInt(process.argv[3] || '0', 10);
+    const outDir = process.argv[4] || `${dataPath.replace(/\W+/g, '_')}_ground_${index}`;
+    fs.mkdirSync(outDir, { recursive: true });
+
+    const provider = new NodeFileProvider('.');
+    const groundBuf = await provider.loadBinary(dataPath, `GROUND${index}O.DAT`);
+    const vgagrBuf = await provider.loadBinary(dataPath, `VGAGR${index}.DAT`);
+    const vgaContainer = new Lemmings.FileContainer(vgagrBuf);
+    const groundReader = new Lemmings.GroundReader(
+        groundBuf,
+        vgaContainer.getPart(0),
+        vgaContainer.getPart(1)
+    );
+
+    const terrains = groundReader.getTerrainImages();
+    const objects  = groundReader.getObjectImages();
+
+    for (let i = 0; i < terrains.length; i++) {
+        const img = terrains[i];
+        if (!img) continue;
+        for (let f = 0; f < img.frameCount; f++) {
+            const frame = bufToFrame(img.frames[f], img.width, img.height, img.palette);
+            const png = frameToPNG(frame);
+            const file = `${outDir}/terrain_${i}_${f}.png`;
+            await new Promise(res => png.pack().pipe(fs.createWriteStream(file)).on('finish', res));
+        }
+    }
+
+    for (let i = 0; i < objects.length; i++) {
+        const img = objects[i];
+        if (!img) continue;
+        for (let f = 0; f < img.frameCount; f++) {
+            const frame = bufToFrame(img.frames[f], img.width, img.height, img.palette);
+            const png = frameToPNG(frame);
+            const file = `${outDir}/object_${i}_${f}.png`;
+            await new Promise(res => png.pack().pipe(fs.createWriteStream(file)).on('finish', res));
+        }
+    }
+})();

--- a/tools/exportLemmingsSprites.js
+++ b/tools/exportLemmingsSprites.js
@@ -1,0 +1,64 @@
+import { Lemmings } from '../js/LemmingsNamespace.js';
+import '../js/LemmingsBootstrap.js';
+import { NodeFileProvider } from './NodeFileProvider.js';
+import fs from 'fs';
+import { PNG } from 'pngjs';
+
+function frameToPNG(frame) {
+    const png = new PNG({ width: frame.width, height: frame.height });
+    for (let y = 0; y < frame.height; y++) {
+        for (let x = 0; x < frame.width; x++) {
+            const idx = y * frame.width + x;
+            const rgba = frame.data[idx];
+            const p = (y * frame.width + x) * 4;
+            png.data[p    ] = rgba & 0xFF;
+            png.data[p + 1] = (rgba >> 8) & 0xFF;
+            png.data[p + 2] = (rgba >> 16) & 0xFF;
+            png.data[p + 3] = (rgba >> 24) & 0xFF;
+        }
+    }
+    return png;
+}
+
+(async () => {
+    const dataPath = process.argv[2] || 'lemmings';
+    const outDir = process.argv[3] || `${dataPath.replace(/\W+/g, '_')}_sprites`;
+    fs.mkdirSync(outDir, { recursive: true });
+
+    const provider = new NodeFileProvider('.');
+    const res = new Lemmings.GameResources(provider, { path: dataPath, level: { groups: [] }});
+    const pal = new Lemmings.ColorPalette();
+    const spriteSet = await res.getLemmingsSprite(pal);
+
+    for (const [name, id] of Object.entries(Lemmings.SpriteTypes)) {
+        for (const dir of [true, false]) {
+            const anim = spriteSet.getAnimation(id, dir);
+            if (!anim || !anim.frames || anim.frames.length === 0) continue;
+
+            const dirName = dir ? 'right' : 'left';
+            const sheet = new PNG({ width: anim.frames[0].width * anim.frames.length, height: anim.frames[0].height });
+
+            for (let i = 0; i < anim.frames.length; i++) {
+                const frame = anim.getFrame(i);
+                const png = frameToPNG(frame);
+                const file = `${outDir}/${name}_${dirName}_${i}.png`;
+                await new Promise(res => png.pack().pipe(fs.createWriteStream(file)).on('finish', res));
+
+                // blit into sheet
+                for (let y = 0; y < frame.height; y++) {
+                    for (let x = 0; x < frame.width; x++) {
+                        const idx = (y * frame.width + x) * 4;
+                        const dest = ((y * sheet.width) + x + i * frame.width) * 4;
+                        sheet.data[dest    ] = png.data[idx];
+                        sheet.data[dest + 1] = png.data[idx + 1];
+                        sheet.data[dest + 2] = png.data[idx + 2];
+                        sheet.data[dest + 3] = png.data[idx + 3];
+                    }
+                }
+            }
+
+            const sheetFile = `${outDir}/${name}_${dirName}_sheet.png`;
+            await new Promise(res => sheet.pack().pipe(fs.createWriteStream(sheetFile)).on('finish', res));
+        }
+    }
+})();

--- a/tools/exportLemmingsSprites.js
+++ b/tools/exportLemmingsSprites.js
@@ -2,7 +2,19 @@ import { Lemmings } from '../js/LemmingsNamespace.js';
 import '../js/LemmingsBootstrap.js';
 import { NodeFileProvider } from './NodeFileProvider.js';
 import fs from 'fs';
+import path from 'path';
 import { PNG } from 'pngjs';
+
+function loadDefaultPack() {
+    try {
+        const cfgPath = path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'config.json');
+        const txt = fs.readFileSync(cfgPath, 'utf8');
+        const cfg = JSON.parse(txt);
+        return cfg[0]?.path || 'lemmings';
+    } catch {
+        return 'lemmings';
+    }
+}
 
 function frameToPNG(frame) {
     const png = new PNG({ width: frame.width, height: frame.height });
@@ -21,7 +33,7 @@ function frameToPNG(frame) {
 }
 
 (async () => {
-    const dataPath = process.argv[2] || 'lemmings';
+    const dataPath = process.argv[2] || loadDefaultPack();
     const outDir = process.argv[3] || `${dataPath.replace(/\W+/g, '_')}_sprites`;
     fs.mkdirSync(outDir, { recursive: true });
 

--- a/tools/exportPanelSprite.js
+++ b/tools/exportPanelSprite.js
@@ -2,10 +2,22 @@ import { Lemmings } from '../js/LemmingsNamespace.js';
 import '../js/LemmingsBootstrap.js';
 import { NodeFileProvider } from './NodeFileProvider.js';
 import fs from 'fs';
+import path from 'path';
 import { PNG } from 'pngjs';
 
+function loadDefaultPack() {
+    try {
+        const cfgPath = path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'config.json');
+        const txt = fs.readFileSync(cfgPath, 'utf8');
+        const cfg = JSON.parse(txt);
+        return cfg[0]?.path || 'lemmings';
+    } catch {
+        return 'lemmings';
+    }
+}
+
 (async () => {
-    const pack = process.argv[2] || 'lemmings';
+    const pack = process.argv[2] || loadDefaultPack();
     const outDir = process.argv[3] || 'panel_export';
     const provider = new NodeFileProvider('.');
     const res = new Lemmings.GameResources(provider, { path: pack, level: { groups: [] }});

--- a/tools/exportPanelSprite.js
+++ b/tools/exportPanelSprite.js
@@ -1,0 +1,30 @@
+import { Lemmings } from '../js/LemmingsNamespace.js';
+import '../js/LemmingsBootstrap.js';
+import { NodeFileProvider } from './NodeFileProvider.js';
+import fs from 'fs';
+import { PNG } from 'pngjs';
+
+(async () => {
+    const pack = process.argv[2] || 'lemmings';
+    const outDir = process.argv[3] || 'panel_export';
+    const provider = new NodeFileProvider('.');
+    const res = new Lemmings.GameResources(provider, { path: pack, level: { groups: [] }});
+    const pal = new Lemmings.ColorPalette();
+    const sprites = await res.getSkillPanelSprite(pal);
+    const panel = sprites.getPanelSprite();
+    const png = new PNG({ width: panel.width, height: panel.height });
+    for (let y = 0; y < panel.height; y++) {
+        for (let x = 0; x < panel.width; x++) {
+            const idx = y * panel.width + x;
+            const rgba = panel.data[idx];
+            const pidx = idx * 4;
+            png.data[pidx  ] = rgba & 0xFF;
+            png.data[pidx+1] = (rgba >> 8) & 0xFF;
+            png.data[pidx+2] = (rgba >> 16) & 0xFF;
+            png.data[pidx+3] = (rgba >> 24) & 0xFF;
+        }
+    }
+    fs.mkdirSync(outDir, { recursive: true });
+    const outFile = `${outDir}/panelSprite.png`;
+    png.pack().pipe(fs.createWriteStream(outFile));
+})();


### PR DESCRIPTION
## Summary
- add `drawMarchingAntRect` helper in `DisplayImage`
- animate skill selection borders using marching ants
- track animation timing inside `GameGui`
- add zip-aware `NodeFileProvider` and enhance export scripts
- provide new utility to export all packs at once

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684002745fac832d8ec4716479276c9e