### PR TITLE
Fix BaseLogger handler selection

### DIFF
--- a/js/LogHandler.js
+++ b/js/LogHandler.js
@@ -33,7 +33,7 @@ class Logger {
 
 class BaseLogger {
     constructor(name) {
-        const Handler = Lemmings.LogHandler || Logger;
+        const Handler = Lemmings.LogHandler || Lemmings.Logger;
         this.log = new Handler(name || this.constructor.name);
     }
 


### PR DESCRIPTION
## Summary
- use `Lemmings.LogHandler` or `Lemmings.Logger` when constructing `BaseLogger`
- keep unit tests using a mock `LogHandler`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684060a1dfe4832d993dbbe10362cc1d