### PR TITLE
Update changelog for Node version requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- _Nothing yet_
+### Changed
+- Project now requires Node.js 16+ (tests use Node 18 in CI).
 
 ## [0.0.2] - 2025-06-04
 ### Added


### PR DESCRIPTION
## Summary
- document Node.js 16+ requirement in the changelog

## Testing
- `npm install`
- `npm test` *(fails: SyntaxError: Identifier 'parse' has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_6840c1ec4e4c832d9c0009e8b338dfc7