### PR TITLE
Fix Stage centering at low zoom

### DIFF
--- a/.agentInfo/notes/stage.md
+++ b/.agentInfo/notes/stage.md
@@ -5,3 +5,7 @@ tags: stage, canvas, input
 `js/Stage.js` creates a `Stage` bound to a canvas element. The constructor sets up a `UserInputManager` for that canvas and wires mouse handlers with helper methods like `handleOnMouseDown` and `handleOnDoubleClick`. Two `StageImageProperties` instances store layout and view information: `gameImgProps` for the gameplay area and `guiImgProps` for the GUI panel. The game display uses the default viewpoint scale while the GUI display starts with scale `2`.
 
 `getGameDisplay` and `getGuiDisplay` lazily construct `DisplayImage` objects, each backed by its associated `StageImageProperties`. New canvases for these displays are made through `createImage`. The `clear` method fills either the whole stage or a single section with black and `redraw` pulls image data from both displays before drawing them to the main canvas.
+
+When the game is zoomed out below scale `1` the level becomes smaller than the
+display area. `updateViewPoint` now checks for that condition and offsets the
+view point so the level remains centered in both directions.

--- a/js/Stage.js
+++ b/js/Stage.js
@@ -156,17 +156,25 @@ class Stage {
       this.draw(stageImage, gameImg);
     }
 
-    const xCeiling = Math.max(0, stageImage.viewPoint.x);
-    const xFloorLimit = stageImage.display.getWidth() - stageImage.width / stageImage.viewPoint.scale;
-    const xFloor = Math.min(xCeiling, xFloorLimit);
+    if (stageImage.viewPoint.scale < 1) {
+      const scale = stageImage.viewPoint.scale;
+      const wDiff = stageImage.width - stageImage.display.getWidth() * scale;
+      const hDiff = stageImage.height - stageImage.display.getHeight() * scale;
+      if (wDiff > 0) stageImage.viewPoint.x = -wDiff / (2 * scale);
+      if (hDiff > 0) stageImage.viewPoint.y = -hDiff / (2 * scale);
+    } else {
+      const xCeiling = Math.max(0, stageImage.viewPoint.x);
+      const xFloorLimit = stageImage.display.getWidth() - stageImage.width / stageImage.viewPoint.scale;
+      const xFloor = Math.min(xCeiling, xFloorLimit);
 
-    stageImage.viewPoint.x = xFloor;
+      stageImage.viewPoint.x = xFloor;
 
-    const yCeiling = Math.max(0, stageImage.viewPoint.y);
-    const yFloorLimit = stageImage.display.getHeight() - stageImage.height / stageImage.viewPoint.scale;
-    const yFloor = Math.min(yCeiling, yFloorLimit);
+      const yCeiling = Math.max(0, stageImage.viewPoint.y);
+      const yFloorLimit = stageImage.display.getHeight() - stageImage.height / stageImage.viewPoint.scale;
+      const yFloor = Math.min(yCeiling, yFloorLimit);
 
-    stageImage.viewPoint.y = yFloor;
+      stageImage.viewPoint.y = yFloor;
+    }
 
     // stageImage.viewPoint.x = this.limitValue(0, stageImage.viewPoint.x, stageImage.display.getWidth() - stageImage.width / stageImage.viewPoint.scale);
     // stageImage.viewPoint.y = this.limitValue(0, stageImage.display.getHeight() - stageImage.height / stageImage.viewPoint.scale, stageImage.viewPoint.y);


### PR DESCRIPTION
## Summary
- handle zooming out below scale 1 in `Stage.updateViewPoint`
- document centering behaviour in `.agentInfo`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840e6d4d73c832d87501d680161583f