### PR TITLE
Document agent notes directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- _Nothing yet_
+### Added
+- `.agentInfo/` directory for searchable design notes.
 
 ## [0.0.2] - 2025-06-04
 ### Added

--- a/tools/check-undefined.js
+++ b/tools/check-undefined.js
@@ -3,9 +3,8 @@ import path from 'path';
 import { spawnSync } from 'child_process';
 import { parse } from 'acorn';
 import { createRequire } from 'module';
-import { parse } from 'acorn';
-import { createRequire } from 'module';
 import { processHtmlFile as extractHtmlSnippets } from './processHtmlFile.js';
+import { parseDocument, DomUtils } from 'htmlparser2';
 
 
 const require = createRequire(import.meta.url);


### PR DESCRIPTION
## Summary
- document the `.agentInfo/` directory in the changelog
- clean up duplicate imports in `check-undefined.js`
- add missing `htmlparser2` import for DOM parsing

## Testing
- `npm run format`
- `npm test` *(fails: 82 passing, 8 failing)*

------
https://chatgpt.com/codex/tasks/task_e_6840c1eb49e4832d8e4530c4024814f5