### PR TITLE
Add pack mechanics defaults

### DIFF
--- a/.agentInfo/index.md
+++ b/.agentInfo/index.md
@@ -29,4 +29,5 @@ The root [AGENTS.md](../AGENTS.md) explains this tag-based note system.
 - **bit-writer**: [notes/bit-writer.md](notes/bit-writer.md)
 - **file-container**: [notes/file-container.md](notes/file-container.md)
 - **unpack-file-part**: [notes/unpack-file-part.md](notes/unpack-file-part.md)
+- **config, mechanics**: [notes/pack-mechanics.md](notes/pack-mechanics.md)
 - **todo, cleanup, code-review**: [notes/todo-review.md](notes/todo-review.md)

--- a/.agentInfo/notes/pack-mechanics.md
+++ b/.agentInfo/notes/pack-mechanics.md
@@ -1,0 +1,7 @@
+# Pack mechanics defaults
+
+tags: config, mechanics
+
+`packMechanics.js` enumerates glitch flag defaults for each level pack. When `ConfigReader` builds a `GameConfig`, it merges these values with any `mechanics` object present in `config.json`. The merged result is stored on `GameConfig.mechanics` so the game code can check feature flags regardless of the active pack.
+
+Each entry uses the pack's folder name (`lemmings`, `xmas92`, etc.) as the key. Flags are simple booleans and can be expanded in the future if new glitch options appear.

--- a/js/ConfigReader.js
+++ b/js/ConfigReader.js
@@ -1,5 +1,6 @@
 import { Lemmings } from './LemmingsNamespace.js';
 import './LogHandler.js';
+import { packMechanics } from './packMechanics.js';
 
 class ConfigReader extends Lemmings.BaseLogger {
   constructor(configFile) {
@@ -54,6 +55,9 @@ class ConfigReader extends Lemmings.BaseLogger {
       newConfig.level.order = configData['level.order'];
       newConfig.level.filePrefix = configData['level.filePrefix'];
       newConfig.level.groups = configData['level.groups'];
+      const defaults = packMechanics[newConfig.path] || {};
+      const overrides = configData.mechanics || {};
+      newConfig.mechanics = { ...defaults, ...overrides };
       gameConfigs.push(newConfig);
     }
     return gameConfigs;

--- a/js/GameConfig.js
+++ b/js/GameConfig.js
@@ -9,6 +9,8 @@ class GameConfig {
     /** unique GameType Name */
     this.gametype = Lemmings.GameTypes.UNKNOWN;
     this.level = new Lemmings.LevelConfig();
+    /** Glitch mechanic flags merged from pack defaults */
+    this.mechanics = {};
   }
 }
 Lemmings.GameConfig = GameConfig;

--- a/js/packMechanics.js
+++ b/js/packMechanics.js
@@ -1,0 +1,36 @@
+import { Lemmings } from './LemmingsNamespace.js';
+
+/**
+ * Default glitch mechanic flags for each level pack.
+ * These values can be overridden via config.json.
+ */
+export const packMechanics = {
+  lemmings: {
+    classicBuilder: true,
+    bomberAssist: false
+  },
+  lemmings_ohNo: {
+    classicBuilder: true,
+    bomberAssist: false
+  },
+  xmas91: {
+    classicBuilder: true,
+    bomberAssist: false
+  },
+  xmas92: {
+    classicBuilder: true,
+    bomberAssist: false
+  },
+  holiday93: {
+    classicBuilder: false,
+    bomberAssist: true
+  },
+  holiday94: {
+    classicBuilder: false,
+    bomberAssist: true
+  }
+};
+
+Lemmings.packMechanics = packMechanics;
+
+export default packMechanics;

--- a/test/configreader.test.js
+++ b/test/configreader.test.js
@@ -1,0 +1,50 @@
+import { expect } from 'chai';
+import { Lemmings } from '../js/LemmingsNamespace.js';
+import '../js/LogHandler.js';
+import '../js/GameConfig.js';
+import '../js/LevelConfig.js';
+import '../js/GameTypes.js';
+import { ConfigReader } from '../js/ConfigReader.js';
+import { packMechanics } from '../js/packMechanics.js';
+
+globalThis.lemmings = { game: { showDebug: false } };
+
+describe('ConfigReader mechanics merge', function () {
+  it('applies pack defaults to GameConfig', async function () {
+    const json = JSON.stringify([
+      {
+        name: 'lemmings',
+        path: 'lemmings',
+        gametype: 'LEMMINGS',
+        'level.filePrefix': 'LEVEL',
+        'level.groups': ['Fun'],
+        'level.useOddTable': false,
+        'level.order': [[0]]
+      }
+    ]);
+
+    const cr = new ConfigReader(Promise.resolve(json));
+    const cfg = await cr.getConfig(Lemmings.GameTypes.LEMMINGS);
+    expect(cfg.mechanics).to.eql(packMechanics.lemmings);
+  });
+
+  it('overrides defaults from config', async function () {
+    const json = JSON.stringify([
+      {
+        name: 'lemmings',
+        path: 'lemmings',
+        gametype: 'LEMMINGS',
+        mechanics: { bomberAssist: true },
+        'level.filePrefix': 'LEVEL',
+        'level.groups': ['Fun'],
+        'level.useOddTable': false,
+        'level.order': [[0]]
+      }
+    ]);
+
+    const cr = new ConfigReader(Promise.resolve(json));
+    const cfg = await cr.getConfig(Lemmings.GameTypes.LEMMINGS);
+    const expected = { ...packMechanics.lemmings, bomberAssist: true };
+    expect(cfg.mechanics).to.eql(expected);
+  });
+});


### PR DESCRIPTION
## Summary
- define `packMechanics` default glitch flags per pack
- store merged mechanic flags on `GameConfig`
- merge defaults in `ConfigReader`
- test that ConfigReader merges defaults correctly
- document mechanics defaults in `.agentInfo`

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6840e6454338832d9873d8c671e66750