### PR TITLE
Handle fractional game speeds

### DIFF
--- a/.agentInfo/index.md
+++ b/.agentInfo/index.md
@@ -34,6 +34,7 @@ Try to always make sure to update this comprehensively
 - **config, mechanics**: [notes/pack-mechanics.md](notes/pack-mechanics.md)
 - **keyboard, input, game-view**: [notes/keyboard-shortcuts.md](notes/keyboard-shortcuts.md)
 - **bench-mode, benchmarking, performance testing, optimization, speed-control**: [notes/bench-mode.md](notes/bench-mode.md)
+- **game-view, speed**: [notes/game-speed-input.md](notes/game-speed-input.md)
 - **tools, cli**: [notes/tools.md](notes/tools.md)
 - **tools, validation**: [notes/check-undefined.md](notes/check-undefined.md)
 - **tests, stage, gameresult, gametimer, groundreader, vgaspec, nodefileprovider, listsprites, solidlayer, geometry, tools, exports**: [notes/test-coverage.md](notes/test-coverage.md)

--- a/.agentInfo/notes/game-speed-input.md
+++ b/.agentInfo/notes/game-speed-input.md
@@ -1,0 +1,5 @@
+# Game speed input rounding
+
+tags: game-view, speed
+
+`GameView.applyQuery` reads the `speed` URL parameter to set `gameSpeedFactor`. Values greater than `1` represent integer speed steps, so the query value is rounded to the nearest whole number. Fractional speeds at or below `1` are left untouched.

--- a/js/GameView.js
+++ b/js/GameView.js
@@ -241,6 +241,10 @@ class GameView extends Lemmings.BaseLogger {
     this.levelGroupIndex = this.parseNumber(query, ['difficulty', 'd'], 1, 1, 5) - 1;
     this.levelIndex = this.parseNumber(query, ['level', 'l'], 1, 1, 30) - 1;
     this.gameSpeedFactor = this.parseNumber(query, ['speed', 's'], 1, 0, 100);
+    // values above normal correspond to discrete steps
+    if (this.gameSpeedFactor > 1) {
+      this.gameSpeedFactor = Math.round(this.gameSpeedFactor);
+    }
     this.cheat = this.parseBool(query, ['cheat', 'c']);
     this.debug = this.parseBool(query, ['debug', 'dbg']);
     this.bench = this.parseBool(query, ['bench', 'b']);

--- a/test/gametimer.test.js
+++ b/test/gametimer.test.js
@@ -38,6 +38,7 @@ describe('GameTimer', function() {
     delete globalThis.window;
     delete globalThis.document;
     visHandler = undefined;
+    delete lemmings.suspendWithColor;
   });
 
   it('emits ticks and stops when paused', function() {
@@ -80,6 +81,7 @@ describe('GameTimer', function() {
     let raf;
     window.requestAnimationFrame = cb => { raf = cb; return 1; };
     const timer = new GameTimer({ timeLimit: 1 });
+    lemmings.suspendWithColor = () => timer.suspend();
     timer.continue();
     clock.tick(1200);
     raf(clock.now);

--- a/test/gameview.test.js
+++ b/test/gameview.test.js
@@ -139,4 +139,43 @@ describe('GameView', function () {
     expect(game.setGuiDisplayArgs).to.equal(guiDisplay);
     expect(game.startCalled).to.be.true;
   });
+
+  it('rounds speed factor up when fraction is above .5', async function () {
+    global.window = {
+      location: { search: '?speed=2.6' },
+      setTimeout,
+      clearTimeout,
+      addEventListener() {},
+      removeEventListener() {}
+    };
+    const { GameView } = await import('../js/GameView.js');
+    const view = new GameView();
+    expect(view.gameSpeedFactor).to.equal(3);
+  });
+
+  it('rounds speed factor down when fraction is below .5', async function () {
+    global.window = {
+      location: { search: '?speed=2.2' },
+      setTimeout,
+      clearTimeout,
+      addEventListener() {},
+      removeEventListener() {}
+    };
+    const { GameView } = await import('../js/GameView.js');
+    const view = new GameView();
+    expect(view.gameSpeedFactor).to.equal(2);
+  });
+
+  it('keeps speed factor below or equal to one', async function () {
+    global.window = {
+      location: { search: '?speed=0.8' },
+      setTimeout,
+      clearTimeout,
+      addEventListener() {},
+      removeEventListener() {}
+    };
+    const { GameView } = await import('../js/GameView.js');
+    const view = new GameView();
+    expect(view.gameSpeedFactor).to.equal(0.8);
+  });
 });


### PR DESCRIPTION
## Summary
- round speed factor values above 1 to the nearest integer
- explain this rule in `applyQuery`
- test rounding behavior in GameView
- fix `GameTimer` test by stubbing `suspendWithColor`
- document game speed input handling

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840f54378e0832db80f34515588bfd8