### PR TITLE
Add async Blob support to BinaryReader

### DIFF
--- a/test/binaryreader.test.js
+++ b/test/binaryreader.test.js
@@ -1,0 +1,16 @@
+import assert from 'assert';
+import { Lemmings } from '../js/LemmingsNamespace.js';
+import { BinaryReader } from '../js/BinaryReader.js';
+
+globalThis.lemmings = { game: { showDebug: false } };
+
+describe('BinaryReader', function () {
+  it('reads data from Blob asynchronously', async function () {
+    const bytes = Uint8Array.from([1, 2, 3, 4]);
+    const blob = new Blob([bytes]);
+    const reader = new BinaryReader(blob);
+    await reader.ready;
+    const result = [reader.readByte(), reader.readByte(), reader.readByte(), reader.readByte()];
+    assert.deepStrictEqual(result, [1, 2, 3, 4]);
+  });
+});


### PR DESCRIPTION
## Summary
- support Blobs by asynchronously populating `BinaryReader` data
- expose a `ready` Promise for Blob inputs
- test asynchronous Blob reading

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840aaa867c8832dbe72fd9c11af8df5