### PR TITLE
Add GameDisplay documentation note

### DIFF
--- a/.agentInfo/index.md
+++ b/.agentInfo/index.md
@@ -7,3 +7,4 @@ The root [AGENTS.md](../AGENTS.md) explains this tag-based note system.
 
 - **example, doc**: [notes/initial.md](notes/initial.md)
 - **debug, render**: [notes/drawMarchingAntRect.md](notes/drawMarchingAntRect.md)
+- **render, display**: [notes/game-display.md](notes/game-display.md)

--- a/.agentInfo/notes/game-display.md
+++ b/.agentInfo/notes/game-display.md
@@ -1,0 +1,7 @@
+# GameDisplay overview
+
+tags: render, display
+
+`js/GameDisplay.js` binds the game state to a GUI display. `setGuiDisplay()` attaches mouse handlers that select the nearest lemming on click and track the mouse position for debugging. The `render()` method draws the level, objects, and lemmings. When debug is off it also highlights the selected lemming with white corners and the hovered one with a grey rectangle. `renderDebug()` paints debug information for the level, lemmings and triggers and draws a marching-ants rectangle around the nearest lemming to the mouse.
+
+Selection is drawn by `#drawSelection()` which calls `#drawCorner()` four times to paint tiny white rectangles at the lemming's corners. Hover uses `#drawHover()` which fills a 10×13 grey box. These helpers provide visual feedback without intruding on normal gameplay.


### PR DESCRIPTION
## Summary
- document GameDisplay rendering logic in `.agentInfo/notes/game-display.md`
- reference the note from `.agentInfo/index.md`

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840a4d1991c832d8ba71bb99255c64b