### PR TITLE
Add GroundReader and VGASpecReader tests

### DIFF
--- a/.agentInfo/index.md
+++ b/.agentInfo/index.md
@@ -34,3 +34,4 @@ The root [AGENTS.md](../AGENTS.md) explains this tag-based note system.
 - **config, mechanics**: [notes/pack-mechanics.md](notes/pack-mechanics.md)
 - **todo, cleanup, code-review**: [notes/todo-review.md](notes/todo-review.md)
 - **keyboard, input, game-view**: [notes/keyboard-shortcuts.md](notes/keyboard-shortcuts.md)
+- **tests, groundreader, vgaspec**: [notes/test-coverage.md](notes/test-coverage.md)

--- a/.agentInfo/notes/test-coverage.md
+++ b/.agentInfo/notes/test-coverage.md
@@ -1,0 +1,7 @@
+# Test coverage note
+
+tags: tests, groundreader, vgaspec
+
+Added unit tests for `GroundReader` and `VGASpecReader` covering palette parsing,
+steel detection and basic RLE decoding. This increases confidence in the binary
+parsers for ground data and VGASPEC levels.

--- a/test/groundreader.test.js
+++ b/test/groundreader.test.js
@@ -1,0 +1,64 @@
+import { expect } from 'chai';
+import { Lemmings } from '../js/LemmingsNamespace.js';
+import { BinaryReader } from '../js/BinaryReader.js';
+import '../js/BitReader.js';
+import '../js/BitWriter.js';
+import '../js/PaletteImage.js';
+import '../js/Frame.js';
+import '../js/ColorPalette.js';
+import { GroundReader } from '../js/GroundReader.js';
+
+// Silence debug output
+globalThis.lemmings = { game: { showDebug: false } };
+
+describe('GroundReader', function() {
+  it('reads palettes and detects steel', async function() {
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = async () => ({ json: async () => ({ lemmings: { 'GROUND0O.DAT': [0] } }) });
+    await Lemmings.loadSteelSprites();
+    globalThis.fetch = origFetch;
+
+    const buf = new Uint8Array(1056);
+    // object0 width/height
+    buf[4] = 1; buf[5] = 1; // width, height
+    buf[6] = 0; buf[7] = 5; // frameDataSize
+    buf[9] = 4; // maskLoc low (delta 4)
+    // terrain0 at offset 448
+    const tOff = 28 * 16;
+    buf[tOff] = 1; buf[tOff + 1] = 1; // width, height
+    buf[tOff + 5] = 3; // maskLoc low (delta 3)
+
+    // palette section
+    const pal = 960 + 24; // skip EGA
+    for (let i = 0; i < 8; i++) {
+      buf[pal + i * 3] = 1 + i;
+      buf[pal + i * 3 + 1] = 2 + i;
+      buf[pal + i * 3 + 2] = 3 + i;
+    }
+    const cp = pal + 24;
+    for (let i = 0; i < 8; i++) {
+      buf[cp + i * 3] = 10 + i;
+      buf[cp + i * 3 + 1] = 20 + i;
+      buf[cp + i * 3 + 2] = 30 + i;
+    }
+    const prev = cp + 24;
+    for (let i = 0; i < 8; i++) {
+      buf[prev + i * 3] = 40 + i;
+      buf[prev + i * 3 + 1] = 50 + i;
+      buf[prev + i * 3 + 2] = 60 + i;
+    }
+
+    const ground = new BinaryReader(buf, 0, buf.length, 'GROUND0O.DAT', 'lemmings');
+    const vgaT = new BinaryReader(new Uint8Array([0, 0, 0, 0]));
+    const vgaO = new BinaryReader(new Uint8Array([0, 0, 0, 0, 0]));
+    const gr = new GroundReader(ground, vgaT, vgaO);
+
+    expect(gr.groundPalette.getR(0)).to.equal(4);
+    expect(gr.groundPalette.getG(0)).to.equal(8);
+    expect(gr.groundPalette.getB(0)).to.equal(12);
+    expect(gr.colorPalette.getR(8)).to.equal(160);
+    expect(gr.colorPalette.getG(8)).to.equal(200);
+    expect(gr.colorPalette.getB(8)).to.equal(240);
+    expect(gr.imgTerrain[0].isSteel).to.equal(true);
+  });
+});

--- a/test/vgaspecreader.test.js
+++ b/test/vgaspecreader.test.js
@@ -1,0 +1,54 @@
+import { expect } from 'chai';
+import { Lemmings } from '../js/LemmingsNamespace.js';
+import { BinaryReader } from '../js/BinaryReader.js';
+import '../js/BitReader.js';
+import '../js/BitWriter.js';
+import '../js/PackFilePart.js';
+import '../js/UnpackFilePart.js';
+import '../js/FileContainer.js';
+import '../js/PaletteImage.js';
+import '../js/Frame.js';
+import '../js/ColorPalette.js';
+import { VGASpecReader } from '../js/VGASpecReader.js';
+
+globalThis.lemmings = { game: { showDebug: false } };
+
+describe('VGASpecReader', function() {
+  it('decodes image and palettes', function() {
+    const part = new Uint8Array(24 + 16 + 3);
+    for (let i = 0; i < 8; i++) {
+      part[i * 3] = 1 + i;
+      part[i * 3 + 1] = 2 + i;
+      part[i * 3 + 2] = 3 + i;
+    }
+    let pos = 24 + 16;
+    part[pos++] = 0x00; // copy one byte
+    part[pos++] = 0x80; // plane0 first bit set
+    part[pos++] = 128;  // end chunk
+
+    const packed = Lemmings.PackFilePart.pack(part);
+    const size = packed.data.length + 10;
+    const header = new Uint8Array([
+      packed.initialBits,
+      packed.checksum,
+      0, 0,
+      (part.length >> 8) & 0xff,
+      part.length & 0xff,
+      0, 0,
+      (size >> 8) & 0xff,
+      size & 0xff
+    ]);
+    const container = new Uint8Array(size);
+    container.set(header, 0);
+    container.set(packed.data, 10);
+    const br = new BinaryReader(container);
+    const reader = new VGASpecReader(br, 320, 40);
+
+    expect(reader.groundPalette.getR(0)).to.equal(4);
+    expect(reader.groundPalette.getG(0)).to.equal(8);
+    expect(reader.groundPalette.getB(0)).to.equal(12);
+    const color = reader.img.getBuffer()[304];
+    const expected = Lemmings.ColorPalette.colorFromRGB(8, 12, 16) >>> 0;
+    expect(color).to.equal(expected);
+  });
+});


### PR DESCRIPTION
## Summary
- create synthetic ground and VGASPEC data buffers
- add `groundreader.test.js` checking palette parsing and steel flag
- add `vgaspecreader.test.js` verifying RLE decoding and palette import
- document coverage increase

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840ee7e9e6c832da4129b86251cce38