### PR TITLE
Add agent note for check-undefined

### DIFF
--- a/.agentInfo/notes/check-undefined.md
+++ b/.agentInfo/notes/check-undefined.md
@@ -2,4 +2,6 @@
 
 tags: tools, validation
 
-`tools/check-undefined.js` scans JavaScript and HTML files for method calls. If it finds a call that cannot be resolved, it fails the build. Run `npm run check-undefined` (or `npm test`) after significant merges or large changes to catch missing or renamed functions early.
+`tools/check-undefined.js` scans JavaScript and HTML files for function or method invocations. If a call cannot be matched to a defined function, the script fails and reports the location.
+
+Run `npm run check-undefined` (also part of `npm test`) after large merges or refactors to catch missing or renamed functions before committing.

--- a/tools/check-undefined.js
+++ b/tools/check-undefined.js
@@ -3,6 +3,7 @@ import path from 'path';
 import { spawnSync } from 'child_process';
 import { parse } from 'acorn';
 import { createRequire } from 'module';
+import { parseDocument, DomUtils } from 'htmlparser2';
 
 const require = createRequire(import.meta.url);
 


### PR DESCRIPTION
## Summary
- expand `.agentInfo/notes/check-undefined.md` with more usage info
- document missing imports in `tools/check-undefined.js`

## Testing
- `npm install`
- `npm run format`
- `npm test` *(fails: ReferenceError, assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_6840be6d0a6c832d922572d9815d7e00