### PR TITLE
Add tools documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ The goal is to create a solid, performant port first. Then build out the sequenc
   - `npm run export-all-sprites` – export the panel, lemmings and ground sprites for one level pack
   - `npm run list-sprites` – list sprite names with sizes and frame counts
   - `npm run patch-sprites` – verify a directory of edited sprites (patching not yet implemented)
+  - See [docs/tools.md](docs/tools.md) for detailed usage of each script
 
 ### NodeFileProvider
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,0 +1,104 @@
+# Tools
+
+This document describes the Node.js scripts found in the `tools` directory. These utilities help export,
+patch and package game assets.
+
+All scripts accept paths to level packs. A pack can be a folder or an archive
+(`.zip`, `.tar`, `.tar.gz`, `.tgz`, or `.rar`). The `NodeFileProvider` class lets
+the tools read from these sources without extracting them first.
+
+## exportAllPacks.js
+
+```
+node tools/exportAllPacks.js [pack1 pack2 ...]
+```
+
+Exports panel, lemming and ground sprites for each pack. If no pack names are
+provided it reads `config.json` to determine pack paths. Assets are saved in
+`export_<pack>` directories.
+
+## exportAllSprites.js
+
+```
+node tools/exportAllSprites.js [packPath] [outDir]
+```
+
+Exports the skill panel, lemming animations and ground object sprites for a
+single pack. `packPath` defaults to the first entry in `config.json`. Output goes
+to `outDir` (`<pack>_all` by default).
+
+## exportPanelSprite.js
+
+```
+node tools/exportPanelSprite.js [packPath] [outDir]
+```
+
+Saves the skill panel background as `panelSprite.png`.
+
+## exportLemmingsSprites.js
+
+```
+node tools/exportLemmingsSprites.js [packPath] [outDir]
+```
+
+Exports every lemming animation as individual PNGs plus sprite sheets. The files
+are placed in `outDir` (`<pack>_sprites` by default).
+
+## exportGroundImages.js
+
+```
+node tools/exportGroundImages.js [packPath] [groundIndex] [outDir]
+```
+
+Writes terrain and object images from one ground set to PNGs. `groundIndex`
+selects the `GROUND?O.DAT` and `VGAGR?.DAT` pair.
+
+## listSprites.js
+
+```
+node tools/listSprites.js [packPath] [--out file]
+```
+
+Lists sprite names, dimensions and frame counts. Use `--out` to write the list
+to a file instead of stdout.
+
+## patchSprites.js
+
+```
+node tools/patchSprites.js [--sheet-orientation=horizontal|vertical] <target DAT> <png dir> <out DAT>
+```
+
+Replaces sprites in an existing DAT archive with PNG data. Multiple frames can
+be supplied as a sprite sheet when `--sheet-orientation` matches the sheet
+layout.
+
+## packLevels.js
+
+```
+node tools/packLevels.js <level dir> <out DAT>
+```
+
+Compresses a directory of 2048 byte `.lvl` files into a single DAT file. Useful
+for building custom level packs.
+
+## archiveDir.js
+
+```
+node -e "import('./tools/archiveDir.js').then(m => m.archiveDir('dir', 'zip'))"
+```
+
+Utility function to create `.zip`, `.tar.gz` or `.rar` archives from a folder.
+
+## cleanExports.js
+
+```
+node tools/cleanExports.js
+```
+
+Removes all `export_*` directories created by the other scripts.
+
+---
+
+Exported assets go in folders starting with `export_` or `exports/`. The game can
+load levels directly from packed archives, so you may keep your level packs
+compressed while still running these tools.


### PR DESCRIPTION
## Summary
- document each tool script in `docs/tools.md`
- link new doc from README

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6840ab594580832dae001b6ab2797538