### PR TITLE
Restore CI test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,4 +18,5 @@ jobs:
         with:
           node-version: 18
       - run: npm install
+      - run: npm run lint
       - run: npm test


### PR DESCRIPTION
## Summary
- fix CI test workflow to run `npm run lint`

## Testing
- `npm run format` *(fails: Parsing error in tools/patchSprites.js)*
- `npm test` *(fails: SyntaxError in tools/patchSprites.js)*

------
https://chatgpt.com/codex/tasks/task_e_68409b5bd2c4832d9983196e601acb9c