### PR TITLE
Adjust pan accel and clamp

### DIFF
--- a/js/KeyboardShortcuts.js
+++ b/js/KeyboardShortcuts.js
@@ -35,15 +35,16 @@ class KeyboardShortcuts {
             const img = stage.gameImgProps;
             const vp = img.viewPoint;
             const scale = vp.scale;
-            // hold shift to pan much further per frame
-            const shiftMul = this.mod.shift ? 2.5 : 1;
+            // hold shift to pan slightly further per frame
+            const shiftMul = this.mod.shift ? 1.5 : 1;
 
             // ----- panning -----
             // tweak distance per frame; previous values felt too large
             const baseX = 25 * scale;
             const baseY = 12 * scale;
             // slow the acceleration a touch for smoother motion
-            const accel = 0.05 / scale * dt;
+            const accelBase = 0.04;
+            const accel = accelBase / scale * dt;
             const targetVX = (this.pan.right - this.pan.left) * baseX * shiftMul;
             const targetVY = (this.pan.down - this.pan.up)   * baseY * shiftMul;
             this.pan.vx += (targetVX - this.pan.vx) * accel;

--- a/js/Stage.js
+++ b/js/Stage.js
@@ -134,17 +134,11 @@ class Stage {
                 this.draw(stageImage, gameImg);
             }
 
-            const xCeiling = Math.max(0, stageImage.viewPoint.x);
-            const xFloorLimit = stageImage.display.getWidth() - stageImage.width / stageImage.viewPoint.scale;
-            const xFloor = Math.min(xCeiling, xFloorLimit);
+            const xMax = Math.max(0, stageImage.display.getWidth() - stageImage.width / stageImage.viewPoint.scale);
+            stageImage.viewPoint.x = Math.min(Math.max(0, stageImage.viewPoint.x), xMax);
 
-            stageImage.viewPoint.x = xFloor;
-
-            const yCeiling = Math.max(0, stageImage.viewPoint.y);
-            const yFloorLimit = stageImage.display.getHeight() - stageImage.height / stageImage.viewPoint.scale;
-            const yFloor = Math.min(yCeiling, yFloorLimit);
-
-            stageImage.viewPoint.y = yFloor;
+            const yMax = Math.max(0, stageImage.display.getHeight() - stageImage.height / stageImage.viewPoint.scale);
+            stageImage.viewPoint.y = Math.min(Math.max(0, stageImage.viewPoint.y), yMax);
 
             // stageImage.viewPoint.x = this.limitValue(0, stageImage.viewPoint.x, stageImage.display.getWidth() - stageImage.width / stageImage.viewPoint.scale);
             // stageImage.viewPoint.y = this.limitValue(0, stageImage.display.getHeight() - stageImage.height / stageImage.viewPoint.scale, stageImage.viewPoint.y);


### PR DESCRIPTION
## Summary
- tone down shift panning in `KeyboardShortcuts`
- track acceleration base separately
- clamp stage viewports correctly

## Testing
- `npm test` *(fails: FileProvider logs error test)*

------
https://chatgpt.com/codex/tasks/task_e_684067adaadc832db50c65c9256ea98e