### PR TITLE
Fix GameResources test

### DIFF
--- a/test/gameresources.test.js
+++ b/test/gameresources.test.js
@@ -109,7 +109,6 @@ describe('GameResources', function () {
     await gr.getCursorSprite();
     await gr.getMasks();
     assert.strictEqual(loadCount, 1);
-    assert.deepStrictEqual(partIndices, [0, 2, 6, 5, 1]);
     assert.deepStrictEqual(partIndices, [0, 2, 6, 1]);
   });
 });


### PR DESCRIPTION
## Summary
- remove outdated expectation in GameResources test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6840cd928368832da2cd4656e9a9a865