### PR TITLE
Add death dot when lemming removed

### DIFF
--- a/js/LemmingManager.js
+++ b/js/LemmingManager.js
@@ -364,15 +364,14 @@ class LemmingManager extends Lemmings.BaseLogger {
               tooltipText: `removeOne ${lem.id}`
             },
             () => {
-              lem.remove();
-              this.gameVictoryCondition.removeOne();
+              this.removeOne(lem);
             }
           )();
           return;
         }
         const actionSystem = this.actions[stateType];
         if (!actionSystem) {
-          lem.remove();
+          this.removeOne(lem);
           this.logging.log(lem.id + ' Action: Error not an action: ' + Lemmings.LemmingStateType[stateType]);
           return;
         } else {
@@ -442,6 +441,15 @@ class LemmingManager extends Lemmings.BaseLogger {
 
   isNuking() { return this.nextNukingLemmingsIndex >= 0; }
   doNukeAllLemmings() { this.nextNukingLemmingsIndex = 0; }
+
+  removeOne(lem) {
+    if (this.miniMap &&
+            lem.action !== this.actions[Lemmings.LemmingStateType.EXITING]) {
+      this.miniMap.addDeath(lem.x, lem.y);
+    }
+    lem.remove();
+    this.gameVictoryCondition.removeOne();
+  }
 
   cycleSelection(dir = 1) {
     if (!this.lemmings?.length) return;


### PR DESCRIPTION
## Summary
- track death location when removing a lemming
- call new helper when lemming leaves the level

## Testing
- `npm test` *(fails: GameResources sprite helpers request the correct parts)*

------
https://chatgpt.com/codex/tasks/task_e_6840cd9b2364832db10bd235d6b30aa0