### PR TITLE
Add GameDisplay buffer tests

### DIFF
--- a/test/gamedisplay.test.js
+++ b/test/gamedisplay.test.js
@@ -1,0 +1,75 @@
+import { expect } from 'chai';
+import { Lemmings } from '../js/LemmingsNamespace.js';
+import '../js/ColorPalette.js';
+import { Frame } from '../js/Frame.js';
+import { DisplayImage } from '../js/DisplayImage.js';
+
+// minimal global env for logging
+globalThis.lemmings = { game: { showDebug: false } };
+
+class MockStage {
+  constructor() {
+    this.display = null;
+  }
+  createImage(display, w, h) {
+    return { data: new Uint8ClampedArray(w * h * 4), width: w, height: h };
+  }
+  getGameDisplay() {
+    if (!this.display) this.display = new DisplayImage(this);
+    return this.display;
+  }
+}
+
+describe('GameDisplay drawFrame', function() {
+  it('draws frames into the buffer', function() {
+    const stage = new MockStage();
+    const gd = stage.getGameDisplay();
+    gd.initSize(5, 5);
+
+    const redFrame = new Frame(2, 2);
+    redFrame.fill(255, 0, 0); // red
+    gd.drawFrame(redFrame, 1, 1);
+
+    const buf = gd.buffer32;
+    const w = gd.getWidth();
+    const red = Lemmings.ColorPalette.colorFromRGB(255, 0, 0) >>> 0;
+    expect(buf[1 + 1 * w]).to.equal(red);
+    expect(buf[2 + 1 * w]).to.equal(red);
+    expect(buf[1 + 2 * w]).to.equal(red);
+    expect(buf[2 + 2 * w]).to.equal(red);
+  });
+
+  it('applies frame offsets', function() {
+    const stage = new MockStage();
+    const gd = stage.getGameDisplay();
+    gd.initSize(4, 4);
+
+    const blueFrame = new Frame(1, 1, 1, 1);
+    blueFrame.fill(0, 0, 255); // blue
+    gd.drawFrame(blueFrame, 0, 0); // should draw at (1,1)
+
+    const buf = gd.buffer32;
+    const w = gd.getWidth();
+    const blue = Lemmings.ColorPalette.colorFromRGB(0, 0, 255) >>> 0;
+    expect(buf[1 + 1 * w]).to.equal(blue);
+  });
+
+  it('overwrites previous pixels on overlap', function() {
+    const stage = new MockStage();
+    const gd = stage.getGameDisplay();
+    gd.initSize(3, 3);
+
+    const greenFrame = new Frame(1, 1);
+    greenFrame.fill(0, 255, 0);
+    gd.drawFrame(greenFrame, 1, 1);
+
+    const yellowFrame = new Frame(1, 1);
+    yellowFrame.fill(255, 255, 0);
+    gd.drawFrame(yellowFrame, 1, 1);
+
+    const buf = gd.buffer32;
+    const w = gd.getWidth();
+    const yellow = Lemmings.ColorPalette.colorFromRGB(255, 255, 0) >>> 0;
+    expect(buf[1 + 1 * w]).to.equal(yellow);
+  });
+});

--- a/tools/check-undefined.js
+++ b/tools/check-undefined.js
@@ -1,6 +1,9 @@
 import fs from 'fs';
 import path from 'path';
 import { parse } from 'acorn';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
 
 const definedFunctions = new Set();
 const definedMethods = new Set();
@@ -116,10 +119,10 @@ function parseJS(code, file) {
   }
 }
 
-function processJSFile(file) {
+function processJSFile(file, withCalls = false) {
   const code = fs.readFileSync(file, 'utf8');
   const ast = parseJS(code, file);
-  if (ast) collectFromAst(ast, file, false);
+  if (ast) collectFromAst(ast, file, withCalls);
 }
 
 function processHtmlFile(file) {
@@ -162,10 +165,28 @@ function gatherFiles(dir, exts, results = []) {
   return results;
 }
 
-const jsFiles = gatherFiles('js', ['.js']);
-const htmlFiles = gatherFiles('.', ['.html']);
+let jsFiles = [];
+let htmlFiles = [];
 
-for (const file of jsFiles) processJSFile(file);
+const includeCalls = process.argv.length > 2;
+if (includeCalls) {
+  const targets = process.argv.slice(2);
+  for (const t of targets) {
+    const stat = fs.statSync(t);
+    if (stat.isDirectory()) {
+      jsFiles.push(...gatherFiles(t, ['.js']));
+      htmlFiles.push(...gatherFiles(t, ['.html']));
+    } else {
+      if (t.endsWith('.js')) jsFiles.push(t);
+      if (t.endsWith('.html')) htmlFiles.push(t);
+    }
+  }
+} else {
+  jsFiles = gatherFiles('js', ['.js']);
+  htmlFiles = gatherFiles('.', ['.html']);
+}
+
+for (const file of jsFiles) processJSFile(file, includeCalls);
 for (const file of htmlFiles) processHtmlFile(file);
 
 const errors = [];
@@ -184,7 +205,11 @@ for (const call of calls) {
 
 if (errors.length) {
   console.error('Undefined calls found:');
-  for (const err of errors) console.error('  ' + err);
+  for (const err of errors) {
+    console.error('  ' + err);
+    const m = /Undefined (?:function|method) (.+)$/.exec(err);
+    if (m) console.error(`${m[1]} is not defined`);
+  }
   process.exit(1);
 } else {
   console.log('No undefined calls detected.');


### PR DESCRIPTION
## Summary
- add new tests for GameDisplay drawFrame behavior
- allow tools/check-undefined.js to work as an ES module
- add CLI handling and error text tweaks to check-undefined.js

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840b2605268832d87704f613a5770e4