### PR TITLE
Add marching ants support to Frame and MiniMap

### DIFF
--- a/js/Frame.js
+++ b/js/Frame.js
@@ -86,6 +86,30 @@ class Frame {
     }
   }
 
+  drawMarchingAntRect(
+    x,
+    y,
+    width,
+    height,
+    dashLen = 1,
+    offset = 0,
+    color1 = 0xFFFFFFFF,
+    color2 = 0xFF000000
+  ) {
+    const pattern = dashLen * 2;
+    let pos = ((offset % pattern) + pattern) % pattern;
+    const set = (px, py) => {
+      const useFirst = Math.floor(pos / dashLen) % 2 === 0;
+      this.setPixel(px, py, useFirst ? color1 : color2);
+      pos = (pos + 1) % pattern;
+    };
+
+    for (let dx = 0; dx <= width; dx++) set(x + dx, y);
+    for (let dy = 1; dy <= height; dy++) set(x + width, y + dy);
+    for (let dx = 1; dx <= width; dx++) set(x + width - dx, y + height);
+    for (let dy = 1; dy < height; dy++) set(x, y + height - dy);
+  }
+
   setPixel (x, y, color, noOverwrite = false, onlyOverwrite = false) {
     if ((x >>> 0) >= this.width || (y >>> 0) >= this.height) return;
     const idx = (y * this.width + x) >>> 0;

--- a/js/MiniMap.js
+++ b/js/MiniMap.js
@@ -32,16 +32,19 @@ class MiniMap {
     // render target (drawn into the GUI canvas once per frame)
     this.frame = new Lemmings.Frame(this.width, this.height);
     //this.renderFrame = new Lemmings.Frame(this.renderWidth, this.renderHeight);
-        
+
     if (!MiniMap.palette) {
       MiniMap.palette = new Uint32Array(129);
       for (let i = 1; i <= 128; ++i) {
         MiniMap.palette[i] = 0xFF000000 | ((i*2) << 8);
       }
     }
-        
+
     this._displayListeners = null;
     this._mouseDown = false;
+    this.viewportDashOffset = 0;
+    this._viewportCounter = 0;
+    this.viewportDashDelay = 20;
     if (this.guiDisplay) this.#hookPointer();
   }
 
@@ -224,6 +227,11 @@ class MiniMap {
   render() {
     if (!this.guiDisplay) return;
 
+    if (++this._viewportCounter >= this.viewportDashDelay) {
+      this._viewportCounter = 0;
+      this.viewportDashOffset += 1;
+    }
+
     const {
       width: W,
       height: H,
@@ -252,13 +260,16 @@ class MiniMap {
     if (vpXW == this.width) {
       vpW -= 1;
     }
-    const vpRectColor = 0xFFFFFFFF;
-    frame.drawRect(vpX, vpY, 0, vpH, vpRectColor, false, false);
-    frame.drawRect(vpX + vpW, vpY, 0, vpH, vpRectColor, false, false);
-    if (vpH < this.height) {
-      frame.drawRect(vpX, vpY, vpW, 0, vpRectColor, false, false);
-      frame.drawRect(vpX, vpY + vpH, vpW, 0, vpRectColor, false, false);
-    }
+    frame.drawMarchingAntRect(
+      vpX,
+      vpY,
+      vpW,
+      vpH,
+      1,
+      this.viewportDashOffset,
+      0xFF00FF00,
+      0xFF005500
+    );
 
     /* Entrances / Exits */
     for (const obj of this.level.objects) {

--- a/test/minimap.test.js
+++ b/test/minimap.test.js
@@ -98,6 +98,6 @@ describe('MiniMap', function() {
 
     mm.render();
     const vp = (expected * mm.scaleX) | 0;
-    expect(mm.frame.data[vp]).to.equal(0xFFFFFFFF);
+    expect(mm.frame.data[vp]).to.equal(0xFF00FF00);
   });
 });


### PR DESCRIPTION
## Summary
- add `drawMarchingAntRect` helper in `Frame`
- animate viewport outline in `MiniMap` using marching ants
- update test for new viewport color

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840ee9eac74832d94c141d265c79d14