### PR TITLE
Add LevelWriter note

### DIFF
--- a/.agentInfo/index.md
+++ b/.agentInfo/index.md
@@ -7,3 +7,4 @@ The root [AGENTS.md](../AGENTS.md) explains this tag-based note system.
 
 - **example, doc**: [notes/initial.md](notes/initial.md)
 - **debug, render**: [notes/drawMarchingAntRect.md](notes/drawMarchingAntRect.md)
+- **level-writing**: [notes/level-writer.md](notes/level-writer.md)

--- a/.agentInfo/notes/level-writer.md
+++ b/.agentInfo/notes/level-writer.md
@@ -1,0 +1,5 @@
+# LevelWriter
+
+tags: level-writing
+
+`js/LevelWriter.js` converts a level object back into the original 2048‑byte binary format used by the game.  It uses a `DataView` to write little‑endian words and dwords at the same offsets expected by `LevelReader`.  Skills and basic properties occupy bytes 0–1F.  Objects follow at `0x0020` (32 entries), terrain at `0x0120` (400 entries), steel areas at `0x0760`, and the level name at `0x07E0`.  Missing entries are padded with zeros or `-1` so that the resulting array can be written directly to a `.lvl` file.


### PR DESCRIPTION
## Summary
- explain how `LevelWriter.js` encodes level data back to bytes
- index the new note

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6840a4d532d8832daeb708888406b381