### PR TITLE
Add cheat mode tests

### DIFF
--- a/test/gameresources.test.js
+++ b/test/gameresources.test.js
@@ -109,7 +109,6 @@ describe('GameResources', function () {
     await gr.getCursorSprite();
     await gr.getMasks();
     assert.strictEqual(loadCount, 1);
-    assert.deepStrictEqual(partIndices, [0, 2, 6, 5, 1]);
     assert.deepStrictEqual(partIndices, [0, 2, 6, 1]);
   });
 });

--- a/test/gameskills.test.js
+++ b/test/gameskills.test.js
@@ -37,4 +37,25 @@ describe('GameSkills', function() {
     expect(gs.reuseSkill(Lemmings.SkillTypes.FLOATER)).to.be.false;
     expect(gs.getSkill(Lemmings.SkillTypes.FLOATER)).to.equal(0);
   });
+
+  it('ignores counts when cheat mode is enabled', function() {
+    const gs = createGameSkills({ BOMBER: 1 });
+    gs.cheatMode = true;
+    const before = gs.getSkill(Lemmings.SkillTypes.BOMBER);
+    expect(gs.canReuseSkill(Lemmings.SkillTypes.BOMBER)).to.be.true;
+    expect(gs.reuseSkill(Lemmings.SkillTypes.BOMBER)).to.be.true;
+    expect(gs.getSkill(Lemmings.SkillTypes.BOMBER)).to.equal(before);
+  });
+
+  it('cheat() sets all skills to Infinity', function() {
+    const gs = createGameSkills({});
+    const triggered = [];
+    gs.onCountChanged.on(idx => triggered.push(idx));
+    gs.cheat();
+    expect(gs.cheatMode).to.be.true;
+    for (let i = 0; i < gs.skills.length; i++) {
+      expect(gs.skills[i]).to.equal(Infinity);
+    }
+    expect(triggered).to.deep.equal([...Array(gs.skills.length).keys()]);
+  });
 });


### PR DESCRIPTION
## Summary
- fix part indices assertion for cursor sprite in GameResources test
- add tests verifying cheat mode logic for GameSkills

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6840cd98ace4832d96b27072200c5ced