### PR TITLE
Add NodeFileProvider doc note

### DIFF
--- a/.agentInfo/index.md
+++ b/.agentInfo/index.md
@@ -7,3 +7,4 @@ The root [AGENTS.md](../AGENTS.md) explains this tag-based note system.
 
 - **example, doc**: [notes/initial.md](notes/initial.md)
 - **debug, render**: [notes/drawMarchingAntRect.md](notes/drawMarchingAntRect.md)
+- **file-system, archives**: [notes/node-file-provider.md](notes/node-file-provider.md)

--- a/.agentInfo/notes/node-file-provider.md
+++ b/.agentInfo/notes/node-file-provider.md
@@ -1,0 +1,18 @@
+# NodeFileProvider note
+
+tags: file-system, archives
+
+`tools/NodeFileProvider.js` allows the rest of the project to read files from
+regular directories or from archives. It maintains three caches so each archive
+is parsed only once.
+
+* **ZIP** files are opened with `AdmZip` in `_getZip`. The resulting `AdmZip`
+  instance is cached in `zipCache` using the archive's absolute path as key.
+* **TAR** and **TAR.GZ/TGZ** files are read via `tar.t` inside `_getTar`. Each
+  file entry is captured as a `Buffer` inside a `Map` and the map is stored in
+  `tarCache`.
+* **RAR** archives are handled by `node-unrar-js` in `_getRar`. Files are
+  extracted to a `Map` of `Buffer`s which is kept in `rarCache`.
+
+Both `loadBinary` and `loadString` consult these caches so subsequent calls for
+the same archive do not re-read the archive from disk.


### PR DESCRIPTION
## Summary
- document how NodeFileProvider caches archives
- reference note from index

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840a4d2dea0832dbfb6c2cc03b96c64