### PR TITLE
Add bench mode note

### DIFF
--- a/.agentInfo/index.md
+++ b/.agentInfo/index.md
@@ -34,3 +34,4 @@ The root [AGENTS.md](../AGENTS.md) explains this tag-based note system.
 - **config, mechanics**: [notes/pack-mechanics.md](notes/pack-mechanics.md)
 - **todo, cleanup, code-review**: [notes/todo-review.md](notes/todo-review.md)
 - **keyboard, input, game-view**: [notes/keyboard-shortcuts.md](notes/keyboard-shortcuts.md)
+- **bench-mode, speed-control**: [notes/bench-mode.md](notes/bench-mode.md)

--- a/.agentInfo/notes/bench-mode.md
+++ b/.agentInfo/notes/bench-mode.md
@@ -1,0 +1,5 @@
+# Bench mode
+
+tags: bench-mode, speed-control
+
+Bench mode enables performance testing by spawning lemmings without limit and automatically adjusting the game speed. `LemmingManager.addNewLemmings()` skips the remaining-count check so new lemmings always appear. `GameTimer.#benchSpeedAdjust()` modifies `speedFactor` whenever the game falls behind, slowing to 0.1 if more than 100 ticks are pending and gradually increasing again when caught up.


### PR DESCRIPTION
## Summary
- document bench mode spawning and speed adjustments
- cross-link bench note from `.agentInfo/index.md`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6840f01acfac832d90469a997df02af4