### PR TITLE
Use shared HTML parser in undefined checker

### DIFF
--- a/js/ConfigReader.js
+++ b/js/ConfigReader.js
@@ -14,7 +14,7 @@ class ConfigReader extends Lemmings.BaseLogger {
   /** return the game config for a given GameType */
   getConfig(gameType) {
     if (gameType == 0) {
-      this.log.log('tried to get gametype 0?')
+      this.log.log('tried to get gametype 0?');
       return;
     }
     return new Promise((resolve, reject) => {

--- a/tools/check-undefined.js
+++ b/tools/check-undefined.js
@@ -1,8 +1,8 @@
 import fs from 'fs';
 import path from 'path';
-import { spawnSync } from 'child_process';
 import { parse } from 'acorn';
 import { createRequire } from 'module';
+import { processHtmlFile as extractHtmlSnippets } from './processHtmlFile.js';
 
 const require = createRequire(import.meta.url);
 
@@ -126,27 +126,11 @@ function processJSFile(file, withCalls = false) {
   if (ast) collectFromAst(ast, file, withCalls);
 }
 
-async function processHtmlFile(file) {
-  const html = fs.readFileSync(file, 'utf8');
-  const document = parseDocument(html);
-
-  // Extract and process <script> tag content
-  const scriptTags = DomUtils.findAll(elem => elem.tagName === 'script', document.children);
-  for (const scriptTag of scriptTags) {
-    const js = DomUtils.textContent(scriptTag);
-    const ast = parseJS(js, file);
+function processHtmlFile(file) {
+  const snippets = extractHtmlSnippets(file);
+  for (const { code } of snippets) {
+    const ast = parseJS(code, file);
     if (ast) collectFromAst(ast, file, true);
-  }
-
-  // Extract and process inline event handler attributes
-  const elementsWithAttributes = DomUtils.findAll(elem => elem.attribs, document.children);
-  for (const elem of elementsWithAttributes) {
-    for (const [attr, value] of Object.entries(elem.attribs)) {
-      if (attr.startsWith('on')) {
-        const ast = parseJS(value, file);
-        if (ast) collectFromAst(ast, file, true);
-      }
-    }
   }
 }
 


### PR DESCRIPTION
## Summary
- reuse `processHtmlFile` from tools/processHtmlFile
- drop old htmlparser2 logic in `check-undefined.js`
- run project formatter

## Testing
- `npm run format`
- `npm test` *(fails: 7 failing)*

------
https://chatgpt.com/codex/tasks/task_e_6840bf2073c0832da0f6fe47cdf13dca