### PR TITLE
Add frame unit tests

### DIFF
--- a/test/frame.test.js
+++ b/test/frame.test.js
@@ -1,0 +1,63 @@
+import { expect } from 'chai';
+import { Lemmings } from '../js/LemmingsNamespace.js';
+import { Frame } from '../js/Frame.js';
+import { ColorPalette } from '../js/ColorPalette.js';
+
+globalThis.lemmings = { game: { showDebug: false } };
+
+describe('Frame', function () {
+  it('fills entire frame with a color', function () {
+    const frame = new Frame(2, 2);
+    frame.fill(1, 2, 3);
+    const color = ColorPalette.colorFromRGB(1, 2, 3);
+    expect(Array.from(frame.data)).to.eql([color, color, color, color]);
+    expect(Array.from(frame.mask)).to.eql([1, 1, 1, 1]);
+  });
+
+  it('setPixel and clearPixel update data with bounds checks', function () {
+    const frame = new Frame(2, 2);
+    frame.fill(10, 20, 30);
+    const color1 = ColorPalette.colorFromRGB(10, 20, 30);
+    const color2 = ColorPalette.colorFromRGB(4, 5, 6);
+
+    frame.setPixel(1, 0, color2);
+    expect(frame.data[1]).to.equal(color2);
+    expect(frame.mask[1]).to.equal(1);
+
+    frame.setPixel(2, 2, color2);
+    frame.setPixel(-1, 0, color2);
+    expect(Array.from(frame.data)).to.eql([color1, color2, color1, color1]);
+    expect(Array.from(frame.mask)).to.eql([1, 1, 1, 1]);
+
+    frame.clearPixel(1, 0);
+    expect(frame.data[1]).to.equal(ColorPalette.black);
+    expect(frame.mask[1]).to.equal(0);
+
+    frame.clearPixel(10, 0);
+    frame.clearPixel(0, -1);
+    expect(Array.from(frame.data)).to.eql([color1, ColorPalette.black, color1, color1]);
+    expect(Array.from(frame.mask)).to.eql([1, 0, 1, 1]);
+  });
+
+  it('drawPaletteImage blits indexed images respecting transparency', function () {
+    const frame = new Frame(2, 2);
+    const palette = new ColorPalette();
+    palette.setColorRGB(0, 1, 2, 3);
+    palette.setColorRGB(1, 4, 5, 6);
+    const img = new Uint8Array([0, 1, 0x81, 0]);
+
+    frame.clear();
+    frame.drawPaletteImage(img, 2, 2, palette, 0, 0);
+
+    const c0 = ColorPalette.colorFromRGB(1, 2, 3);
+    const c1 = ColorPalette.colorFromRGB(4, 5, 6);
+    expect(Array.from(frame.data)).to.eql([
+      c0, c1,
+      ColorPalette.black, c0
+    ]);
+    expect(Array.from(frame.mask)).to.eql([
+      1, 1,
+      0, 1
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add a new mocha test for the Frame class
- verify fill, setPixel, clearPixel and drawPaletteImage
- confirm out-of-range coordinates are ignored

## Testing
- `npm test` *(fails: require is not defined in ES module scope)*

------
https://chatgpt.com/codex/tasks/task_e_6840b25c08ac832dbfa374e806a81da1