### PR TITLE
Enable infinite skill usage in cheat mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ URL parameters (shortcut in brackets):
 - `difficulty (d)`: Difficulty 1-5 (default: 1)
 - `level (l)`: Level 1-30 (default: 1)
 - `speed (s)`: Control speed 0-100 (default: 1)
-- `cheat (c)`: Enable cheat mode (99 for all actions) (default: false)
+- `cheat (c)`: Enable cheat mode (infinite actions) (default: false)
 - `debug (dbg)`: Enable debug mode until the page is refreshed (default: false)
 - `bench (b)`: Enable bench mode, lemmings never stop spawning (default: false)
 - `endless (e)`: Disables time limit (default: false)

--- a/js/GameSkills.js
+++ b/js/GameSkills.js
@@ -6,6 +6,7 @@ class GameSkills {
             this.onCountChanged = new Lemmings.EventHandler();
             this.onSelectionChanged = new Lemmings.EventHandler();
             this.skills = level.skills;
+            this.cheatMode = false;
             this.selectFirstAvailable();
         }
 
@@ -19,9 +20,11 @@ class GameSkills {
         }
         /** return true if the skill can be reused / used */
         canReuseSkill(type) {
+            if (this.cheatMode) return true;
             return (this.skills[type] > 0);
         }
         reuseSkill(type) {
+            if (this.cheatMode) return true;
             if (this.skills[type] <= 0)
                 return false;
             this.skills[type]--;
@@ -34,7 +37,9 @@ class GameSkills {
         getSkill(type) {
             if (!Lemmings.SkillTypes[Object.keys(Lemmings.SkillTypes)[type]])
                 return 0;
-            return this.skills[type];
+            const val = this.skills[type];
+            if (val === Infinity) return 99;
+            return val;
         }
         getSelectedSkill() {
             return this.selectedSkill;
@@ -52,8 +57,9 @@ class GameSkills {
         }
         /** increase the amount of actions for all skills */
         cheat() {
+            this.cheatMode = true;
             for (let i = 0; i < this.skills.length; i++) {
-                this.skills[i] = 99;
+                this.skills[i] = Infinity;
                 this.onCountChanged.trigger(i);
             }
         }

--- a/js/LogHandler.js
+++ b/js/LogHandler.js
@@ -33,7 +33,7 @@ class Logger {
 
 class BaseLogger {
     constructor(name) {
-        this.log = new Logger(name || this.constructor.name);
+        this.log = new Lemmings.LogHandler(name || this.constructor.name);
     }
 
     /**


### PR DESCRIPTION
## Summary
- keep skill counts infinite when cheat mode is active
- use LogHandler for BaseLogger to fix test logging
- update README cheat mode description

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684046af4538832d94817a0d0571f5f1