### PR TITLE
Add DisplayImage canvas tests

### DIFF
--- a/test/displayimage.test.js
+++ b/test/displayimage.test.js
@@ -1,0 +1,121 @@
+import { expect } from 'chai';
+import { Lemmings } from '../js/LemmingsNamespace.js';
+import '../js/LogHandler.js';
+import '../js/ViewPoint.js';
+import '../js/StageImageProperties.js';
+import { Stage } from '../js/Stage.js';
+import { DisplayImage } from '../js/DisplayImage.js';
+import { Frame } from '../js/Frame.js';
+import '../js/ColorPalette.js';
+
+globalThis.lemmings = { game: { showDebug: false } };
+
+function color32(r, g, b) {
+  return (0xFF000000 | (b & 0xFF) << 16 | (g & 0xFF) << 8 | (r & 0xFF)) >>> 0;
+}
+
+function createCanvasStub(width = 8, height = 8) {
+  const ctx = {
+    canvas: null,
+    fillStyle: null,
+    globalAlpha: 1,
+    fillRect() {},
+    drawImage() {},
+    putImageData() {}
+  };
+  const canvas = {
+    width,
+    height,
+    getContext() { return ctx; },
+    addEventListener() {},
+    removeEventListener() {},
+    getBoundingClientRect() { return { left: 0, top: 0, width, height }; }
+  };
+  ctx.canvas = canvas;
+  return canvas;
+}
+
+class SimpleImageData {
+  constructor(width, height) {
+    this.width = width;
+    this.height = height;
+    this.data = new Uint8ClampedArray(width * height * 4);
+  }
+}
+
+describe('DisplayImage primitives', function() {
+  let stage, display;
+
+  beforeEach(function() {
+    const canvas = createCanvasStub(8, 8);
+    stage = new Stage(canvas);
+    stage.createImage = function(d, w, h) {
+      return new SimpleImageData(w, h);
+    };
+    display = stage.getGameDisplay();
+    display.initSize(4, 4);
+    display.clear(color32(0, 0, 0));
+  });
+
+  afterEach(function() {
+    stage.dispose();
+  });
+
+  it('drawRect outlines correctly', function() {
+    display.drawRect(0, 0, 2, 2, 255, 0, 0);
+    const RED = color32(255, 0, 0);
+    const BLACK = color32(0, 0, 0);
+    expect(Array.from(display.buffer32)).to.eql([
+      RED, RED, RED, BLACK,
+      RED, BLACK, RED, BLACK,
+      RED, RED, RED, BLACK,
+      BLACK, BLACK, BLACK, BLACK
+    ]);
+  });
+
+  it('drawHorizontalLine draws across row', function() {
+    display.drawHorizontalLine(0, 1, 3, 0, 255, 0);
+    const GREEN = color32(0, 255, 0);
+    const BLACK = color32(0, 0, 0);
+    expect(Array.from(display.buffer32)).to.eql([
+      BLACK, BLACK, BLACK, BLACK,
+      GREEN, GREEN, GREEN, GREEN,
+      BLACK, BLACK, BLACK, BLACK,
+      BLACK, BLACK, BLACK, BLACK
+    ]);
+  });
+
+  it('drawVerticalLine draws column', function() {
+    display.drawVerticalLine(2, 0, 3, 0, 0, 255);
+    const BLUE = color32(0, 0, 255);
+    const BLACK = color32(0, 0, 0);
+    expect(Array.from(display.buffer32)).to.eql([
+      BLACK, BLACK, BLUE, BLACK,
+      BLACK, BLACK, BLUE, BLACK,
+      BLACK, BLACK, BLUE, BLACK,
+      BLACK, BLACK, BLUE, BLACK
+    ]);
+  });
+
+  it('drawStippleRect fills pattern', function() {
+    display.drawStippleRect(0, 0, 3, 3, 128, 128, 128);
+    const GRAY = color32(128, 128, 128);
+    const BLACK = color32(0, 0, 0);
+    const expected = [];
+    for (let y = 0; y < 4; y++) {
+      for (let x = 0; x < 4; x++) {
+        expected.push(((x + y) & 1) === 0 ? GRAY : BLACK);
+      }
+    }
+    expect(Array.from(display.buffer32)).to.eql(expected);
+  });
+
+  it('_blit scales frame', function() {
+    const frame = new Frame(2, 2);
+    frame.fill(255, 0, 0);
+    display.clear(color32(0, 0, 0));
+    display._blit(frame, 0, 0, { size: { width: 4, height: 4 } });
+    const RED = color32(255, 0, 0);
+    expect(Array.from(display.buffer32)).to.eql(new Array(16).fill(RED));
+  });
+});

--- a/tools/check-undefined.js
+++ b/tools/check-undefined.js
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { parse } from 'acorn';
+import { parseDocument, DomUtils } from 'htmlparser2';
 
 const definedFunctions = new Set();
 const definedMethods = new Set();
@@ -116,16 +117,14 @@ function parseJS(code, file) {
   }
 }
 
-function processJSFile(file) {
+function processJSFile(file, withCalls = false) {
   const code = fs.readFileSync(file, 'utf8');
   const ast = parseJS(code, file);
-  if (ast) collectFromAst(ast, file, false);
+  if (ast) collectFromAst(ast, file, withCalls);
 }
 
 function processHtmlFile(file) {
   const html = fs.readFileSync(file, 'utf8');
-  const { parseDocument } = require('htmlparser2');
-  const { DomUtils } = require('htmlparser2');
   const document = parseDocument(html);
 
   // Extract and process <script> tag content
@@ -162,22 +161,29 @@ function gatherFiles(dir, exts, results = []) {
   return results;
 }
 
-const jsFiles = gatherFiles('js', ['.js']);
-const htmlFiles = gatherFiles('.', ['.html']);
+const args = process.argv.slice(2);
+let jsFiles = [];
+let htmlFiles = [];
+if (args.length) {
+  jsFiles = args;
+} else {
+  jsFiles = gatherFiles('js', ['.js']);
+  htmlFiles = gatherFiles('.', ['.html']);
+}
 
-for (const file of jsFiles) processJSFile(file);
+for (const file of jsFiles) processJSFile(file, args.length > 0);
 for (const file of htmlFiles) processHtmlFile(file);
 
 const errors = [];
 for (const call of calls) {
   if (call.type === 'function') {
     if (!definedFunctions.has(call.name) && !builtinFunctions.has(call.name)) {
-      errors.push(`${call.file}:${call.line} - Undefined function ${call.name}`);
+      errors.push(`${call.file}:${call.line} - ${call.name} is not defined`);
     }
   } else if (call.type === 'method') {
     if (builtinObjects.has(call.object)) continue;
     if (!definedMethods.has(call.name) && !builtinMethods.has(call.name)) {
-      errors.push(`${call.file}:${call.line} - Undefined method ${call.name}`);
+      errors.push(`${call.file}:${call.line} - ${call.name} is not defined`);
     }
   }
 }


### PR DESCRIPTION
## Summary
- add new DisplayImage drawing tests covering primitive operations
- adjust `check-undefined.js` to use ESM imports and accept file arguments

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840b25b07e4832db9a643d4bf935bec