### PR TITLE
Improve level group shortcuts

### DIFF
--- a/js/GameView.js
+++ b/js/GameView.js
@@ -319,6 +319,11 @@ async moveToLevel(moveInterval = 0) {
     }
     /** switch the selected level group */
     async selectLevelGroup(newLevelGroupIndex) {
+        if (!this.gameResources) return;
+        const groups = this.gameResources.getLevelGroups();
+        const max = groups.length - 1;
+        if (newLevelGroupIndex < 0) newLevelGroupIndex = 0;
+        else if (newLevelGroupIndex > max) newLevelGroupIndex = max;
         this.levelGroupIndex = newLevelGroupIndex;
         this.levelIndex = 0;
         await this.populateLevelSelect();

--- a/js/KeyboardShortcuts.js
+++ b/js/KeyboardShortcuts.js
@@ -259,14 +259,23 @@ class KeyboardShortcuts {
                 break;
             case 'Comma':
                 if (e.shiftKey) {
-                    if (this.view.levelGroupIndex > 0) this.view.selectLevelGroup(this.view.levelGroupIndex - 1);
+                    if (this.view.levelGroupIndex > 0) {
+                        this.view.selectLevelGroup(this.view.levelGroupIndex - 1);
+                    } else if (this.view.gameType > 1) {
+                        this.view.selectGameType(this.view.gameType - 1);
+                    }
                 } else {
                     this.view.moveToLevel(-1);
                 }
                 break;
             case 'Period':
                 if (e.shiftKey) {
-                    this.view.selectLevelGroup(this.view.levelGroupIndex + 1);
+                    const totalGroups = this.view.gameResources?.getLevelGroups().length || 0;
+                    if (this.view.levelGroupIndex + 1 < totalGroups) {
+                        this.view.selectLevelGroup(this.view.levelGroupIndex + 1);
+                    } else {
+                        this.view.selectGameType(this.view.gameType + 1);
+                    }
                 } else {
                     this.view.moveToLevel(1);
                 }


### PR DESCRIPTION
## Summary
- handle group overflow/underflow when using `Shift+.` or `Shift+,`
- clamp level group indices for safety

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6840723c82ec832d972de0937f153afd