### PR TITLE
Update README with test and CI instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,9 +143,16 @@ The goal is to create a solid, performant port first. Then build out the sequenc
 - See [docs/exporting-sprites.md](docs/exporting-sprites.md) for instructions on running tools for exporting sprites.
 - See [docs/TESTING.md](docs/TESTING.md) for how to run the Mocha test suite.
 
+### Running Tests
 
-For details on the GitHub Actions workflow that runs `npm install`, `npm run lint`,
-and `npm test` using Node 18, see [docs/ci.md](docs/ci.md).
+Run `npm test` to execute the Mocha suite. The command also invokes
+[`tools/check-undefined.js`](tools/check-undefined.js) to ensure no
+accidental global variables leak into the tests.
+
+### Continuous Integration
+
+The GitHub Actions workflow uses **Node 18** and runs `npm run lint` followed
+by `npm test`. See [docs/ci.md](docs/ci.md) for details.
 
 ### Progressive Web App
 


### PR DESCRIPTION
## Summary
- add new section explaining `npm test`
- mention CI uses Node 18 and runs `npm run lint` and `npm test`

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6840b07c502c832d873e9a370b859295