### PR TITLE
Fix cross-env crypto usage

### DIFF
--- a/js/FileProvider.js
+++ b/js/FileProvider.js
@@ -217,10 +217,21 @@ class FileProvider extends Lemmings.BaseLogger {
   }
 
   async _hashBuffer(buffer) {
-    const hashBuf = await crypto.subtle.digest('SHA-256', buffer);
-    return Array.from(new Uint8Array(hashBuf))
-      .map(b => b.toString(16).padStart(2, '0'))
-      .join('');
+    if (typeof globalThis.crypto !== 'undefined' && globalThis.crypto.subtle) {
+      const hashBuf = await globalThis.crypto.subtle.digest('SHA-256', buffer);
+      return Array.from(new Uint8Array(hashBuf))
+        .map(b => b.toString(16).padStart(2, '0'))
+        .join('');
+    }
+
+    try {
+      const { createHash } = await import('node:crypto');
+      const hash = createHash('sha256');
+      hash.update(Buffer.from(buffer));
+      return hash.digest('hex');
+    } catch (e) {
+      throw new Error('crypto API not available');
+    }
   }
 
   async _hashString(str) {


### PR DESCRIPTION
## Summary
- support Node.js crypto in FileProvider

## Testing
- `npm run lint`
- `npm test`
- `npx --yes node@18 --import ./js/LogHandler.js ./node_modules/mocha/bin/mocha`

------
https://chatgpt.com/codex/tasks/task_e_6840a46396a0832db958c91f10406b0c