### PR TITLE
Expand GameTimer tests

### DIFF
--- a/.agentInfo/index.md
+++ b/.agentInfo/index.md
@@ -34,3 +34,4 @@ The root [AGENTS.md](../AGENTS.md) explains this tag-based note system.
 - **config, mechanics**: [notes/pack-mechanics.md](notes/pack-mechanics.md)
 - **todo, cleanup, code-review**: [notes/todo-review.md](notes/todo-review.md)
 - **keyboard, input, game-view**: [notes/keyboard-shortcuts.md](notes/keyboard-shortcuts.md)
+- **tests, gametimer**: [notes/test-coverage.md](notes/test-coverage.md)

--- a/.agentInfo/notes/test-coverage.md
+++ b/.agentInfo/notes/test-coverage.md
@@ -1,0 +1,8 @@
+# GameTimer test coverage
+
+tags: tests, gametimer
+
+Additional tests validate that `GameTimer` pauses automatically when the
+`visibilitychange` event reports a hidden document and resumes once visible
+again. They also verify the private speed adjustment logic through bench and
+catch-up modes by driving the timer with `fakeTimers`.


### PR DESCRIPTION
## Summary
- cover GameTimer visibility handling
- verify benchSpeedAdjust and catchupSpeedAdjust logic
- record coverage note

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840ee7de5e4832d83c88c56fefc68f3