### PR TITLE
Update explosion dots and minimap

### DIFF
--- a/js/ActionExplodingSystem.js
+++ b/js/ActionExplodingSystem.js
@@ -36,7 +36,17 @@ class ActionExplodingSystem extends ActionBaseSystem {
     lem.frameIndex++;
     if (lem.frameIndex == 1) {
       this.triggerManager.removeByOwner(lem);
-      level.clearGroundWithMask(this.masks.get('both').GetMask(0), lem.x, lem.y);
+      const mask = this.masks.get('both').GetMask(0);
+      const changed = level.clearGroundWithMask(mask, lem.x, lem.y);
+      if (changed) {
+        lemmings.game.lemmingManager.miniMap.invalidateRegion(
+          lem.x + mask.offsetX,
+          lem.y + mask.offsetY,
+          mask.width,
+          mask.height
+        );
+      }
+      lemmings.game.lemmingManager.miniMap.addDeath(lem.x, lem.y);
     }
     if (lem.frameIndex == 52) {
       return Lemmings.LemmingStateType.OUT_OF_LEVEL;

--- a/js/Level.js
+++ b/js/Level.js
@@ -131,7 +131,7 @@ class Level extends Lemmings.BaseLogger {
   isOutOfLevel(y) { return y < 0 || y >= this.height; }
 
   clearGroundWithMask(mask, x, y) {
-    this.groundMask.clearGroundWithMask(
+    let changed = this.groundMask.clearGroundWithMask(
       mask, x, y,
       (px, py) => this.isSteelAt(px, py)
     );
@@ -146,9 +146,11 @@ class Level extends Lemmings.BaseLogger {
         if (this.isSteelAt(px, py)) continue;
         if (px < 0 || px >= this.width || py < 0 || py >= this.height) continue;
         const idx = (py * w + px) * 4;
+        if (img[idx] || img[idx + 1] || img[idx + 2]) changed = true;
         img[idx] = img[idx + 1] = img[idx + 2] = 0;
       }
     }
+    return changed;
   }
 
   setGroundAt(x, y, paletteIndex) {

--- a/js/SolidLayer.js
+++ b/js/SolidLayer.js
@@ -52,6 +52,7 @@ class SolidLayer extends Lemmings.BaseLogger {
      * @param {Function|null} skipTest - Optional (x, y) => true if pixel should not be cleared (e.g. steel check)
      */
   clearGroundWithMask(mask, x, y, skipTest = null) {
+    let changed = false;
     Lemmings.withPerformance(
       'clearGroundWithMask',
       {
@@ -71,12 +72,17 @@ class SolidLayer extends Lemmings.BaseLogger {
             // Only clear where mask pixel is **not** solid
             if (!mask.at(dx, dy)) {
               if (!skipTest || !skipTest(mapX, mapY)) {
-                this.mask[mapX + mapY * this.width] = 0;
+                const idx = mapX + mapY * this.width;
+                if (this.mask[idx]) {
+                  this.mask[idx] = 0;
+                  changed = true;
+                }
               }
             }
           }
         }
       })();
+    return changed;
   }
 
   /**

--- a/test/gameresources.test.js
+++ b/test/gameresources.test.js
@@ -109,7 +109,6 @@ describe('GameResources', function () {
     await gr.getCursorSprite();
     await gr.getMasks();
     assert.strictEqual(loadCount, 1);
-    assert.deepStrictEqual(partIndices, [0, 2, 6, 5, 1]);
     assert.deepStrictEqual(partIndices, [0, 2, 6, 1]);
   });
 });


### PR DESCRIPTION
## Summary
- track ground changes in `SolidLayer.clearGroundWithMask`
- return whether ground changed from `Level.clearGroundWithMask`
- add death dot for exploding lemmings and invalidate minimap if ground cleared
- fix failing GameResources test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840cd999520832d9a284a424808f79c