### PR TITLE
Update release rate lock overlay

### DIFF
--- a/.agentInfo/notes/game-gui.md
+++ b/.agentInfo/notes/game-gui.md
@@ -17,5 +17,7 @@ tags: gui, input
 ## Skill panel updates
 `render` refreshes the panel whenever flags like `gameTimeChanged` or `skillsCountChanged` are set. It draws remaining skill counts, highlights the selected skill via `drawSelection`, and applies grey stippling when a skill or release-rate button is unavailable. Hover states and the nuke confirmation are drawn every frame. The marching-ants offset increments in `_guiLoop` so the selection outline animates even while paused.
 
+When the release rate reaches its minimum or maximum, panels 0 and 1 show a stippled border rather than covering the digits. Once the lock is released the GUI refreshes the background so any leftover dots disappear.
+
 ## Mini-map synchronization
 `setMiniMap` stores a MiniMap instance and passes it to the lemming manager. During `render`, after updating the panel, `miniMap.render` is called with the current `level.screenPositionX` and display width so the map matches the view.

--- a/js/GameGui.js
+++ b/js/GameGui.js
@@ -47,6 +47,10 @@ class GameGui {
     this._hoverSpeedUp    = false;
     this._hoverSpeedDown  = false;
 
+    /* release rate lock state */
+    this._rrLockMin = false;
+    this._rrLockMax = false;
+
     this._guiBound = this._guiLoop.bind(this);
     this._guiRafId        = 0;
 
@@ -471,8 +475,18 @@ class GameGui {
     const rrMin = this.gameVictoryCondition.getMinReleaseRate?.() ?? 0;
     const rrMax = this.gameVictoryCondition.getMaxReleaseRate?.() ?? 99;
     const rrCur = this.gameVictoryCondition.getCurrentReleaseRate?.() ?? 0;
-    if (rrCur <= rrMin) d.drawStippleRect(0, 16, 16, 23, 160, 160, 160);
-    if (rrCur >= rrMax) d.drawStippleRect(16, 16, 16, 23, 160, 160, 160);
+
+    const lockMin = rrCur <= rrMin;
+    const lockMax = rrCur >= rrMax;
+
+    if (lockMin) this._drawLockEdge(d, 0);
+    if (lockMax) this._drawLockEdge(d, 1);
+
+    if (this._rrLockMin && !lockMin) this.backgroundChanged = true;
+    if (this._rrLockMax && !lockMax) this.backgroundChanged = true;
+
+    this._rrLockMin = lockMin;
+    this._rrLockMax = lockMax;
 
     if (this.miniMap) {
       const viewX = this.game.level.screenPositionX;
@@ -526,6 +540,17 @@ class GameGui {
   drawSkillHover(d, panelIdx, r = 255, g = 255, b = 0) {
     if (panelIdx < 0) return;
     d.drawRect(16 * panelIdx, 16, 16, 23, r, g, b);
+  }
+
+  _drawLockEdge(d, panelIdx) {
+    const x = 16 * panelIdx;
+    const y = 16;
+    const w = 15; // inclusive width for 16px panel
+    const h = 22; // inclusive height for 23px panel
+    d.drawStippleRect(x, y, w, 0, 160, 160, 160);       // top
+    d.drawStippleRect(x, y + h, w, 0, 160, 160, 160);    // bottom
+    d.drawStippleRect(x, y, 0, h, 160, 160, 160);        // left
+    d.drawStippleRect(x + w, y, 0, h, 160, 160, 160);    // right
   }
 
   drawSpeedChange(upDown, reset = false) {


### PR DESCRIPTION
## Summary
- refine visual lock for release rate controls
- refresh background when lock state lifts
- record the behaviour in game-gui notes

## Testing
- `npm run format`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6840e6cc88a8832dba2115a151520b3d