### PR TITLE
Fix group length boundary check

### DIFF
--- a/js/LevelConfig.js
+++ b/js/LevelConfig.js
@@ -16,7 +16,7 @@ class LevelConfig {
             this.order = [];
         }
         getGroupLength(groupIndex) {
-            if ((groupIndex < 0) || (groupIndex > this.order.length)) {
+            if ((groupIndex < 0) || (groupIndex >= this.order.length)) {
                 return 0;
             }
             return this.order[groupIndex].length;


### PR DESCRIPTION
## Summary
- ensure getGroupLength() handles out-of-bounds index correctly

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68407246edb8832d9f6df70dc6c6c60f