### PR TITLE
Add CLI tool reference

### DIFF
--- a/.agentInfo/index.md
+++ b/.agentInfo/index.md
@@ -7,3 +7,4 @@ The root [AGENTS.md](../AGENTS.md) explains this tag-based note system.
 
 - **example, doc**: [notes/initial.md](notes/initial.md)
 - **debug, render**: [notes/drawMarchingAntRect.md](notes/drawMarchingAntRect.md)
+- **tools, cli**: [notes/tools.md](notes/tools.md)

--- a/.agentInfo/notes/tools.md
+++ b/.agentInfo/notes/tools.md
@@ -1,0 +1,11 @@
+# Tool scripts overview
+
+tags: tools, cli
+
+The `tools/` directory contains small command-line utilities for working with level packs and sprites.
+
+- **exportAllPacks.js** – loops over packs defined in `config.json` and runs `exportAllSprites.js` for each. Each pack is exported into an `export_<pack>` folder. You can also pass pack paths via command line.
+- **exportAllSprites.js** – exports skill panel, lemming and object sprites from a pack to PNG files. Usage: `node tools/exportAllSprites.js <pack dir> <out dir>`. Relies on `NodeFileProvider` to read data files from folders or archives.
+- **packLevels.js** – packs a directory of 2048 byte level files into a single DAT. Usage: `node tools/packLevels.js <level dir> <out DAT>`.
+
+Most export scripts instantiate `NodeFileProvider` so they can read level packs from plain directories or archives like `.zip`, `.tar.gz`, or `.rar`. Keep pack archives next to the repo and the provider will find files automatically.


### PR DESCRIPTION
## Summary
- document CLI utilities in `.agentInfo/notes/tools.md`
- add the note to the `.agentInfo` index

## Testing
- `npm install`
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840a4d73354832d971af81afc877efd