### PR TITLE
Fix animation frame cleanup

### DIFF
--- a/js/KeyboardShortcuts.js
+++ b/js/KeyboardShortcuts.js
@@ -15,6 +15,10 @@ class KeyboardShortcuts {
   }
 
   dispose() {
+    if (this._raf) {
+      window.cancelAnimationFrame(this._raf);
+      this._raf = null;
+    }
     window.removeEventListener('keydown', this._down);
     window.removeEventListener('keyup', this._up);
   }


### PR DESCRIPTION
## Summary
- add cancelAnimationFrame in `KeyboardShortcuts.dispose`

## Testing
- `npm run format`
- `npm test` *(fails: GameResources sprite helpers request the correct parts)*

------
https://chatgpt.com/codex/tasks/task_e_6840ded1d1d0832d807c229f6357aa07