### PR TITLE
Optimize MiniMap terrain rebuild

### DIFF
--- a/js/MiniMap.js
+++ b/js/MiniMap.js
@@ -111,16 +111,21 @@ class MiniMap {
   #buildTerrain() {
     this.terrain.fill(0);
     const gm = this.level.getGroundMaskLayer();
-    for (let y = 0; y < this.level.height; ++y) {
-      const mY = (y * this.scaleY) | 0;
-      const base = mY * this.width;
-      for (let x = 0; x < this.level.width; ++x) {
-        if (gm.hasGroundAt(x, y)) {
-          const mX = (x * this.scaleX) | 0;
-          const idx = base + mX;
-          if (this.terrain[idx] < 128) ++this.terrain[idx];
-          if (this.terrain[idx] > 71) this.terrain[idx] = 72;
+    for (let mY = 0; mY < this.height; ++mY) {
+      const ly1 = Math.floor(mY / this.scaleY);
+      const ly2 = Math.min(this.level.height, Math.ceil((mY + 1) / this.scaleY));
+      for (let mX = 0; mX < this.width; ++mX) {
+        const lx1 = Math.floor(mX / this.scaleX);
+        const lx2 = Math.min(this.level.width, Math.ceil((mX + 1) / this.scaleX));
+        const layer = gm.getSubLayer(lx1, ly1, lx2 - lx1, ly2 - ly1);
+        let count = 0;
+        for (const v of layer.mask) {
+          if (v) {
+            if (++count === 128) break;
+          }
         }
+        if (count > 71) count = 72;
+        this.terrain[mY * this.width + mX] = count;
       }
     }
   }
@@ -169,16 +174,14 @@ class MiniMap {
         const ly1 = Math.floor(mY / this.scaleY);
         const ly2 = Math.min(this.level.height, Math.ceil((mY + 1) / this.scaleY));
 
+        const layer = gm.getSubLayer(lx1, ly1, lx2 - lx1, ly2 - ly1);
         let count = 0;
-        for (let ly = ly1; ly < ly2; ++ly) {
-          for (let lx = lx1; lx < lx2; ++lx)
-            if (gm.hasGroundAt(lx, ly)) {
-              if (++count === 128) {
-                ly = ly2;
-                break;
-              }
-            }
+        for (const v of layer.mask) {
+          if (v) {
+            if (++count === 128) break;
+          }
         }
+        if (count > 71) count = 72;
         this.terrain[idx] = count;
       }
     }

--- a/test/minimap.test.js
+++ b/test/minimap.test.js
@@ -24,7 +24,22 @@ function createLevel(width, height) {
     height,
     data: new Uint8Array(width * height),
     hasGroundAt(x, y) { return this.data[y * this.width + x] !== 0; },
-    setGroundAt(x, y) { this.data[y * this.width + x] = 1; }
+    setGroundAt(x, y) { this.data[y * this.width + x] = 1; },
+    getSubLayer(x, y, w, h) {
+      const sub = { width: w, height: h, mask: new Uint8Array(w * h) };
+      for (let dy = 0; dy < h; ++dy) {
+        const sy = y + dy;
+        if (sy < 0 || sy >= this.height) continue;
+        const srcRow = sy * this.width;
+        const dstRow = dy * w;
+        for (let dx = 0; dx < w; ++dx) {
+          const sx = x + dx;
+          if (sx < 0 || sx >= this.width) continue;
+          sub.mask[dstRow + dx] = this.data[srcRow + sx];
+        }
+      }
+      return sub;
+    }
   };
   return {
     width,


### PR DESCRIPTION
## Summary
- speed up MiniMap building and invalidation
- use `SolidLayer.getSubLayer()` when recomputing terrain
- extend MiniMap tests with simple ground mask layer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840e9302178832d8da5251c24b547d1