### PR TITLE
Remove normTickCount accessors

### DIFF
--- a/.agentInfo/index.md
+++ b/.agentInfo/index.md
@@ -34,6 +34,7 @@ Try to always make sure to update this comprehensively
 - **config, mechanics**: [notes/pack-mechanics.md](notes/pack-mechanics.md)
 - **keyboard, input, game-view**: [notes/keyboard-shortcuts.md](notes/keyboard-shortcuts.md)
 - **bench-mode, benchmarking, performance testing, optimization, speed-control**: [notes/bench-mode.md](notes/bench-mode.md)
+- **cleanup, game-timer**: [notes/norm-tick-count-removal.md](notes/norm-tick-count-removal.md)
 - **tools, cli**: [notes/tools.md](notes/tools.md)
 - **tools, validation**: [notes/check-undefined.md](notes/check-undefined.md)
 - **tests, stage, gameresult, gametimer, groundreader, vgaspec, nodefileprovider, listsprites, solidlayer, geometry, tools, exports**: [notes/test-coverage.md](notes/test-coverage.md)

--- a/.agentInfo/notes/norm-tick-count-removal.md
+++ b/.agentInfo/notes/norm-tick-count-removal.md
@@ -1,0 +1,7 @@
+# Norm tick count removal
+
+tags: cleanup, game-timer
+
+The obsolete `normTickCount` field in `GameTimer` was folded into
+`#stableTicks` and its accessor methods removed. Bench mode now updates
+`#stableTicks` directly.


### PR DESCRIPTION
## Summary
- remove `normTickCount` getter/setter
- rename private field to `#stableTicks` and use it directly in `#benchSpeedAdjust`
- document removal in `.agentInfo`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840f5459200832d96cbe3e40f85355f