### PR TITLE
Define groundMask variable in ActionBashSystem

### DIFF
--- a/js/ActionBashSystem.js
+++ b/js/ActionBashSystem.js
@@ -24,9 +24,13 @@ class ActionBashSystem extends ActionBaseSystem {
       }
       level.clearGroundWithMask(subMask, lem.x, lem.y);
     }
+    const groundMask = level.getGroundMaskLayer();
     /// check if end of solid?
     if (state == 5) {
-      if (this.findHorizontalSpace(groundMask, lem.x + (lem.lookRight ? 8 : -8), lem.y - 6, lem.lookRight) == 4) {
+      const offset = lem.lookRight ? 0 : 3;
+      const sliceX = lem.x + (lem.lookRight ? 8 : -8) - offset;
+      const slice = groundMask.getSubLayer(sliceX, lem.y - 6, 4, 1);
+      if (this.findHorizontalSpace(slice, offset, 0, lem.lookRight) == 4) {
         return Lemmings.LemmingStateType.WALKING;
       }
     }

--- a/js/SolidLayer.js
+++ b/js/SolidLayer.js
@@ -45,6 +45,31 @@ class SolidLayer extends Lemmings.BaseLogger {
   }
 
   /**
+     * Return a new SolidLayer representing a rectangular region of this mask.
+     * Out-of-bounds coordinates are treated as empty.
+     * @param {number} x - left coordinate of region
+     * @param {number} y - top coordinate of region
+     * @param {number} w - width of region
+     * @param {number} h - height of region
+     * @return {SolidLayer}
+     */
+  getSubLayer(x, y, w, h) {
+    const sub = new SolidLayer(w, h);
+    for (let dy = 0; dy < h; ++dy) {
+      const srcY = y + dy;
+      if (srcY < 0 || srcY >= this.height) continue;
+      const srcRow = srcY * this.width;
+      const dstRow = dy * w;
+      for (let dx = 0; dx < w; ++dx) {
+        const srcX = x + dx;
+        if (srcX < 0 || srcX >= this.width) continue;
+        sub.mask[dstRow + dx] = this.mask[srcRow + srcX];
+      }
+    }
+    return sub;
+  }
+
+  /**
      * Clear ground using a mask at a given map position.
      * @param {Mask} mask
      * @param {number} x - top-left X position in map where mask will be applied (includes mask.offsetX)


### PR DESCRIPTION
## Summary
- implement `SolidLayer.getSubLayer` for extracting rectangular mask regions
- use the sub mask slice when bashing to check nearby ground
- keep formatting and tests green

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6840e28d57e8832d824a8ab937603f19