### PR TITLE
Add docs index and fix duplicate import

### DIFF
--- a/.agentInfo/index.md
+++ b/.agentInfo/index.md
@@ -1,9 +1,9 @@
-# .agentInfo Index
+# .agentInfo index
 
-This directory stores tagged notes about design decisions or TODOs. The root `AGENTS.md` advises keeping these notes in `.agentInfo/` and maintaining an index so they can be searched by tag.
+This directory stores short notes about design decisions, TODOs, or debugging details.
+The root [AGENTS.md](../AGENTS.md) explains this tag-based note system.
 
 ## Notes by tag
 
-- **example**: [notes/initial.md](notes/initial.md)
-
+- **example, doc**: [notes/initial.md](notes/initial.md)
 - **debug, render**: [notes/drawMarchingAntRect.md](notes/drawMarchingAntRect.md)

--- a/tools/patchSprites.js
+++ b/tools/patchSprites.js
@@ -1,6 +1,5 @@
 import { Lemmings } from '../js/LemmingsNamespace.js';
 import '../js/LemmingsBootstrap.js';
-import { NodeFileProvider } from './NodeFileProvider.js';
 import { PNG } from 'pngjs';
 import fs from 'fs';
 import path from 'path';


### PR DESCRIPTION
## Summary
- update the `.agentInfo` index with a short description and link to `AGENTS.md`
- remove a duplicate `NodeFileProvider` import in `patchSprites.js`

## Testing
- `npm install`
- `npm test`
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_68409fac0820832da88f39cba23df1eb