### PR TITLE
Add GameView startup notes

### DIFF
--- a/.agentInfo/index.md
+++ b/.agentInfo/index.md
@@ -9,6 +9,7 @@ The root [AGENTS.md](../AGENTS.md) explains this tag-based note system.
 - **lemming-manager, actions, spawning lemmings, processing lemmings, lemming triggers, lemming actions**: [notes/lemming-manager.md](notes/lemming-manager.md)
 - **trigger-system, grid**: [notes/trigger-manager.md](notes/trigger-manager.md)
 - **game, main-loop**: [notes/game.md](notes/game.md)
+- **game-view, setup, stage**: [notes/game-view.md](notes/game-view.md)
 - **gui, input, skill selection, release rate, nuke, pause button, speed control, minimap, game text display**: [notes/game-gui.md](notes/game-gui.md)
 - **render, ground**: [notes/ground-renderer.md](notes/ground-renderer.md)
 - **level-writing**: [notes/level-writer.md](notes/level-writer.md)

--- a/.agentInfo/notes/game-view.md
+++ b/.agentInfo/notes/game-view.md
@@ -1,0 +1,7 @@
+# GameView overview
+
+tags: game-view, setup, stage
+
+`GameView` orchestrates the page's startup sequence. Assigning to the `.gameCanvas` property constructs a new `Stage` bound to the HTML canvas element. Calling `setup()` uses `GameFactory` to read available configs and fills the level and group selectors. `start()` then acquires a `Game` instance, connects its displays via the stage, and begins play.
+
+During `Game.start()` the GUI's mini‑map is created when `GameGui.setMiniMap` runs, storing the map on `gameGui.miniMap`.


### PR DESCRIPTION
## Summary
- document GameView startup flow and minimap creation
- index the new note under game-view tags

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840a99455b0832dbf19d3678dc6b4b1