### PR TITLE
Update MiniMap viewport lines

### DIFF
--- a/.agentInfo/notes/game-view.md
+++ b/.agentInfo/notes/game-view.md
@@ -5,3 +5,6 @@ tags: game-view, setup, stage
 `GameView` orchestrates the page's startup sequence. Assigning to the `.gameCanvas` property constructs a new `Stage` bound to the HTML canvas element. Calling `setup()` uses `GameFactory` to read available configs and fills the level and group selectors. `start()` then acquires a `Game` instance, connects its displays via the stage, and begins play.
 
 During `Game.start()` the GUI's mini‑map is created when `GameGui.setMiniMap` runs, storing the map on `gameGui.miniMap`.
+
+`stage.getGameViewRect()` provides the current viewport bounds. `GameGui` feeds
+this rectangle to `MiniMap.render` so the map can draw an accurate view frame.

--- a/js/MiniMap.js
+++ b/js/MiniMap.js
@@ -250,8 +250,8 @@ class MiniMap {
       vpW -= 1;
     }
     const vpRectColor = 0xFFFFFFFF;
-    frame.drawRect(vpX, 0, 0, this.height - 1, vpRectColor, false, false);
-    frame.drawRect(vpX + vpW, 0, 0, this.height - 1, vpRectColor, false, false);
+    frame.drawRect(vpX, vpY, 0, vpH, vpRectColor, false, false);
+    frame.drawRect(vpX + vpW, vpY, 0, vpH, vpRectColor, false, false);
     if (vpH < this.height) {
       frame.drawRect(vpX, vpY, vpW, 0, vpRectColor, false, false);
       frame.drawRect(vpX, vpY + vpH, vpW, 0, vpRectColor, false, false);


### PR DESCRIPTION
## Summary
- adjust MiniMap to draw the viewport using scaled Y and height values
- note how GameView passes the stage viewport to the MiniMap

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840e7229058832d9cc36d244e0ae074