### PR TITLE
Avoid jquery load in tests

### DIFF
--- a/test/lemming.test.js
+++ b/test/lemming.test.js
@@ -1,13 +1,12 @@
 import { expect } from 'chai';
 import { Lemmings } from '../js/LemmingsNamespace.js';
-import '../js/SolidLayer.js';
-import '../js/LemmingStateType.js';
-import '../js/Lemming.js';
-import '../js/SkillTypes.js';
 import { Level } from '../js/Level.js';
 import { LemmingManager } from '../js/LemmingManager.js';
 import { GameVictoryCondition } from '../js/GameVictoryCondition.js';
-import '../js/LemmingsBootstrap.js';
+// LemmingsBootstrap loads jquery, which isn't needed for unit tests.
+// Avoid importing it here to prevent Node from trying to parse the
+// non-ESM jquery.js file.
+// Instead, import only the modules required by these tests.
 import '../js/SolidLayer.js';
 import '../js/LemmingStateType.js';
 import '../js/SkillTypes.js';


### PR DESCRIPTION
## Summary
- skip `LemmingsBootstrap` in `lemming.test.js` so `js/jquery.js` is never imported

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840c845c144832dbaa5565c1d5f942f