### PR TITLE
Add GameFactory createFromConfig test

### DIFF
--- a/js/GameFactory.js
+++ b/js/GameFactory.js
@@ -36,6 +36,14 @@ class GameFactory {
       });
     });
   }
+
+  /** create and load a game from a provided config */
+  async createFromConfig(config, groupIndex = 0, levelIndex = 0) {
+    const res = new Lemmings.GameResources(this.fileProvider, config);
+    const game = new Lemmings.Game(res);
+    await game.loadLevel(groupIndex, levelIndex);
+    return game;
+  }
 }
 Lemmings.GameFactory = GameFactory;
 

--- a/test/gamefactory.test.js
+++ b/test/gamefactory.test.js
@@ -1,0 +1,65 @@
+import { expect } from 'chai';
+import { Lemmings } from '../js/LemmingsNamespace.js';
+import { GameFactory } from '../js/GameFactory.js';
+
+globalThis.lemmings = { game: { showDebug: false } };
+
+describe('GameFactory.createFromConfig', function () {
+  it('builds a Game with GameResources and timer', async function () {
+    class FileProviderStub {
+      constructor(root) { this.root = root; }
+      loadString() { return Promise.resolve('[]'); }
+    }
+    class ConfigReaderStub {
+      constructor() {}
+      getConfig() {}
+    }
+    class GameResourcesStub {
+      constructor(fp, cfg) { this.fp = fp; this.cfg = cfg; }
+      async getLevel() { return { timeLimit: 5, colorPalette: null, triggers: [], objects: [] }; }
+      async getMasks() { return []; }
+      async getLemmingsSprite() { return null; }
+      async getSkillPanelSprite() { return null; }
+    }
+    class GameTimerStub {}
+    class GameStub {
+      constructor(res) { this.res = res; this.loadArgs = []; this.gameTimer = null; }
+      async loadLevel(g, i) {
+        this.loadArgs = [g, i];
+        this.gameTimer = new Lemmings.GameTimer({});
+        return this;
+      }
+    }
+
+    const orig = {
+      FileProvider: Lemmings.FileProvider,
+      ConfigReader: Lemmings.ConfigReader,
+      GameResources: Lemmings.GameResources,
+      Game: Lemmings.Game,
+      GameTimer: Lemmings.GameTimer
+    };
+
+    Lemmings.FileProvider = FileProviderStub;
+    Lemmings.ConfigReader = ConfigReaderStub;
+    Lemmings.GameResources = GameResourcesStub;
+    Lemmings.Game = GameStub;
+    Lemmings.GameTimer = GameTimerStub;
+
+    const config = { path: 'data', level: {} };
+    const gf = new GameFactory('root');
+    const game = await gf.createFromConfig(config, 1, 2);
+
+    expect(game).to.be.instanceOf(GameStub);
+    expect(game.res).to.be.instanceOf(GameResourcesStub);
+    expect(game.res.fp).to.be.instanceOf(FileProviderStub);
+    expect(game.res.cfg).to.equal(config);
+    expect(game.loadArgs).to.eql([1, 2]);
+    expect(game.gameTimer).to.be.instanceOf(GameTimerStub);
+
+    Lemmings.FileProvider = orig.FileProvider;
+    Lemmings.ConfigReader = orig.ConfigReader;
+    Lemmings.GameResources = orig.GameResources;
+    Lemmings.Game = orig.Game;
+    Lemmings.GameTimer = orig.GameTimer;
+  });
+});

--- a/tools/check-undefined.js
+++ b/tools/check-undefined.js
@@ -1,6 +1,21 @@
 import fs from 'fs';
 import path from 'path';
+import { pathToFileURL } from 'url';
 import { parse } from 'acorn';
+import { parseDocument, DomUtils } from 'htmlparser2';
+
+if (process.argv.length > 2) {
+  let exitCode = 0;
+  for (const f of process.argv.slice(2)) {
+    try {
+      await import(pathToFileURL(path.resolve(f)).href);
+    } catch (err) {
+      console.error(err.toString());
+      exitCode = 1;
+    }
+  }
+  process.exit(exitCode);
+}
 
 const definedFunctions = new Set();
 const definedMethods = new Set();
@@ -116,16 +131,14 @@ function parseJS(code, file) {
   }
 }
 
-function processJSFile(file) {
+function processJSFile(file, withCalls = false) {
   const code = fs.readFileSync(file, 'utf8');
   const ast = parseJS(code, file);
-  if (ast) collectFromAst(ast, file, false);
+  if (ast) collectFromAst(ast, file, withCalls);
 }
 
 function processHtmlFile(file) {
   const html = fs.readFileSync(file, 'utf8');
-  const { parseDocument } = require('htmlparser2');
-  const { DomUtils } = require('htmlparser2');
   const document = parseDocument(html);
 
   // Extract and process <script> tag content
@@ -162,10 +175,21 @@ function gatherFiles(dir, exts, results = []) {
   return results;
 }
 
-const jsFiles = gatherFiles('js', ['.js']);
-const htmlFiles = gatherFiles('.', ['.html']);
+let jsFiles = [];
+let htmlFiles = [];
+if (process.argv.length > 2) {
+  for (const f of process.argv.slice(2)) {
+    const ext = path.extname(f).toLowerCase();
+    if (ext === '.js') jsFiles.push(f);
+    else if (ext === '.html') htmlFiles.push(f);
+  }
+} else {
+  jsFiles = gatherFiles('js', ['.js']);
+  htmlFiles = gatherFiles('.', ['.html']);
+}
 
-for (const file of jsFiles) processJSFile(file);
+const cliMode = process.argv.length > 2;
+for (const file of jsFiles) processJSFile(file, cliMode);
 for (const file of htmlFiles) processHtmlFile(file);
 
 const errors = [];


### PR DESCRIPTION
## Summary
- extend `GameFactory` with `createFromConfig` helper
- allow `check-undefined.js` to run files directly
- add unit test for `GameFactory.createFromConfig`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840b268ae84832da3cb73ae14d92494