### PR TITLE
Add PWA manifest note

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,13 @@ The goal is to create a solid, performant port first. Then build out the sequenc
 - After `npm install`, run `npm test` to execute the Mocha test suite.
 - Mocha is installed automatically as part of the project's `devDependencies`.
 
+## Progressive Web App
+
+This repo ships with [site.webmanifest](site.webmanifest) so it can be installed
+as a **Progressive Web App (PWA)**. Installing adds the game to your device's
+app list and launches it fullscreen in landscape mode. Touch input still needs
+polish, so the mobile experience may be rough.
+
 ## Options
 
 URL parameters (shortcut in brackets):

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lemmings-js-midi",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lemmings-js-midi",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "devDependencies": {
         "adm-zip": "^0.5.10",
         "chai": "^4.3.7",


### PR DESCRIPTION
## Summary
- move manifest mention lower in README
- explain Progressive Web App support and link to `site.webmanifest`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68405a7a6884832da923e012faf7dd5a