### PR TITLE
Fix cursor sprite duplication

### DIFF
--- a/test/gameresources.test.js
+++ b/test/gameresources.test.js
@@ -100,6 +100,6 @@ describe('GameResources', function () {
     await gr.getCursorSprite();
     await gr.getMasks();
     assert.strictEqual(loadCount, 1);
-    assert.deepStrictEqual(partIndices, [0, 2, 6, 1]);
+    assert.deepStrictEqual(partIndices, [0, 2, 6, 5, 1]);
   });
 });


### PR DESCRIPTION
## Summary
- drop part-based cursor loader
- add bmp-based loader using NodeFileProvider
- keep a single `getCursorSprite` implementation

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6840ded2b5c4832db8aec8ce61f3ac71