### PR TITLE
Add Stage.js design note

### DIFF
--- a/.agentInfo/index.md
+++ b/.agentInfo/index.md
@@ -16,6 +16,7 @@ The root [AGENTS.md](../AGENTS.md) explains this tag-based note system.
 - **level-parsing**: [notes/level-reader.md](notes/level-reader.md)
 - **ui, debug, render**: [notes/drawMarchingAntRect.md](notes/drawMarchingAntRect.md)
 - **render, display**: [notes/game-display.md](notes/game-display.md)
+- **stage, canvas, input**: [notes/stage.md](notes/stage.md)
 - **commands, replay, events**: [notes/command-manager.md](notes/command-manager.md)
 - **resources, caching**: [notes/game-resources.md](notes/game-resources.md)
 - **tools, cli**: [notes/tools.md](notes/tools.md)

--- a/.agentInfo/notes/stage.md
+++ b/.agentInfo/notes/stage.md
@@ -1,0 +1,7 @@
+# Stage overview
+
+tags: stage, canvas, input
+
+`js/Stage.js` creates a `Stage` bound to a canvas element. The constructor sets up a `UserInputManager` for that canvas and wires mouse handlers with helper methods like `handleOnMouseDown` and `handleOnDoubleClick`. Two `StageImageProperties` instances store layout and view information: `gameImgProps` for the gameplay area and `guiImgProps` for the GUI panel. The game display uses the default viewpoint scale while the GUI display starts with scale `2`.
+
+`getGameDisplay` and `getGuiDisplay` lazily construct `DisplayImage` objects, each backed by its associated `StageImageProperties`. New canvases for these displays are made through `createImage`. The `clear` method fills either the whole stage or a single section with black and `redraw` pulls image data from both displays before drawing them to the main canvas.


### PR DESCRIPTION
## Summary
- add `.agentInfo/notes/stage.md` describing how Stage sets up input on a canvas and manages game/gui display properties
- reference the note from `.agentInfo/index.md`

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6840a9943858832d9ca5426971d01834