### PR TITLE
Implement hover highlight

### DIFF
--- a/js/DisplayImage.js
+++ b/js/DisplayImage.js
@@ -198,6 +198,18 @@ class DisplayImage extends Lemmings.BaseLogger {
     }
   }
 
+  /** Draw filled corner squares around a rectangle. */
+  drawCornerRect(x, y, size, r, g, b) {
+    const w = typeof size === 'object' ? size.width : size;
+    const h = typeof size === 'object' ? size.height : size;
+    const x2 = x + w - 2;
+    const y2 = y + h - 2;
+    this.drawRect(x, y, 2, 2, r, g, b, true);
+    this.drawRect(x2, y, 2, 2, r, g, b, true);
+    this.drawRect(x, y2, 2, 2, r, g, b, true);
+    this.drawRect(x2, y2, 2, 2, r, g, b, true);
+  }
+
   /* ---------- blitting helpers ---------- */
   /** Write sprite mask (white) */
   drawMask(mask, posX, posY) {

--- a/js/GameDisplay.js
+++ b/js/GameDisplay.js
@@ -42,9 +42,18 @@ class GameDisplay {
     if (!this.game.showDebug) {
       const sel = this.lemmingManager.getSelectedLemming();
       if (sel && !sel.removed) this.#drawSelection(sel);
-      if (this.hoverIndex >= 0 && this.hoverIndex !== this.lemmingManager.selectedIndex) {
-        const h = this.lemmingManager.getLemming(this.hoverIndex);
-        if (h && !h.removed) this.#drawHover(h);
+
+      if (this.hoverLemming && !this.hoverLemming.removed) {
+        const selected = this.hoverLemming.id === this.lemmingManager.selectedIndex;
+        const color = selected ? [255, 255, 255] : [64, 64, 64];
+        this.display.drawCornerRect(
+          this.hoverLemming.x - 5,
+          this.hoverLemming.y - 6,
+          { width: 10, height: 13 },
+          color[0],
+          color[1],
+          color[2]
+        );
       }
     }
   }
@@ -67,14 +76,14 @@ class GameDisplay {
   }
 
   #drawSelection(lem) {
-    const x1 = lem.x - 5;
-    const y1 = lem.y - 6;
-    const x2 = lem.x + 5 - 2;
-    const y2 = lem.y + 7 - 2;
-    this.#drawCorner(x1, y1, 255, 255, 255);
-    this.#drawCorner(x2, y1, 255, 255, 255);
-    this.#drawCorner(x1, y2, 255, 255, 255);
-    this.#drawCorner(x2, y2, 255, 255, 255);
+    this.display.drawCornerRect(
+      lem.x - 5,
+      lem.y - 6,
+      { width: 10, height: 13 },
+      255,
+      255,
+      255
+    );
   }
 
   #drawHover(lem) {

--- a/js/LemmingManager.js
+++ b/js/LemmingManager.js
@@ -294,7 +294,13 @@ class LemmingManager extends Lemmings.BaseLogger {
   }
 
   getSelectedLemming() {
-    return this.getLemming(this.selectedIndex);
+    const lem = this.getLemming(this.selectedIndex);
+    if (!lem || lem.removed || lem.disabled) return null;
+    return lem;
+  }
+
+  setSelectedLemming(lem) {
+    this.selectedIndex = lem?.id ?? -1;
   }
 
   getLemmings() {
@@ -452,18 +458,19 @@ class LemmingManager extends Lemmings.BaseLogger {
   }
 
   cycleSelection(dir = 1) {
-    if (!this.lemmings?.length) return;
+    if (!this.lemmings?.length) return null;
     const total = this.lemmings.length;
     let idx = this.selectedIndex;
     for (let i = 0; i < total; i++) {
       idx = (idx + dir + total) % total;
       const lem = this.lemmings[idx];
       if (!lem.removed && !lem.disabled) {
-        this.selectedIndex = idx;
-        return;
+        this.setSelectedLemming(lem);
+        return lem;
       }
     }
     this.selectedIndex = -1;
+    return null;
   }
 
   dispose() {


### PR DESCRIPTION
## Summary
- add `drawCornerRect` to DisplayImage for drawing corners automatically
- highlight hovered lemmings in GameDisplay using the new primitive
- track selection index in LemmingManager with helper methods

## Testing
- `npm test` *(fails: GameResources sprite helpers request the correct parts)*

------
https://chatgpt.com/codex/tasks/task_e_6840de2e5f68832d8d942fadfdb50828