### PR TITLE
Fix zoom display check

### DIFF
--- a/js/Stage.js
+++ b/js/Stage.js
@@ -114,10 +114,12 @@ class Stage {
   }
   handleOnZoom() {
     this.controller.onZoom.on((e) => {
-      let stageImage = this.getStageImageAt(e.x, e.y);
-      if (stageImage == null || stageImage.display == null) return;
-      if (stageImage.display.getWidth() != 1600) return;
-      let pos = this.calcPosition2D(stageImage, e);
+      const stageImage = this.getStageImageAt(e.x, e.y);
+      if (stageImage == null) return;
+      const { display } = stageImage;
+      if (display == null) return;
+      if (display.getWidth() != 1600) return;
+      const pos = this.calcPosition2D(stageImage, e);
       this.updateViewPoint(stageImage, e.x, e.y, -e.deltaZoom, pos.x, pos.y);
     });
   }


### PR DESCRIPTION
## Summary
- ensure zoom handler checks for a display before accessing its width

## Testing
- `npm test` *(fails: NodeFileProvider is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6840a2c7d444832dae4c27503a80c984