### PR TITLE
Auto select skill on load

### DIFF
--- a/.agentInfo/notes/game-gui.md
+++ b/.agentInfo/notes/game-gui.md
@@ -19,3 +19,6 @@ tags: gui, input
 
 ## Mini-map synchronization
 `setMiniMap` stores a MiniMap instance and passes it to the lemming manager. During `render`, after updating the panel, `miniMap.render` is called with the current `level.screenPositionX` and display width so the map matches the view.
+
+## Automatic skill selection
+`GameSkills.selectFirstAvailable` runs on level load so the panel highlights the first usable skill automatically.

--- a/js/GameSkills.js
+++ b/js/GameSkills.js
@@ -7,6 +7,8 @@ class GameSkills {
     this.onSelectionChanged = new Lemmings.EventHandler();
     this.skills = level.skills;
     this.cheatMode = false;
+    // automatically select a valid skill when a level loads
+    this.selectFirstAvailable();
   }
 
   selectFirstAvailable() {


### PR DESCRIPTION
## Summary
- pick first usable skill in `GameSkills` ctor
- document automatic skill selection in notes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840e6c531c8832d83772fd5f3a2d157