### PR TITLE
Fix ESM preload and missing import

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "start": "http-server --cors=*",
-    "test": "node -r ./js/LogHandler.js ./node_modules/mocha/bin/mocha",
+    "test": "node --import ./js/LogHandler.js ./node_modules/mocha/bin/mocha",
     "export-panel-sprite": "node tools/exportPanelSprite.js",
     "export-lemmings-sprites": "node tools/exportLemmingsSprites.js",
     "export-ground-images": "node tools/exportGroundImages.js",

--- a/tools/patchSprites.js
+++ b/tools/patchSprites.js
@@ -1,5 +1,6 @@
 import { Lemmings } from '../js/LemmingsNamespace.js';
 import '../js/LemmingsBootstrap.js';
+import { NodeFileProvider } from './NodeFileProvider.js';
 import { PNG } from 'pngjs';
 import fs from 'fs';
 import path from 'path';


### PR DESCRIPTION
## Summary
- update `npm test` script to preload LogHandler.js as ESM
- import NodeFileProvider in patchSprites tool

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840a23d203c832d8a75af37730dfdf4