### PR TITLE
Fix cursor rendering

### DIFF
--- a/.agentInfo/notes/game-resources.md
+++ b/.agentInfo/notes/game-resources.md
@@ -12,3 +12,5 @@ The holiday packs share some graphics files. For example the `xmas92` entry in
 `config.json` reuses `VGAGR0.DAT` from `xmas91`. Copying that file or pointing
 the config to `xmas91` avoids 404 errors when the loader requests missing
 assets.
+
+The cursor graphic from `MAIN.DAT` uses a 16×16 `PaletteImage`. A 17×17 size causes smearing at the edges.

--- a/js/GameResources.js
+++ b/js/GameResources.js
@@ -47,7 +47,7 @@ class GameResources extends Lemmings.BaseLogger {
     return new Promise((resolve) => {
       this.getMainDat().then((container) => {
         const fr = container.getPart(5);
-        const pimg = new Lemmings.PaletteImage(17, 17);
+        const pimg = new Lemmings.PaletteImage(16, 16);
         pimg.processImage(fr, 1);
         pimg.processTransparentByColorIndex(0);
         const pal = new Lemmings.ColorPalette();


### PR DESCRIPTION
## Summary
- size cursor sprite buffer at 16x16
- note cursor buffer detail in GameResources notes

## Testing
- `npm test`
- `node - <<'NODE' ...` to confirm cursor sprite is 16x16

------
https://chatgpt.com/codex/tasks/task_e_6840e9038574832d8da5f503ea09bcc5