### PR TITLE
Add note on LevelReader parsing

### DIFF
--- a/.agentInfo/index.md
+++ b/.agentInfo/index.md
@@ -7,3 +7,4 @@ The root [AGENTS.md](../AGENTS.md) explains this tag-based note system.
 
 - **example, doc**: [notes/initial.md](notes/initial.md)
 - **debug, render**: [notes/drawMarchingAntRect.md](notes/drawMarchingAntRect.md)
+- **level-parsing**: [notes/level-reader.md](notes/level-reader.md)

--- a/.agentInfo/notes/level-reader.md
+++ b/.agentInfo/notes/level-reader.md
@@ -1,0 +1,12 @@
+# LevelReader
+
+tags: level-parsing
+
+`js/LevelReader.js` consumes a 2048 byte `.DAT` level file. The first 0x20 bytes contain the release rate, lemming counts, time limit and skill amounts followed by the start X position and graphics set indices. The remainder of the file is split into several tables:
+
+- **Objects (0x0020..0x011F)** – 32 records of 8 bytes. Each entry provides an X/Y coordinate, object id and flag word. Flags are decoded into `DrawProperties` (flip, no-overwrite, only-overwrite). Empty records have all zero flags.
+- **Terrain (0x0120..0x075F)** – 400 records of 4 bytes. A packed 32‑bit value stores X, Y, id and flags. Flags control erase mode, upside‑down drawing and the overwrite behavior. Y coordinates are signed.
+- **Steel areas (0x0760..0x07DF)** – 32 entries describing rectangular steel zones. Two bytes pack X and Y in 8‑pixel steps, the third encodes width/height in 4‑pixel blocks. LevelReader adjusts the origin based on whether the level came from LemEdit.
+- **Level name (0x07E0..0x07FF)** – ASCII string padded with zeros.
+
+These structures populate the `objects`, `terrains` and `steel` arrays on the resulting LevelReader instance.


### PR DESCRIPTION
## Summary
- document LevelReader's parsing logic
- reference the new note from the agent info index

## Testing
- `npm install`
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6840a4d47710832d9e1566a41701746f