### PR TITLE
Fix movement reversal at wall edges

### DIFF
--- a/js/ActionJumpSystem.js
+++ b/js/ActionJumpSystem.js
@@ -16,7 +16,15 @@ class ActionJumpSystem extends ActionBaseSystem {
 
     process(level, lem) {
         lem.frameIndex++;
-        lem.x += (lem.lookRight ? 1 : -1);
+        const step = lem.lookRight ? 1 : -1;
+        lem.x += step;
+
+        if (level.hasGroundAt(lem.x, lem.y)) {
+            lem.x -= step;
+            lem.lookRight = !lem.lookRight;
+            lem.state = 0;
+            return Lemmings.LemmingStateType.WALKING;
+        }
 
         if (lem.state == null) {
             lem.state = 0; // how far we've jumped so far

--- a/js/ActionWalkSystem.js
+++ b/js/ActionWalkSystem.js
@@ -27,7 +27,8 @@ class ActionWalkSystem extends ActionBaseSystem {
         }
         process(level, lem) {
             lem.frameIndex++;
-            lem.x += (lem.lookRight ? 1 : -1);
+            const step = lem.lookRight ? 1 : -1;
+            lem.x += step;
 
             const groundMask = level.getGroundMaskLayer();
             const upDelta = this.getGroundStepHeight(groundMask, lem.x, lem.y);
@@ -36,6 +37,7 @@ class ActionWalkSystem extends ActionBaseSystem {
                 if (lem.canClimb) {
                     return Lemmings.LemmingStateType.CLIMBING;
                 } else {
+                    lem.x -= step;
                     lem.lookRight = !lem.lookRight;
                     return Lemmings.LemmingStateType.NO_STATE_TYPE;
                 }


### PR DESCRIPTION
## Summary
- prevent lemmings from walking into walls and flipping endlessly
- handle jump collision with walls similarly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840662584bc832db6cc70fe07c6ad18