### PR TITLE
Add running flag to GameTimer

### DIFF
--- a/.agentInfo/notes/game-gui.md
+++ b/.agentInfo/notes/game-gui.md
@@ -16,6 +16,7 @@ tags: gui, input
 
 ## Skill panel updates
 `render` refreshes the panel whenever flags like `gameTimeChanged` or `skillsCountChanged` are set. It draws remaining skill counts, highlights the selected skill via `drawSelection`, and applies grey stippling when a skill or release-rate button is unavailable. Hover states and the nuke confirmation are drawn every frame. The marching-ants offset increments in `_guiLoop` so the selection outline animates even while paused.
+- Pause border visibility now relies on `gameTimer.isRunning()` which reads a `#running` flag maintained by `GameTimer`.
 
 ## Mini-map synchronization
 `setMiniMap` stores a MiniMap instance and passes it to the lemming manager. During `render`, after updating the panel, `miniMap.render` is called with the current `level.screenPositionX` and display width so the map matches the view.

--- a/js/GameGui.js
+++ b/js/GameGui.js
@@ -88,7 +88,7 @@ class GameGui {
 
   _applyReleaseRateAuto() {
     if (!this.deltaReleaseRate) return;
-    if (this.gameTimer.isRunning?.()) {
+    if (this.gameTimer.isRunning()) {
       const min = this.gameVictoryCondition.getMinReleaseRate?.() ?? 0;
       const max = this.gameVictoryCondition.getMaxReleaseRate?.() ?? 99;
       const cur = this.gameVictoryCondition.getCurrentReleaseRate();
@@ -123,7 +123,7 @@ class GameGui {
         }
         return;
       }
-      if (this.gameTimer.isRunning?.()) {
+      if (this.gameTimer.isRunning()) {
         let neu = cur + step;
         if (neu < min) neu = min;
         if (neu > max) neu = max;
@@ -248,7 +248,7 @@ class GameGui {
     const rawIdx = e.y > 15 ? Math.trunc(e.x / 16) : -1;
     let idx = rawIdx;
 
-    if (!this.gameTimer.isRunning?.() && rawIdx !== 11) {
+    if (!this.gameTimer.isRunning() && rawIdx !== 11) {
       idx = -1;
     }
 
@@ -438,7 +438,7 @@ class GameGui {
       this.skillSelectionChanged = false;
     }
 
-    if (!this.gameTimer.isRunning?.()) {
+    if (!this.gameTimer.isRunning()) {
       this.drawPaused(d);
     }
     if (this.nukePrepared) {

--- a/js/GameTimer.js
+++ b/js/GameTimer.js
@@ -4,6 +4,7 @@ class GameTimer {
   #speedFactor;
   #frameTime;
   #rafId;
+  #running;
   #lastTime;
   #lastGameSecond;
   #tickIndex;
@@ -18,6 +19,7 @@ class GameTimer {
     this.#speedFactor = 1;
     this.#frameTime = this.TIME_PER_FRAME_MS;
     this.#rafId = 0;
+    this.#running = false;
     this.#lastTime = 0;
     this.#lastGameSecond = 0;
     this.#tickIndex = 0;
@@ -47,7 +49,7 @@ class GameTimer {
     this.#updateFrameTime();
   }
 
-  isRunning() { return this.#rafId !== 0; }
+  isRunning() { return this.#running; }
 
   get tickIndex() { return this.#tickIndex; }
   set tickIndex(v) {
@@ -93,6 +95,7 @@ class GameTimer {
   continue() {
     if (this.isRunning()) return;
     this.#lastTime = performance.now();
+    this.#running = true;
     this.#rafId = window.requestAnimationFrame(this.#loopBound);
   }
 
@@ -101,6 +104,7 @@ class GameTimer {
       window.cancelAnimationFrame(this.#rafId);
       this.#rafId = 0;
     }
+    this.#running = false;
   }
 
   #loop(now) {


### PR DESCRIPTION
## Summary
- track timer state with `#running`
- rely on `isRunning()` in GameGui to show pause border
- document flag usage in the game-gui note

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840e6c24e98832dad653c2d91eb8a96