### PR TITLE
Fix exportAllPacks steel sprite loading

### DIFF
--- a/tools/exportAllSprites.js
+++ b/tools/exportAllSprites.js
@@ -41,6 +41,9 @@ function frameToPNG(frame) {
     const res = new Lemmings.GameResources(provider, { path: dataPath, level: { groups: [] }});
     const pal = new Lemmings.ColorPalette();
 
+    // Ensure steel sprite metadata is loaded for accurate terrain flags
+    await Lemmings.loadSteelSprites();
+
     // --- Panel background and letters/numbers ---
     const panelSprites = await res.getSkillPanelSprite(pal);
 


### PR DESCRIPTION
## Summary
- load steel sprite metadata before exporting ground sprites

## Testing
- `npm test` *(fails: logs an error when binary load fails)*

------
https://chatgpt.com/codex/tasks/task_e_684044291c64832db48c6c6d7219bf6b