### PR TITLE
Remove htmlparser2 dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "chai": "^4.3.7",
         "cheerio": "^1.0.0",
         "eslint": "^9.28.0",
-        "htmlparser2": "^10.0.0",
         "http-server": "^14.0.1",
         "mocha": "^11.5.0",
         "node-unrar-js": "^2.0.2",
@@ -1616,39 +1615,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/htmlparser2": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
-      "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
-      "dev": true,
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.2.1",
-        "entities": "^6.0.0"
-      }
-    },
-    "node_modules/htmlparser2/node_modules/entities": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.0.tgz",
-      "integrity": "sha512-aKstq2TDOndCn4diEyp9Uq/Flu2i1GlLkc6XIDQSDMuaFE3OPW5OphLCyQ5SpSJZTb4reN+kTcYru5yIfXoRPw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/http-proxy": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "chai": "^4.3.7",
     "cheerio": "^1.0.0",
     "eslint": "^9.28.0",
-    "htmlparser2": "^10.0.0",
     "http-server": "^14.0.1",
     "mocha": "^11.5.0",
     "node-unrar-js": "^2.0.2",


### PR DESCRIPTION
## Summary
- remove unused htmlparser2 entry from `devDependencies`
- regenerate `package-lock.json`

## Testing
- `npm run format` *(fails: Parsing error in tools/check-undefined.js)*
- `npm test` *(fails: SyntaxError: Identifier 'parse' has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_6840c34eea88832d8ef195aa4cbb2b41