### PR TITLE
Inline LogHandler imports

### DIFF
--- a/js/BinaryReader.js
+++ b/js/BinaryReader.js
@@ -1,4 +1,5 @@
 import { Lemmings } from './LemmingsNamespace.js';
+import './LogHandler.js';
 
 /**
  * Reads binary data with flexible offset, length, and endian options.

--- a/js/BitReader.js
+++ b/js/BitReader.js
@@ -1,4 +1,5 @@
 import { Lemmings } from './LemmingsNamespace.js';
+import './LogHandler.js';
 
 /**
  * Optimized bitwise reader for Lemmings decompression.

--- a/js/BitWriter.js
+++ b/js/BitWriter.js
@@ -1,4 +1,5 @@
 import { Lemmings } from './LemmingsNamespace.js';
+import './LogHandler.js';
 
 /**
  * Efficient backwards-writing buffer for Lemmings decompression (LZ-style).

--- a/js/CommandManager.js
+++ b/js/CommandManager.js
@@ -1,4 +1,5 @@
 import { Lemmings } from './LemmingsNamespace.js';
+import './LogHandler.js';
 
 class CommandManager extends Lemmings.BaseLogger {
     constructor(game, gameTimer) {

--- a/js/CommandSelectSkill.js
+++ b/js/CommandSelectSkill.js
@@ -1,4 +1,5 @@
 import { Lemmings } from './LemmingsNamespace.js';
+import './LogHandler.js';
 
 class CommandSelectSkill extends Lemmings.BaseLogger {
     constructor(skill) {

--- a/js/ConfigReader.js
+++ b/js/ConfigReader.js
@@ -1,4 +1,5 @@
 import { Lemmings } from './LemmingsNamespace.js';
+import './LogHandler.js';
 
 class ConfigReader extends Lemmings.BaseLogger {
         constructor(configFile) {

--- a/js/DisplayImage.js
+++ b/js/DisplayImage.js
@@ -1,4 +1,5 @@
 /* -------------------- DisplayImage.js -------------------- */
+import './LogHandler.js';
 import { Lemmings } from './LemmingsNamespace.js';
 
 // a simple but high quality 53-bit hash

--- a/js/FileContainer.js
+++ b/js/FileContainer.js
@@ -1,4 +1,5 @@
 import { Lemmings } from './LemmingsNamespace.js';
