### PR TITLE
Add Stage and GameResult tests

### DIFF
--- a/.agentInfo/index.md
+++ b/.agentInfo/index.md
@@ -34,3 +34,4 @@ The root [AGENTS.md](../AGENTS.md) explains this tag-based note system.
 - **config, mechanics**: [notes/pack-mechanics.md](notes/pack-mechanics.md)
 - **todo, cleanup, code-review**: [notes/todo-review.md](notes/todo-review.md)
 - **keyboard, input, game-view**: [notes/keyboard-shortcuts.md](notes/keyboard-shortcuts.md)
+- **tests, stage, gameresult**: [notes/test-coverage.md](notes/test-coverage.md)

--- a/.agentInfo/notes/test-coverage.md
+++ b/.agentInfo/notes/test-coverage.md
@@ -1,0 +1,5 @@
+# Test coverage note
+
+tags: tests, stage, gameresult
+
+New tests cover `StageImageProperties.createImage`, zoomed pointer event handling in `Stage`, and the `GameResult` data container.

--- a/test/gameresult.test.js
+++ b/test/gameresult.test.js
@@ -1,0 +1,26 @@
+import { expect } from 'chai';
+import { Lemmings } from '../js/LemmingsNamespace.js';
+import '../js/GameResult.js';
+
+describe('GameResult', function() {
+  it('captures game state and stats', function() {
+    const mockGame = {
+      getGameState() { return 'state'; },
+      getCommandManager() { return { serialize() { return 'replay'; } }; },
+      getVictoryCondition() {
+        return {
+          getSurvivorPercentage() { return 75; },
+          getSurvivorsCount() { return 10; }
+        };
+      },
+      getGameTimer() { return { getGameTicks() { return 1234; } }; }
+    };
+
+    const result = new Lemmings.GameResult(mockGame);
+    expect(result.state).to.equal('state');
+    expect(result.replay).to.equal('replay');
+    expect(result.survivorPercentage).to.equal(75);
+    expect(result.survivors).to.equal(10);
+    expect(result.duration).to.equal(1234);
+  });
+});

--- a/test/stage.test.js
+++ b/test/stage.test.js
@@ -85,4 +85,24 @@ describe('Stage pointer events', function() {
     expect(events[0][1].x).to.equal(55);
     expect(events[0][1].y).to.equal(55);
   });
+
+  it('forwards coordinates when zoomed', function() {
+    const canvas = createStubCanvas();
+    const stage = new Stage(canvas);
+    stage.clear = () => {};
+    stage.draw = () => {};
+
+    const display = stage.getGameDisplay();
+    stage.gameImgProps.viewPoint.scale = 0.5;
+    stage.gameImgProps.viewPoint.x = 10;
+    stage.gameImgProps.viewPoint.y = 20;
+
+    let pos = null;
+    display.onMouseDown.on(p => { pos = p; });
+
+    stage.controller.handleMouseDown(new Lemmings.Position2D(30, 40));
+
+    expect(pos.x).to.equal(70);
+    expect(pos.y).to.equal(100);
+  });
 });

--- a/test/stageimageprops.test.js
+++ b/test/stageimageprops.test.js
@@ -1,0 +1,45 @@
+import { expect } from 'chai';
+import { Lemmings } from '../js/LemmingsNamespace.js';
+import '../js/ViewPoint.js';
+import { StageImageProperties } from '../js/StageImageProperties.js';
+
+function createDocumentStub() {
+  return {
+    createElement() {
+      const ctx = {
+        canvas: {},
+        fillRect() {},
+        drawImage() {},
+        putImageData() {},
+        createImageData(w, h) {
+          return { width: w, height: h, data: new Uint8ClampedArray(w * h * 4) };
+        }
+      };
+      return {
+        width: 0,
+        height: 0,
+        getContext() { ctx.canvas = this; return ctx; }
+      };
+    }
+  };
+}
+
+describe('StageImageProperties', function() {
+  before(function() {
+    globalThis.lemmings = { game: { showDebug: false } };
+    global.document = createDocumentStub();
+  });
+
+  after(function() {
+    delete global.document;
+    delete globalThis.lemmings;
+  });
+
+  it('createImage returns ImageData of requested size', function() {
+    const props = new StageImageProperties();
+    const img = props.createImage(5, 7);
+    expect(img.width).to.equal(5);
+    expect(img.height).to.equal(7);
+    expect(img.data).to.have.lengthOf(5 * 7 * 4);
+  });
+});


### PR DESCRIPTION
## Summary
- expand coverage with StageImageProperties tests
- verify pointer coordinates while zoomed
- cover GameResult field extraction
- document additional coverage note

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840ee7bebe8832da84860f702fd7d6e