### PR TITLE
Refactor HTML snippet parsing

### DIFF
--- a/test/patchSprites.test.js
+++ b/test/patchSprites.test.js
@@ -54,7 +54,7 @@ describe('tools/patchSprites.js', function () {
 
     const origArgv = process.argv;
     process.argv = ['node', tempScript, datFile, pngDir, outFile];
-    await import(pathToFileURL(tempScript).href);
+    await import(pathToFileURL(tempScript).href + `?t=${Date.now()}`);
     process.argv = origArgv;
     fs.unlinkSync(tempScript);
 
@@ -128,7 +128,7 @@ describe('tools/patchSprites.js', function () {
 
     const origArgv = process.argv;
     process.argv = ['node', tempScript, '--sheet-orientation=vertical', datFile, pngDir, outFile];
-    await import(pathToFileURL(tempScript).href);
+    await import(pathToFileURL(tempScript).href + `?t=${Date.now()}`);
     process.argv = origArgv;
     fs.unlinkSync(tempScript);
 

--- a/tools/check-undefined.js
+++ b/tools/check-undefined.js
@@ -3,8 +3,6 @@ import path from 'path';
 import { spawnSync } from 'child_process';
 import { parse } from 'acorn';
 import { createRequire } from 'module';
-import { parse } from 'acorn';
-import { createRequire } from 'module';
 import { processHtmlFile as extractHtmlSnippets } from './processHtmlFile.js';
 
 const require = createRequire(import.meta.url);
@@ -129,30 +127,6 @@ function processJSFile(file, withCalls = false) {
   if (ast) collectFromAst(ast, file, withCalls);
 }
 
-async function processHtmlFile(file) {
-  const html = fs.readFileSync(file, 'utf8');
-  const document = parseDocument(html);
-
-  // Extract and process <script> tag content
-  const scriptTags = DomUtils.findAll(elem => elem.tagName === 'script', document.children);
-  for (const scriptTag of scriptTags) {
-    const js = DomUtils.textContent(scriptTag);
-    const ast = parseJS(js, file);
-    if (ast) collectFromAst(ast, file, true);
-  }
-
-  // Extract and process inline event handler attributes
-  const elementsWithAttributes = DomUtils.findAll(elem => elem.attribs, document.children);
-  for (const elem of elementsWithAttributes) {
-    for (const [attr, value] of Object.entries(elem.attribs)) {
-      if (attr.startsWith('on')) {
-        const ast = parseJS(value, file);
-        if (ast) collectFromAst(ast, file, true);
-      }
-    }
-  }
-}
-
 function gatherFiles(dir, exts, results = []) {
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
     if (entry.name === 'node_modules' || entry.name === '.git') continue;
@@ -184,7 +158,13 @@ if (extra.length) {
 
 
 for (const file of jsFiles) processJSFile(file, extra.length > 0);
-for (const file of htmlFiles) processHtmlFile(file);
+for (const file of htmlFiles) {
+  const snippets = extractHtmlSnippets(file);
+  for (const snippet of snippets) {
+    const ast = parseJS(snippet.code, file);
+    if (ast) collectFromAst(ast, file, true);
+  }
+}
 
 const errors = [];
 for (const call of calls) {


### PR DESCRIPTION
## Summary
- remove duplicate imports in `tools/check-undefined.js`
- use `extractHtmlSnippets` from `processHtmlFile.js`
- run parser on returned snippets
- make patchSprites tests re-import helper script correctly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840c34ac674832d95d367ae2f0838b5