### PR TITLE
Add CI workflow docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,9 @@ packs. This provider can load files directly from folders or from archives such
 as `.zip`, `.tar`, `.tar.gz`, `.tgz`, and `.rar`, so you can keep level packs
 packed while running scripts with Node.
 
+For details on the GitHub Actions workflow that runs `npm install`, `npm run lint`,
+and `npm test` using Node 18, see [docs/ci.md](docs/ci.md).
+
 ### Progressive Web App
 
 This repo ships with [site.webmanifest](site.webmanifest) so it can be installed

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,19 @@
+# Continuous Integration
+
+This project uses GitHub Actions to run tests on every push and pull request targeting the `master` branch.
+
+The workflow is defined in [`.github/workflows/test.yml`](../.github/workflows/test.yml). Although the `package.json` requires Node 16 or newer, the workflow installs **Node 18**:
+
+```yaml
+- uses: actions/setup-node@v4
+  with:
+    node-version: 18
+```
+
+The CI job performs the following steps:
+
+1. `npm install`
+2. `npm run lint`
+3. `npm test`
+
+All tests must pass before code is merged.


### PR DESCRIPTION
## Summary
- document CI steps using Node 18
- explain the GitHub Actions workflow in README
- add standalone docs/ci.md for more details

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6840ab5afa84832d979c19727d6e7104