### PR TITLE
Add ColorPalette unit tests

### DIFF
--- a/test/colorpalette.test.js
+++ b/test/colorpalette.test.js
@@ -1,0 +1,24 @@
+import { expect } from 'chai';
+import { Lemmings } from '../js/LemmingsNamespace.js';
+import { ColorPalette } from '../js/ColorPalette.js';
+
+globalThis.lemmings = { game: { showDebug: false } };
+
+describe('ColorPalette', function() {
+  it('maintains consistent RGB values', function() {
+    const pal = new ColorPalette();
+    pal.setColorRGB(0, 12, 34, 56);
+
+    const stored = pal.getColor(0);
+    const expected = ColorPalette.colorFromRGB(12, 34, 56);
+    expect(stored).to.equal(expected);
+    expect(pal.getR(0)).to.equal(12);
+    expect(pal.getG(0)).to.equal(34);
+    expect(pal.getB(0)).to.equal(56);
+  });
+
+  it('defines black and debugColor constants', function() {
+    expect(ColorPalette.black).to.equal(0xFF000000);
+    expect(ColorPalette.debugColor).to.equal(0xFFFF00FF);
+  });
+});


### PR DESCRIPTION
## Summary
- add a ColorPalette test suite

## Testing
- `npm test` *(fails: require is not defined in ES module scope)*

------
https://chatgpt.com/codex/tasks/task_e_6840b2642724832d88938da4ed892b49