### PR TITLE
Improve async Blob support

### DIFF
--- a/.agentInfo/notes/binary-reader.md
+++ b/.agentInfo/notes/binary-reader.md
@@ -6,4 +6,6 @@ tags: binary-reader
 It accepts arrays, ArrayBuffers or another reader and exposes methods like
 `readByte`, `readInt`, `readWord` and `readString`. Offsets and lengths define a
 logical window so multiple readers can share data. Position setters/getters allow
-seek-like access when decoding resource files.
+seek-like access when decoding resource files. The constructor also accepts a
+`Blob`; when provided, it loads the blob asynchronously and the `ready` promise
+resolves with the resulting `Uint8Array`.

--- a/js/BinaryReader.js
+++ b/js/BinaryReader.js
@@ -40,7 +40,8 @@ class BinaryReader extends Lemmings.BaseLogger {
 
     /**
      * Promise that resolves when the backing data is available.
-     * @type {Promise<void>}
+     * For synchronous sources it resolves immediately with the data array.
+     * @type {Promise<Uint8Array>}
      */
     this.ready = Promise.resolve();
 
@@ -90,6 +91,7 @@ class BinaryReader extends Lemmings.BaseLogger {
         this.#hiddenOffset = offset;
         this.#length = length;
         this.#pos = this.#hiddenOffset;
+        return this.#data;
       })();
       // constructor returns immediately; callers should await this.ready
       this.ready.catch(() => {}); // avoid unhandled rejection
@@ -105,6 +107,7 @@ class BinaryReader extends Lemmings.BaseLogger {
     this.#hiddenOffset = offset;
     this.#length = length;
     this.#pos = this.#hiddenOffset;
+    this.ready = Promise.resolve(this.#data);
   }
 
   /** @returns {Uint8Array} Backing data array */

--- a/test/binaryreader.test.js
+++ b/test/binaryreader.test.js
@@ -9,7 +9,9 @@ describe('BinaryReader', function () {
     const bytes = Uint8Array.from([1, 2, 3, 4]);
     const blob = new Blob([bytes]);
     const reader = new BinaryReader(blob);
-    await reader.ready;
+    const loaded = await reader.ready;
+    assert.ok(loaded instanceof Uint8Array);
+    assert.deepStrictEqual(Array.from(loaded), [1, 2, 3, 4]);
     const result = [reader.readByte(), reader.readByte(), reader.readByte(), reader.readByte()];
     assert.deepStrictEqual(result, [1, 2, 3, 4]);
   });


### PR DESCRIPTION
## Summary
- resolve BinaryReader.ready to the loaded data
- update BinaryReader asynchronous test to check returned Uint8Array
- note Blob loading behaviour in agent docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840aed77518832db0b52754d1df64b0