### PR TITLE
Update layout to scale canvas with screen width

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,21 +73,23 @@
 
     function setSize() {
       const ratio = 800 / 480;
-      const gameContainer = jQuery(".game_container");
       const width = window.innerWidth;
-      const height = window.innerHeight;
-      if (width >= height * ratio) {
-        gameContainer.width(height * ratio);
-        gameContainer.height(height);
-        gameContainer.css("margin-top", "");
-        gameContainer.css("margin-left", (width - height * ratio) / 2);
-        gameContainer.removeClass("small");
-      } else {
-        gameContainer.width(width);
-        gameContainer.height(width / ratio);
-        gameContainer.css("margin-top", (height - width / ratio) / 2);
-        gameContainer.css("margin-left", "");
-        gameContainer.addClass("small");
+      const height = width / ratio;
+      const gameContainer = jQuery(".game_container");
+      gameContainer.width(width);
+      gameContainer.height(height);
+      gameContainer.css("margin-left", "");
+      gameContainer.css("margin-top", (window.innerHeight - height) / 2);
+      gameContainer.removeClass("small");
+
+      const canvas = document.getElementById("gameCanvas");
+      if (canvas) {
+        canvas.width = width;
+        canvas.height = height;
+      }
+
+      if (window.lemmings && window.lemmings.stage) {
+        window.lemmings.stage.updateStageSize();
       }
     }
 

--- a/index.html
+++ b/index.html
@@ -73,19 +73,32 @@
 
     function setSize() {
       const ratio = 800 / 480;
-      const width = window.innerWidth;
-      const height = width / ratio;
       const gameContainer = jQuery(".game_container");
-      gameContainer.width(width);
-      gameContainer.height(height);
-      gameContainer.css("margin-left", "");
-      gameContainer.css("margin-top", (window.innerHeight - height) / 2);
-      gameContainer.removeClass("small");
+      const width = window.innerWidth;
+      const height = window.innerHeight;
+      let containerWidth, containerHeight;
+
+      if (width >= height * ratio) {
+        containerWidth = height * ratio;
+        containerHeight = height;
+        gameContainer.css("margin-top", "");
+        gameContainer.css("margin-left", (width - containerWidth) / 2);
+        gameContainer.removeClass("small");
+      } else {
+        containerWidth = width;
+        containerHeight = width / ratio;
+        gameContainer.css("margin-top", (height - containerHeight) / 2);
+        gameContainer.css("margin-left", "");
+        gameContainer.addClass("small");
+      }
+
+      gameContainer.width(containerWidth);
+      gameContainer.height(containerHeight);
 
       const canvas = document.getElementById("gameCanvas");
       if (canvas) {
-        canvas.width = width;
-        canvas.height = height;
+        canvas.width = containerWidth;
+        canvas.height = containerHeight;
       }
 
       if (window.lemmings && window.lemmings.stage) {

--- a/js/Stage.js
+++ b/js/Stage.js
@@ -212,6 +212,10 @@ class Stage {
     this.guiImgProps.y = stageHeight - 100;
     this.guiImgProps.height = 100;
     this.guiImgProps.width = stageWidth;
+    if (this.gameImgProps.display) {
+      this.setGameViewPointPosition(this.gameImgProps.viewPoint.x, 0);
+      this.redraw();
+    }
   }
   getStageImageAt(x, y) {
     if (this.isPositionInStageImage(this.gameImgProps, x, y))
@@ -245,7 +249,10 @@ class Stage {
       this._rawScale = lemmings.scale;
       this.gameImgProps.viewPoint.scale = this.snapScale(this._rawScale);
       this.gameImgProps.viewPoint.x = x;
-      this.gameImgProps.viewPoint.y = this.gameImgProps.display.getHeight() - this.gameImgProps.height / this.gameImgProps.viewPoint.scale;
+      const displayHeight = this.gameImgProps.display.getHeight();
+      const gameHeight = this.gameImgProps.height;
+      const scale = this.gameImgProps.viewPoint.scale;
+      this.gameImgProps.viewPoint.y = Math.max(0, displayHeight - gameHeight / scale);
       this.redraw();
       return;
     }
@@ -254,7 +261,10 @@ class Stage {
     if (scale == 2) {
       this._rawScale = this.gameImgProps.viewPoint.scale;
       this.gameImgProps.viewPoint.x = x;
-      this.gameImgProps.viewPoint.y = this.gameImgProps.display.getHeight() - this.gameImgProps.height / this.gameImgProps.viewPoint.scale;
+      const displayHeight = this.gameImgProps.display.getHeight();
+      const gameHeight = this.gameImgProps.height;
+      const newScale = this.gameImgProps.viewPoint.scale;
+      this.gameImgProps.viewPoint.y = Math.max(0, displayHeight - gameHeight / newScale);
       this.redraw();
       return;
     } else {


### PR DESCRIPTION
## Summary
- adjust `setSize` in `index.html` to resize the canvas and game container
- update canvas dimensions on window resize to use the full screen width
- keep stage layout in sync via `updateStageSize`

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6840edfe457c832d8a2dd8a222f1e049