### PR TITLE
Fix gitignore duplicate and absolute paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,3 @@ node_modules/
 .jshintconfig
 .jshintignore
 exports/
-exports/

--- a/tools/NodeFileProvider.js
+++ b/tools/NodeFileProvider.js
@@ -117,7 +117,7 @@ class NodeFileProvider {
       const arr = new Uint8Array(buf);
       return new Lemmings.BinaryReader(arr, 0, arr.length, filename, dir);
     }
-    const fullPath = path.join(this.rootPath, dir, filename);
+    const fullPath = path.resolve(this.rootPath, dir, filename);
     const data = fs.readFileSync(fullPath);
     const arr = new Uint8Array(data);
     return new Lemmings.BinaryReader(arr, 0, arr.length, filename, dir);
@@ -145,7 +145,7 @@ class NodeFileProvider {
         return Buffer.from(buf).toString('utf8');
       }
     }
-    const fullPath = path.join(this.rootPath, file);
+    const fullPath = path.resolve(this.rootPath, file);
     return fs.readFileSync(fullPath, 'utf8');
   }
 }


### PR DESCRIPTION
## Summary
- deduplicate `exports/` entry in `.gitignore`
- allow `NodeFileProvider` to read from absolute paths so tests pass

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840977e49e4832d86b60ac1d7b22965