### PR TITLE
Fix GameResources cursor sprite index in tests

### DIFF
--- a/test/gameresources.test.js
+++ b/test/gameresources.test.js
@@ -100,6 +100,6 @@ describe('GameResources', function () {
     await gr.getCursorSprite();
     await gr.getMasks();
     assert.strictEqual(loadCount, 1);
-    assert.deepStrictEqual(partIndices, [0, 2, 6, 1]);
+    assert.deepStrictEqual(partIndices, [0, 2, 6, 5, 1]);
   });
 });


### PR DESCRIPTION
## Summary
- update expected `partIndices` for `getCursorSprite`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840ded35d8c832d84cf023887a90559