### PR TITLE
Add ground renderer note

### DIFF
--- a/.agentInfo/index.md
+++ b/.agentInfo/index.md
@@ -7,3 +7,4 @@ The root [AGENTS.md](../AGENTS.md) explains this tag-based note system.
 
 - **example, doc**: [notes/initial.md](notes/initial.md)
 - **debug, render**: [notes/drawMarchingAntRect.md](notes/drawMarchingAntRect.md)
+- **render, ground**: [notes/ground-renderer.md](notes/ground-renderer.md)

--- a/.agentInfo/notes/ground-renderer.md
+++ b/.agentInfo/notes/ground-renderer.md
@@ -1,0 +1,11 @@
+# GroundRenderer note
+
+tags: render, ground
+
+`js/GroundRenderer.js` builds the bitmap used as the level background. `createGroundMap` allocates a `Frame` using the level's width and height then loops over `levelReader.terrains`, drawing each terrain image with `_blit`. `_blit` copies pixels from a `PaletteImage` frame, skipping transparent entries (`ci & 0x80`). The `drawProperties` flags affect how each pixel is drawn:
+- `isUpsideDown` flips the source image vertically so the inner loop has no branches.
+- `isErase` clears pixels instead of setting them, erasing terrain.
+- `noOverwrite` and `onlyOverwrite` are forwarded to `Frame.setPixel` to control mask updates.
+
+`createVgaspecMap` simply reuses a predecoded frame for VGASPEC levels.
+After rendering, `GroundRenderer.img` holds the complete ground bitmap and its mask, which the loader passes to `Level.setGroundImage` for display.


### PR DESCRIPTION
## Summary
- document how `js/GroundRenderer.js` builds the level ground bitmap
- index the new note in `.agentInfo/index.md`

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6840a4d5f680832da18108beb1d7119d