### PR TITLE
Add overlay fade effect to Stage

### DIFF
--- a/js/Stage.js
+++ b/js/Stage.js
@@ -5,6 +5,9 @@ class Stage {
     this.controller = null;
     this.fadeTimer = 0;
     this.fadeAlpha = 0;
+    this.overlayColor = 'black';
+    this.overlayAlpha = 0;
+    this.overlayTimer = 0;
     this.cursorCanvas = null;
     this.cursorX = 0;
     this.cursorY = 0;
@@ -304,9 +307,14 @@ class Stage {
   }
   resetFade() {
     this.fadeAlpha = 0;
+    this.overlayAlpha = 0;
     if (this.fadeTimer != 0) {
       clearInterval(this.fadeTimer);
       this.fadeTimer = 0;
+    }
+    if (this.overlayTimer != 0) {
+      clearInterval(this.overlayTimer);
+      this.overlayTimer = 0;
     }
   }
   startFadeOut() {
@@ -319,11 +327,31 @@ class Stage {
       }
     }, 40);
   }
+
+  startOverlayFade(color) {
+    if (this.overlayTimer) {
+      clearInterval(this.overlayTimer);
+      this.overlayTimer = 0;
+    }
+    this.overlayColor = color;
+    this.overlayAlpha = 1;
+    this.overlayTimer = setInterval(() => {
+      this.overlayAlpha = Math.max(this.overlayAlpha - 0.02, 0);
+      if (this.overlayAlpha <= 0) {
+        clearInterval(this.overlayTimer);
+        this.overlayTimer = 0;
+      }
+    }, 40);
+  }
   dispose() {
     this.resetFade();
     if (this.fadeTimer) {
       clearInterval(this.fadeTimer);
       this.fadeTimer = 0;
+    }
+    if (this.overlayTimer) {
+      clearInterval(this.overlayTimer);
+      this.overlayTimer = 0;
     }
     if (this.gameImgProps.display?.dispose) this.gameImgProps.display.dispose();
     if (this.guiImgProps.display?.dispose) this.guiImgProps.display.dispose();
@@ -365,6 +393,11 @@ class Stage {
     if (this.fadeAlpha != 0) {
       ctx.globalAlpha = this.fadeAlpha;
       ctx.fillStyle = 'black';
+      ctx.fillRect(display.x, display.y, Math.trunc(dW * display.viewPoint.scale), Math.trunc(dH * display.viewPoint.scale));
+    }
+    if (display === this.gameImgProps && this.overlayAlpha > 0) {
+      ctx.globalAlpha = this.overlayAlpha;
+      ctx.fillStyle = this.overlayColor;
       ctx.fillRect(display.x, display.y, Math.trunc(dW * display.viewPoint.scale), Math.trunc(dH * display.viewPoint.scale));
     }
   }


### PR DESCRIPTION
## Summary
- extend `Stage` with overlay fade fields
- implement `startOverlayFade` to fade a color out
- draw overlay color in the game layer
- clear overlay timer on reset and dispose

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840f01ff8dc832dae246a40885a5238