### PR TITLE
Add helper for nearest lemming

### DIFF
--- a/js/LemmingManager.js
+++ b/js/LemmingManager.js
@@ -302,13 +302,7 @@ class LemmingManager extends Lemmings.BaseLogger {
   }
 
   getLemmingAt(x, y, radius = 6) {
-    const halfW = radius;
-    const halfH = radius * 2;
-    for (const lem of this.lemmings) {
-      if (lem.removed) continue;
-      if (x >= lem.x - halfW && x <= lem.x + halfW && y >= lem.y - halfH && y <= lem.y + halfH) return lem;
-    }
-    return null;
+    return this.getNearestLemming(x, y);
   }
 
   getNearestLemming(x, y) {


### PR DESCRIPTION
## Summary
- wrap `getLemmingAt` around new `getNearestLemming`
- locate the closest clickable lemming using `getClickDistance`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840c880b1b0832d8fb364a1ce77cbc8