### PR TITLE
Improve lemming highlight drawing

### DIFF
--- a/.agentInfo/notes/display-image.md
+++ b/.agentInfo/notes/display-image.md
@@ -7,3 +7,10 @@ tags: display, canvas
 The method `initSize(width, height)` (re)allocates this `ImageData` and buffer.  After allocating it calls `clear()` which fills the entire image with a color (default `0xFF00FF00`).  `setBackground()` copies an existing ground image into the buffer, handling both `Uint8ClampedArray` and `Uint32Array` sources and storing an optional mask for later use.
 
 `DisplayImage` exposes several event handlers – `onMouseDown`, `onMouseUp`, `onMouseRightDown`, `onMouseRightUp`, `onMouseMove` and `onDoubleClick`.  `Stage` forwards pointer events to these handlers so the rest of the engine can listen for input relative to the offscreen canvas.
+
+GameDisplay now draws hover and selection rectangles using `drawDashedRect` with
+`dashLen` 2. Hover uses a mid-dark grey (`0xFF555555`) while the selected
+lemming gets a bright green outline (`0xFF00FF00`). If the selected skill would
+be redundant (basher, blocker, digger or miner) the outline turns yellow
+(`0xFFFFFF00`). The rectangle sits three pixels higher than before so more of the
+lemming is visible.

--- a/js/GameDisplay.js
+++ b/js/GameDisplay.js
@@ -76,22 +76,36 @@ class GameDisplay {
   }
 
   #drawSelection(lem) {
-    this.display.drawCornerRect(
-      lem.x - 5,
-      lem.y - 6,
-      { width: 10, height: 13 },
-      255,
-      255,
-      255
-    );
+    const dashLen = 2;
+    const x = lem.x - 5;
+    const y = lem.y - 9; // slight upward offset
+
+    let color = 0xff00ff00; // bright green
+    const skills = this.game?.getGameSkills?.();
+    if (skills) {
+      const selectedSkill = skills.getSelectedSkill();
+      const redundant = {
+        [Lemmings.SkillTypes.BASHER]: Lemmings.ActionBashSystem,
+        [Lemmings.SkillTypes.BLOCKER]: Lemmings.ActionBlockerSystem,
+        [Lemmings.SkillTypes.DIGGER]: Lemmings.ActionDiggSystem,
+        [Lemmings.SkillTypes.MINER]: Lemmings.ActionMineSystem
+      };
+      const ActionClass = redundant[selectedSkill];
+      if (ActionClass && lem.action instanceof ActionClass) {
+        color = 0xffffff00; // yellow tint for redundant action
+      }
+    }
+
+    this.display.drawDashedRect(x, y, 10, 13, dashLen, 0, color, 0xff000000);
   }
 
   #drawHover(lem) {
-    const x1 = lem.x - 5;
-    const y1 = lem.y - 6;
-    const width = 10;
-    const height = 13;
-    this.display.drawRect(x1, y1, width, height, 64, 64, 64);
+    const dashLen = 2;
+    const x = lem.x - 5;
+    const y = lem.y - 9; // slight upward offset
+    const color = 0xff555555; // mid-dark gray
+
+    this.display.drawDashedRect(x, y, 10, 13, dashLen, 0, color, 0xff000000);
   }
 
   dispose() {


### PR DESCRIPTION
## Summary
- show hover and selection outlines using drawDashedRect
- note new colours and dash length in display-image notes

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840e72b2edc832d94915548e4e5a43a