### PR TITLE
Fix game type selection

### DIFF
--- a/js/GameView.js
+++ b/js/GameView.js
@@ -353,6 +353,10 @@ class GameView extends Lemmings.BaseLogger {
   }
   /** switch the selected game type */
   async selectGameType(newGameType) {
+    // dropdown values correspond to config array indices
+    if (this.configs && this.configs[newGameType]) {
+      newGameType = this.configs[newGameType].gametype;
+    }
     this.gameType = newGameType;
     this.levelGroupIndex = 0;
     this.levelIndex = 0;

--- a/test/configreader.test.js
+++ b/test/configreader.test.js
@@ -21,9 +21,14 @@ describe('ConfigReader', function () {
     const cfg = await reader.getConfig(Lemmings.GameTypes.LEMMINGS);
     expect(cfg.mechanics).to.deep.equal({ fallDistance: 50 });
 
-    const cr = new ConfigReader(Promise.resolve(json));
-    const cfg = await cr.getConfig(Lemmings.GameTypes.LEMMINGS);
-    expect(cfg.mechanics).to.eql(packMechanics.lemmings);
+    const jsonDefault = `[
+      { "name": "t", "path": "lemmings", "gametype": "LEMMINGS",
+        "level.filePrefix": "LEVEL", "level.groups": ["Fun"],
+        "level.order": [[0]], "level.useOddTable": false }
+    ]`;
+    const cr = new ConfigReader(Promise.resolve(jsonDefault));
+    const cfgDefault = await cr.getConfig(Lemmings.GameTypes.LEMMINGS);
+    expect(cfgDefault.mechanics).to.eql(packMechanics.lemmings);
   });
 
   it('overrides defaults from config', async function () {


### PR DESCRIPTION
## Summary
- fix dropdown handling so selecting index 0 resolves to proper game type
- fix lint issue in config reader test

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6840eaeaf948832d8fac44c251ee87bb