### PR TITLE
Enhance GUI features and sprite tooling

### DIFF
--- a/js/GameGui.js
+++ b/js/GameGui.js
@@ -366,6 +366,14 @@ class GameGui {
       this.gameTimeChanged = false;
             
       if (lemmings.bench == false) {
+        const sel = this.skills.getSelectedSkill();
+        if (sel !== Lemmings.SkillTypes.UNKNOWN) {
+          const key = Object.keys(Lemmings.SkillTypes)[sel];
+          if (key) {
+            const name = key.charAt(0) + key.slice(1).toLowerCase();
+            this.drawGreenString(d, name, 0, 0);
+          }
+        }
         this.drawGreenString(d, 'Time ' + this.gameTimer.getGameLeftTimeString() + '-00', 248, 0);
         const outCount = this.gameVictoryCondition.getOutCount();
         if (outCount >= 0) {
@@ -447,13 +455,12 @@ class GameGui {
     }
     if (this.nukePrepared) {
       this.drawNukeConfirm(d);
+      this.drawNukeHover(d);
     }
 
     if (this._hoverPanelIdx >= 0) {
-      if (this._hoverPanelIdx === 11 && this.nukePrepared) {
-        this.drawNukeHover(d);
-      } else if (this._hoverPanelIdx === 11) {
-        this.drawSkillHover(d, this._hoverPanelIdx, 255, 128, 0);
+      if (this._hoverPanelIdx === 11) {
+        if (!this.nukePrepared) this.drawSkillHover(d, this._hoverPanelIdx, 255, 128, 0);
       } else {
         this.drawSkillHover(d, this._hoverPanelIdx);
       }
@@ -543,10 +550,10 @@ class GameGui {
   }
 
   _drawLockEdge(d, panelIdx) {
-    const x = 16 * panelIdx;
-    const y = 16;
-    const w = 15; // inclusive width for 16px panel
-    const h = 22; // inclusive height for 23px panel
+    const x = 16 * panelIdx + 2;
+    const y = 18;
+    const w = 11; // narrower than full panel
+    const h = 18; // shorter than full panel
     d.drawStippleRect(x, y, w, 0, 160, 160, 160);       // top
     d.drawStippleRect(x, y + h, w, 0, 160, 160, 160);    // bottom
     d.drawStippleRect(x, y, 0, h, 160, 160, 160);        // left
@@ -589,7 +596,7 @@ class GameGui {
       16,
       23,
       this.selectionDashLen,
-      this._selectionOffset,
+      this._selectionOffset * 2,
       0xFF0080FF,
       0xFF00FFFF
     );

--- a/js/Stage.js
+++ b/js/Stage.js
@@ -161,7 +161,11 @@ class Stage {
       const wDiff = stageImage.width - stageImage.display.getWidth() * scale;
       const hDiff = stageImage.height - stageImage.display.getHeight() * scale;
       if (wDiff > 0) stageImage.viewPoint.x = -wDiff / (2 * scale);
-      if (hDiff > 0) stageImage.viewPoint.y = -hDiff / (2 * scale);
+      if (hDiff > 0) {
+        stageImage.viewPoint.y = stageImage.height - stageImage.display.getHeight() / scale;
+      } else {
+        stageImage.viewPoint.y = 0;
+      }
     } else {
       const xCeiling = Math.max(0, stageImage.viewPoint.x);
       const xFloorLimit = stageImage.display.getWidth() - stageImage.width / stageImage.viewPoint.scale;

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "export-all-packs": "node tools/exportAllPacks.js",
     "clean-exports": "node tools/cleanExports.js",
     "list-sprites": "node tools/listSprites.js",
+    "scan-panel-green": "node tools/scanGreenPanel.js",
     "patch-sprites": "node tools/patchSprites.js",
     "pack-levels": "node tools/packLevels.js",
     "format": "eslint . --fix",

--- a/tools/scanGreenPanel.js
+++ b/tools/scanGreenPanel.js
@@ -1,0 +1,57 @@
+import { Lemmings } from '../js/LemmingsNamespace.js';
+import '../js/LemmingsBootstrap.js';
+import { NodeFileProvider } from './NodeFileProvider.js';
+import fs from 'fs';
+import path from 'path';
+import { PNG } from 'pngjs';
+
+function loadDefaultPack() {
+  try {
+    const cfgPath = path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'config.json');
+    const txt = fs.readFileSync(cfgPath, 'utf8');
+    const cfg = JSON.parse(txt);
+    return cfg[0]?.path || 'lemmings';
+  } catch {
+    return 'lemmings';
+  }
+}
+
+(async () => {
+  const pack = process.argv[2] || loadDefaultPack();
+  const outDir = process.argv[3] || path.join('exports', 'panel_green_map');
+  const provider = new NodeFileProvider('.');
+  const pal = new Lemmings.ColorPalette();
+  const res = new Lemmings.GameResources(provider, { path: pack, level: { groups: [] }});
+  const sprites = await res.getSkillPanelSprite(pal);
+  const panel = sprites.getPanelSprite();
+  const w = Math.min(40, panel.width);
+  const h = Math.min(40, panel.height);
+  const png = new PNG({ width: w, height: h });
+
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      const idx = y * panel.width + x;
+      const col = panel.data[idx];
+      const r = col & 0xFF;
+      const g = (col >> 8) & 0xFF;
+      const b = (col >> 16) & 0xFF;
+      const o = (y * w + x) * 4;
+      if (g > r && g > b) {
+        // mark green as blue
+        png.data[o] = 0;
+        png.data[o + 1] = 0;
+        png.data[o + 2] = 255;
+        png.data[o + 3] = 255;
+      } else {
+        png.data[o] = r;
+        png.data[o + 1] = g;
+        png.data[o + 2] = b;
+        png.data[o + 3] = (col >> 24) & 0xFF;
+      }
+    }
+  }
+
+  fs.mkdirSync(outDir, { recursive: true });
+  const outPath = path.join(outDir, 'green_map.png');
+  png.pack().pipe(fs.createWriteStream(outPath));
+})();


### PR DESCRIPTION
## Summary
- show current skill name beside the stats
- keep nuke confirmation visible and animate ants faster
- shrink lock window on release rate buttons
- fix bottom alignment when zooming out
- add tool for mapping green pixels in panel sprite

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840ecc54ba4832db8c2bc2f6aaf1c5d