### PR TITLE
Fix missing display check in Stage

### DIFF
--- a/js/Stage.js
+++ b/js/Stage.js
@@ -90,6 +90,8 @@ class Stage {
         let stageImage = this.getStageImageAt(e.mouseDownX, e.mouseDownY);
         if (stageImage == null)
           return;
+        if (stageImage.display == null)
+          return;
         if (stageImage == this.gameImgProps) {
           this.updateViewPoint(stageImage, e.deltaX, e.deltaY, 0);
         }


### PR DESCRIPTION
## Summary
- avoid errors when dragging by returning early if a display is missing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6840a1797e3c832da670685d2fb198d0