### PR TITLE
Preallocate minimap dot arrays

### DIFF
--- a/js/LemmingManager.js
+++ b/js/LemmingManager.js
@@ -21,7 +21,11 @@ class LemmingManager extends Lemmings.BaseLogger {
         } else {
           this.lemmings = [];
         }
-        this.minimapDots = new Uint8Array(0);
+        const maxDots = (gameVictoryCondition.getReleaseCount() +
+          (lemmings.extraLemmings | 0)) * 2;
+        this._minimapDotBuffer = new Uint8Array(maxDots);
+        this.minimapDots = this._minimapDotBuffer.subarray(0, 0);
+        this._mmVisited = new Uint8Array(65536);
         if (!LemmingManager.log) {
           LemmingManager.log = this.log;
         }
@@ -130,8 +134,12 @@ class LemmingManager extends Lemmings.BaseLogger {
         }
         if (this.miniMap && ((++this.mmTickCounter % 10) === 0)) {
           const lemsCount = lems.length;
-          const dots = new Uint8Array(lemsCount * 2);
-          const visited = new Set();
+          if (this._minimapDotBuffer.length < lemsCount * 2) {
+            this._minimapDotBuffer = new Uint8Array(lemsCount * 2);
+          }
+          const dots = this._minimapDotBuffer;
+          const visited = this._mmVisited;
+          visited.fill(0);
           const scaleX = this.miniMap.scaleX;
           const scaleY = this.miniMap.scaleY;
           let idx = 0;
@@ -140,8 +148,8 @@ class LemmingManager extends Lemmings.BaseLogger {
             const x = (lem.x * scaleX) | 0;
             const y = (lem.y * scaleY) | 0;
             const key = (y << 8) | x;
-            if (visited.has(key)) continue;
-            visited.add(key);
+            if (visited[key]) continue;
+            visited[key] = 1;
             dots[idx++] = x;
             dots[idx++] = y;
           }
@@ -396,6 +404,8 @@ class LemmingManager extends Lemmings.BaseLogger {
     const start = performance.now();
     if (this.lemmings) this.lemmings.length = 0;
     if (this.minimapDots) this.minimapDots = new Uint8Array(0);
+    this._minimapDotBuffer = null;
+    this._mmVisited = null;
     this.level = null;
     this.triggerManager = null;
     this.gameVictoryCondition = null;


### PR DESCRIPTION
## Summary
- preallocate a buffer for minimap dot rendering
- track visited minimap cells with a typed array
- reuse the buffer when sending live dots to the minimap

## Testing
- `npm test` *(fails: SyntaxError in tools/patchSprites.js)*

------
https://chatgpt.com/codex/tasks/task_e_68409b547768832dbe04f42ed375d06d