+import './LogHandler.js';
 
 /**
  * Represents a file composed of compressed segments/parts (Lemmings resource).

--- a/js/FileProvider.js
+++ b/js/FileProvider.js
@@ -1,4 +1,5 @@
 import { Lemmings } from './LemmingsNamespace.js';
+import './LogHandler.js';
 
 /**
  * FileProvider with transparent in‑memory caching.

--- a/js/Game.js
+++ b/js/Game.js
@@ -1,4 +1,5 @@
 import { Lemmings } from './LemmingsNamespace.js';
+import './LogHandler.js';
 
 class Game extends Lemmings.BaseLogger {
   constructor (gameResources) {

--- a/js/GameView.js
+++ b/js/GameView.js
@@ -1,4 +1,5 @@
 import { Lemmings } from './LemmingsNamespace.js';
+import './LogHandler.js';
 import './KeyboardShortcuts.js';
 
 class GameView extends Lemmings.BaseLogger {

--- a/js/GroundReader.js
+++ b/js/GroundReader.js
@@ -1,4 +1,5 @@
 import { Lemmings } from './LemmingsNamespace.js';
+import './LogHandler.js';
 let steelSprites = null;
 
 async function loadSteelSprites() {

--- a/js/Lemming.js
+++ b/js/Lemming.js
@@ -1,4 +1,5 @@
 import { Lemmings } from './LemmingsNamespace.js';
+import './LogHandler.js';
 
 class Lemming extends Lemmings.BaseLogger {
     constructor(x = 0, y = 0, id) {

--- a/js/LemmingManager.js
+++ b/js/LemmingManager.js
@@ -1,4 +1,5 @@
 import { Lemmings } from './LemmingsNamespace.js';
+import './LogHandler.js';
 
 class LemmingManager extends Lemmings.BaseLogger {
     #mmTickCounter = 0;

--- a/js/Level.js
+++ b/js/Level.js
@@ -1,4 +1,5 @@
 import { Lemmings } from './LemmingsNamespace.js';
+import './LogHandler.js';
 import './ColorPalette.js';
 // Palette remapping for the fire shooter trap.
 const FIRE_INDICES = Object.freeze([3, 4, 5, 6, 10, 11, 12, 13, 14]);

--- a/js/LevelReader.js
+++ b/js/LevelReader.js
@@ -1,4 +1,5 @@
 import { Lemmings } from './LemmingsNamespace.js';
+import './LogHandler.js';
 
 class LevelReader extends Lemmings.BaseLogger {
     /// Load a Level

--- a/js/LevelWriter.js
+++ b/js/LevelWriter.js
@@ -1,4 +1,5 @@
 import { Lemmings } from './LemmingsNamespace.js';
+import './LogHandler.js';
 
 class LevelWriter extends Lemmings.BaseLogger {
     /**

--- a/js/OddTableReader.js
+++ b/js/OddTableReader.js
@@ -1,4 +1,5 @@
 import { Lemmings } from './LemmingsNamespace.js';
+import './LogHandler.js';
 
 class OddTableReader extends Lemmings.BaseLogger {
         constructor(oddfile) {

--- a/js/SolidLayer.js
+++ b/js/SolidLayer.js
@@ -1,4 +1,5 @@
 import { Lemmings } from './LemmingsNamespace.js';
+import './LogHandler.js';
 
 class SolidLayer extends Lemmings.BaseLogger {
     /**

--- a/js/UnpackFilePart.js
+++ b/js/UnpackFilePart.js
@@ -1,4 +1,5 @@
 import { Lemmings } from './LemmingsNamespace.js';
+import './LogHandler.js';
 
 /**
  * Represents a single compressed file part/chunk in a Lemmings resource.

--- a/js/VGASpecReader.js
+++ b/js/VGASpecReader.js
@@ -1,4 +1,5 @@
 import { Lemmings } from './LemmingsNamespace.js';
+import './LogHandler.js';
 
 /**
  * Decodes a VGASPEC-format ground file, including color palette and image buffer.

--- a/test/bitreader.test.js
+++ b/test/bitreader.test.js
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 import { Lemmings } from '../js/LemmingsNamespace.js';
-import '../js/LogHandler.js';
 import { BinaryReader } from '../js/BinaryReader.js';
 import { BitReader } from '../js/BitReader.js';
 

--- a/test/bitstream.test.js
+++ b/test/bitstream.test.js
@@ -1,6 +1,5 @@
 import assert from 'assert';
 import { Lemmings } from '../js/LemmingsNamespace.js';
-import '../js/LogHandler.js';
 import { BinaryReader } from '../js/BinaryReader.js';
 import { BitReader } from '../js/BitReader.js';
 import { BitWriter } from '../js/BitWriter.js';

--- a/test/bitwriter.test.js
+++ b/test/bitwriter.test.js
@@ -2,9 +2,7 @@ import assert from 'assert';
 import { Lemmings } from '../js/LemmingsNamespace.js';
 import { BitWriter } from '../js/BitWriter.js';
 import { BinaryReader } from '../js/BinaryReader.js';
-import '../js/LogHandler.js';
-
-// minimal global used by LogHandler
+// minimal global environment for logging
 globalThis.lemmings = { game: { showDebug: false } };
 
 class StubReader {

--- a/test/filecontainer.test.js
+++ b/test/filecontainer.test.js
@@ -4,7 +4,6 @@ import assert from 'assert';
 global.lemmings = { game: { showDebug: false } };
 
 import { Lemmings } from '../js/LemmingsNamespace.js';
-import '../js/LogHandler.js';
 import '../js/BinaryReader.js';
 import '../js/BitReader.js';
 import '../js/BitWriter.js';

--- a/test/levelwriter.test.js
+++ b/test/levelwriter.test.js
@@ -1,10 +1,17 @@
 import { expect } from 'chai';
 import { readFileSync } from 'fs';
-import '../js/LemmingsBootstrap.js';
 import { BinaryReader } from '../js/BinaryReader.js';
+import { BitReader } from '../js/BitReader.js';
+import { BitWriter } from '../js/BitWriter.js';
+import { UnpackFilePart } from '../js/UnpackFilePart.js';
 import { FileContainer } from '../js/FileContainer.js';
 import { LevelReader } from '../js/LevelReader.js';
 import { LevelWriter } from '../js/LevelWriter.js';
+import '../js/LevelProperties.js';
+import '../js/LevelElement.js';
+import '../js/DrawProperties.js';
+import '../js/Range.js';
+import '../js/SkillTypes.js';
 
 globalThis.lemmings = { game: { showDebug: false } };
 

--- a/test/packfilepart.test.js
+++ b/test/packfilepart.test.js
@@ -2,7 +2,6 @@ import { expect } from 'chai';
 import { readFileSync } from 'fs';
 
 import { Lemmings } from '../js/LemmingsNamespace.js';
-import '../js/LogHandler.js';
 import { BinaryReader } from '../js/BinaryReader.js';
 import { BitReader } from '../js/BitReader.js';
 import { BitWriter } from '../js/BitWriter.js';


### PR DESCRIPTION
## Summary
- load LogHandler from within BinaryReader, BitReader, BitWriter and UnpackFilePart
- load LogHandler from all other modules that extend `Lemmings.BaseLogger`
- remove explicit LogHandler preloads from unit tests
- update LevelWriter test to import only needed modules

## Testing
- `npx mocha` *(fails: PackFilePart tests)*

------
https://chatgpt.com/codex/tasks/task_e_6840770e85dc832d85a88e74e8572236