### PR TITLE
Fix zoom handler check

### DIFF
--- a/js/Stage.js
+++ b/js/Stage.js
@@ -110,8 +110,8 @@ class Stage {
   handleOnZoom() {
     this.controller.onZoom.on((e) => {
       let stageImage = this.getStageImageAt(e.x, e.y);
-      if (stageImage == null || stageImage.display.getWidth() != 1600)
-        return;
+      if (stageImage == null || stageImage.display == null) return;
+      if (stageImage.display.getWidth() != 1600) return;
       let pos = this.calcPosition2D(stageImage, e);
       this.updateViewPoint(stageImage, e.x, e.y, -e.deltaZoom, pos.x, pos.y);
     });


### PR DESCRIPTION
## Summary
- avoid calling `getWidth()` on a null display

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840a17b94f8832da7371a6384c73c6e