### PR TITLE
Fix duplicate import

### DIFF
--- a/js/LemmingsBootstrap.js
+++ b/js/LemmingsBootstrap.js
@@ -94,7 +94,6 @@ import './TriggerManager.js';
 import './TriggerTypes.js';
 import './UnpackFilePart.js';
 import './PackFilePart.js';
-import './PackFilePart.js';
 import './UserInputManager.js';
 import './VGASpecReader.js';
 import './ViewPoint.js';

--- a/tools/patchSprites.js
+++ b/tools/patchSprites.js
@@ -28,7 +28,8 @@ function usage() {
     return;
   }
 
-  const provider = new NodeFileProvider('.');
+  // Use an empty root path so absolute input paths work correctly
+  const provider = new NodeFileProvider('');
   const datReader = await provider.loadBinary(path.dirname(datFile), path.basename(datFile));
   const container = new Lemmings.FileContainer(datReader);
 


### PR DESCRIPTION
## Summary
- clean up `LemmingsBootstrap.js` by removing a duplicate import
- allow absolute paths in `tools/patchSprites.js`

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840978eca6c832d8e4b97e71e0367ae