### PR TITLE
Fix mocha setup and modernize tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "start": "http-server --cors=*",
-    "test": "mocha",
+    "test": "node -r ./js/LogHandler.js ./node_modules/mocha/bin/mocha",
     "export-panel-sprite": "node tools/exportPanelSprite.js",
     "export-lemmings-sprites": "node tools/exportLemmingsSprites.js",
     "export-ground-images": "node tools/exportGroundImages.js",

--- a/test/filecontainer.test.js
+++ b/test/filecontainer.test.js
@@ -56,7 +56,12 @@ function runTest(bad) {
   }
 }
 
-runTest(false);
-runTest(true);
+describe('FileContainer', function () {
+  it('unpacks a valid part', function () {
+    runTest(false);
+  });
 
-console.log('All tests passed.');
+  it('detects invalid checksum', function () {
+    runTest(true);
+  });
+});

--- a/test/levelwriter.test.js
+++ b/test/levelwriter.test.js
@@ -1,6 +1,15 @@
 import { expect } from 'chai';
 import { readFileSync } from 'fs';
-import '../js/LemmingsBootstrap.js';
+import { Lemmings } from '../js/LemmingsNamespace.js';
+import '../js/LogHandler.js';
+import '../js/SkillTypes.js';
+import '../js/LevelProperties.js';
+import '../js/DrawProperties.js';
+import '../js/LevelElement.js';
+import '../js/Range.js';
+import '../js/BitReader.js';
+import '../js/BitWriter.js';
+import '../js/UnpackFilePart.js';
 import { BinaryReader } from '../js/BinaryReader.js';
 import { FileContainer } from '../js/FileContainer.js';
 import { LevelReader } from '../js/LevelReader.js';


### PR DESCRIPTION
## Summary
- preload `LogHandler.js` during tests
- convert filecontainer test to use mocha hooks
- avoid loading the full bootstrap in levelwriter test

## Testing
- `npm test` *(fails: PackFilePart compress/unpack tests)*

------
https://chatgpt.com/codex/tasks/task_e_6840770944a8832d83076b7366f04df7