### PR TITLE
Implement snapped zoom handling

### DIFF
--- a/js/KeyboardShortcuts.js
+++ b/js/KeyboardShortcuts.js
@@ -82,7 +82,8 @@ class KeyboardShortcuts {
       this.zoom.v *= 0.9;
       const dz = this.zoom.v;
       if (Math.abs(dz) > 0.001) {
-        const newScale = Math.max(0.25, Math.min(4, vp.scale * (1 + dz / 1500)));
+        stage._rawScale = stage.limitValue(0.25, stage._rawScale * (1 + dz / 1500), 4);
+        const newScale = stage.snapScale(stage._rawScale);
         const nx = centerX - cx / newScale;
         const ny = centerY - cy / newScale;
         const maxX = img.display.getWidth()  - img.width  / newScale;
@@ -93,7 +94,8 @@ class KeyboardShortcuts {
         stage.redraw();
         again = true;
       } else if (this.zoom.reset !== null) {
-        vp.scale = this.zoom.reset;
+        stage._rawScale = this.zoom.reset;
+        vp.scale = stage.snapScale(stage._rawScale);
         this.zoom.reset = null;
         stage.redraw();
         this.zoom.v = 0;


### PR DESCRIPTION
## Summary
- ensure zoom levels align to pixel increments via `snapScale`
- maintain a separate `_rawScale` for mouse and keyboard zoom
- redraw the stage after snapping during keyboard zoom

## Testing
- `npm run format`
- `npm test` *(fails: GameResources sprite helpers request the correct parts)*

------
https://chatgpt.com/codex/tasks/task_e_6840de357b4c832d98f63346c65f1276