### PR TITLE
Update changelog with NodeFileProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- _Nothing yet_
+### Added
+- `NodeFileProvider` can load files from `.zip`, `.tar.gz`, `.tgz`, and `.rar` archives and exposes `clearCache()`.
 
 ## [0.0.2] - 2025-06-04
 ### Added


### PR DESCRIPTION
## Summary
- document NodeFileProvider archive support

## Testing
- `npm install`
- `npm test` *(fails: Identifier 'parse' has already been declared)*
- `npm run format` *(fails: Parsing error in `tools/check-undefined.js`)*

------
https://chatgpt.com/codex/tasks/task_e_6840c1f29dfc832da129516c5aaae92b