### PR TITLE
Add strToNum helper

### DIFF
--- a/js/GameView.js
+++ b/js/GameView.js
@@ -209,6 +209,12 @@ async moveToLevel(moveInterval = 0) {
         return def;
     }
 
+    /** convert a string value to an integer, return 0 for NaN */
+    strToNum(value) {
+        const num = parseInt(value, 10);
+        return isNaN(num) ? 0 : num;
+    }
+
     /** read parameters from the current URL */
     applyQuery() {
         this.gameType = 1;


### PR DESCRIPTION
## Summary
- add `strToNum` conversion helper near parsing utilities

## Testing
- `npm test` *(fails: SyntaxError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_6840823303ac832d8f6b4f79d1053b27