### PR TITLE
Fix syntax errors in Level and Animation modules

### DIFF
--- a/js/Animation.js
+++ b/js/Animation.js
@@ -23,30 +23,6 @@ const ICE_COLORS = Object.freeze([
   Lemmings.ColorPalette.colorFromRGB(2, 32, 120),
   Lemmings.ColorPalette.colorFromRGB(0, 16, 104)
 ]);
-import './ColorPalette.js';
-
-// Palette indices for the fire shooter trap that will be remapped when
-// creating an ice version of the animation.  They cover the full gradient
-// from the bright yellow core through orange to the darkest reds.
-// Indices 2 and 3 are now included so the entire flame gets swapped.
-const FIRE_INDICES = Object.freeze([2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
-
-// Destination colours lifted from the object palette of the ONML ice
-// set.  These values replace the warm tones of the fire trap with
-// cooler shades to give the impression of an "ice" trap.
-const ICE_COLORS = Object.freeze([
-  Lemmings.ColorPalette.colorFromRGB(64, 160, 255),  // brightest blue core
-  Lemmings.ColorPalette.colorFromRGB(56, 152, 240),
-  Lemmings.ColorPalette.colorFromRGB(48, 144, 232),
-  Lemmings.ColorPalette.colorFromRGB(40, 128, 216),
-  Lemmings.ColorPalette.colorFromRGB(32, 112, 200),
-  Lemmings.ColorPalette.colorFromRGB(24, 96, 184),
-  Lemmings.ColorPalette.colorFromRGB(16, 80, 168),
-  Lemmings.ColorPalette.colorFromRGB(8, 64, 152),
-  Lemmings.ColorPalette.colorFromRGB(4, 48, 136),
-  Lemmings.ColorPalette.colorFromRGB(2, 32, 120),
-  Lemmings.ColorPalette.colorFromRGB(0, 16, 104)
-]);
 
 class Animation {
   constructor (_compat = null, loop = true) {
@@ -65,42 +41,7 @@ class Animation {
     });
   }
 
-
-  /**
-   * Load animation frames while applying a simple palette swap.
-   *
-   * A few colour indices are replaced with different ones from the
-   * supplied palette before the frames are generated.  The indices are
-   * defined by the const arrays FIRE_INDICES and ICE_INDICES below.
-   *
-   * @param {Lemmings.BinaryReader} fr - Frame data source
-   * @param {number} bitsPerPixel     - Bits per pixel of the source data
-   * @param {number} width            - Frame width
-   * @param {number} height           - Frame height
-   * @param {number} frames           - Number of frames to read
-   * @param {any}    palette          - Base colour palette
-   * @param {number} [offsetX=null]   - Optional X offset
-   * @param {number} [offsetY=null]   - Optional Y offset
-   */
-  loadFromFileWithPaletteSwap (fr, bitsPerPixel, width, height, frames, palette,
-                               offsetX = null, offsetY = null) {
-    const newPal = new Lemmings.ColorPalette();
-    // Copy existing palette colours
-    for (let i = 0; i < 16; i++) {
-      newPal.setColorInt(i, palette.getColor(i));
-    }
-
-    // Replace selected indices with icy colours pulled from the ONML
-    // object palette.  The ICE_COLORS array mirrors FIRE_INDICES by
-    // position rather than by colour index.
-    for (let i = 0; i < FIRE_INDICES.length; i++) {
-      newPal.setColorInt(FIRE_INDICES[i], ICE_COLORS[i]);
-    }
-
-    this.loadFromFile(fr, bitsPerPixel, width, height, frames,
-                      newPal, offsetX, offsetY);
-  }
-export { Animation };
+  /** Resets playback so the next call to getFrame() starts over. */
   restart (startTick = 0) {
     this.firstFrameIndex = startTick;
     this.isFinished      = false;

--- a/js/Level.js
+++ b/js/Level.js
@@ -1,42 +1,8 @@
 import { Lemmings } from './LemmingsNamespace.js';
 import './ColorPalette.js';
-// Palette remapping for the fire shooter trap.
+
+// Palette remapping for the fire shooter trap. 
 const FIRE_INDICES = Object.freeze([3, 4, 5, 6, 10, 11, 12, 13, 14]);
-const ICE_COLORS   = Object.freeze([
-  Lemmings.ColorPalette.colorFromRGB(92, 224, 255),
-  Lemmings.ColorPalette.colorFromRGB(96, 255, 255),
-  Lemmings.ColorPalette.colorFromRGB(72, 192, 255),
-  Lemmings.ColorPalette.colorFromRGB(64, 160, 255),
-  Lemmings.ColorPalette.colorFromRGB(4, 48, 136),
-  Lemmings.ColorPalette.colorFromRGB(0, 64, 152),
-  Lemmings.ColorPalette.colorFromRGB(2, 32, 120),
-  Lemmings.ColorPalette.colorFromRGB(0, 64, 152),
-  Lemmings.ColorPalette.colorFromRGB(64, 160, 255)
-]);
-
-    /** @type {Lemmings.Frame|null} prebuilt debug overlay */
-    this._debugFrame = null;
-    const arrowRects = [];
-
-      // // Ice palette swap for fire shooter traps
-      // if (ob.id === 8 || ob.id === 10) {
-      //   const pal = new Lemmings.ColorPalette();
-      //   for (let i = 0; i < 16; ++i) {
-      //     pal.setColorInt(i, info.palette.getColor(i));
-      //   }
-      //   for (let i = 0; i < FIRE_INDICES.length; ++i) {
-      //     pal.setColorInt(FIRE_INDICES[i], ICE_COLORS[i]);
-      //   }
-
-      //   const clone = new Lemmings.ObjectImageInfo();
-      //   Object.assign(clone, info);
-      //   clone.palette = pal;
-      //   info = clone;
-      // }
-
-        const trigger = new Lemmings.Trigger(tfxID, x1, y1, x2, y2, repeatDelay, info.trap_sound_effect_id, mapOb);
-          const newRange = new Lemmings.Range();
-    this._debugFrame = null; // invalidate cached debug overlay
 const ICE_COLORS   = Object.freeze([
   Lemmings.ColorPalette.colorFromRGB(92, 224, 255),
   Lemmings.ColorPalette.colorFromRGB(96, 255, 255),
@@ -156,27 +122,15 @@ class Level extends Lemmings.BaseLogger {
       })();
   }
 
-    this._debugFrame = null; // invalidate cached debug overlay
-    const newSteelRanges = [];
-        const newRange = new Lemmings.Range();
+  getGroundMaskLayer() { return this.groundMask; }
+  setGroundMaskLayer(solidLayer) { this.groundMask = solidLayer; }
 
-    this._debugFrame = null; // invalidate cached debug overlay
-    if (!this._debugFrame) this.#buildDebugFrame();
-    gameDisplay.drawFrame(this._debugFrame, 0, 0);
-  }
+  isOutOfLevel(y) { return y < 0 || y >= this.height; }
 
-  #buildDebugFrame() {
-    const frame = new Lemmings.Frame(this.width, this.height);
-    const steelColor  = Lemmings.ColorPalette.colorFromRGB(0, 255, 255);
-    const arrowRColor = Lemmings.ColorPalette.colorFromRGB(128, 255, 0);
-    const arrowLColor = Lemmings.ColorPalette.colorFromRGB(255, 128, 0);
-
-      frame.drawRect(s[i], s[i+1], s[i+2], s[i+3], steelColor);
-
-      const col = a[i+4] ? arrowRColor : arrowLColor;
-      frame.drawRect(a[i], a[i+1], a[i+2], a[i+3], col);
-
-    this._debugFrame = frame;
+  clearGroundWithMask(mask, x, y) {
+    this.groundMask.clearGroundWithMask(
+      mask, x, y,
+      (px, py) => this.isSteelAt(px, py)
     );
     const img = this.groundImage;
     const w = this.width;


### PR DESCRIPTION
## Summary
- restore `Level.js` and `Animation.js` to valid versions

## Testing
- `node --check js/Level.js && node --check js/Animation.js`
- `npm test` *(fails: SyntaxError in levelwriter.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68408234f588832db5f4c8ae0f38835c