### PR TITLE
Fix cursor rendering

### DIFF
--- a/.agentInfo/notes/game-resources.md
+++ b/.agentInfo/notes/game-resources.md
@@ -12,3 +12,5 @@ The holiday packs share some graphics files. For example the `xmas92` entry in
 `config.json` reuses `VGAGR0.DAT` from `xmas91`. Copying that file or pointing
 the config to `xmas91` avoids 404 errors when the loader requests missing
 assets.
+
+The cursor graphic from `MAIN.DAT` uses a 16×16 `PaletteImage`. Anything larger smears at the edges.

--- a/.agentInfo/notes/tools.md
+++ b/.agentInfo/notes/tools.md
@@ -7,5 +7,6 @@ The `tools/` directory contains small command-line utilities for working with le
 - **exportAllPacks.js** – loops over packs defined in `config.json` and runs `exportAllSprites.js` for each. Each pack is exported into an `export_<pack>` folder. You can also pass pack paths via command line.
 - **exportAllSprites.js** – exports skill panel, lemming and object sprites from a pack to PNG files. Usage: `node tools/exportAllSprites.js <pack dir> <out dir>`. Relies on `NodeFileProvider` to read data files from folders or archives.
 - **packLevels.js** – packs a directory of 2048 byte level files into a single DAT. Usage: `node tools/packLevels.js <level dir> <out DAT>`.
+- **renderCursorSizes.js** – outputs the cursor sprite rendered at all width/height pairs from 8×8 to 24×24. Usage: `node tools/renderCursorSizes.js [pack] [out dir]`.
 
 Most export scripts instantiate `NodeFileProvider` so they can read level packs from plain directories or archives like `.zip`, `.tar.gz`, or `.rar`. Keep pack archives next to the repo and the provider will find files automatically.

--- a/js/GameResources.js
+++ b/js/GameResources.js
@@ -47,7 +47,7 @@ class GameResources extends Lemmings.BaseLogger {
     return new Promise((resolve) => {
       this.getMainDat().then((container) => {
         const fr = container.getPart(5);
-        const pimg = new Lemmings.PaletteImage(17, 17);
+        const pimg = new Lemmings.PaletteImage(16, 16);
         pimg.processImage(fr, 1);
         pimg.processTransparentByColorIndex(0);
         const pal = new Lemmings.ColorPalette();

--- a/tools/renderCursorSizes.js
+++ b/tools/renderCursorSizes.js
@@ -1,0 +1,60 @@
+import { Lemmings } from '../js/LemmingsNamespace.js';
+import '../js/LemmingsBootstrap.js';
+import { NodeFileProvider } from './NodeFileProvider.js';
+import fs from 'fs';
+import path from 'path';
+import { PNG } from 'pngjs';
+
+function loadDefaultPack() {
+  try {
+    const cfgPath = path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'config.json');
+    const txt = fs.readFileSync(cfgPath, 'utf8');
+    const cfg = JSON.parse(txt);
+    return cfg[0]?.path || 'lemmings';
+  } catch {
+    return 'lemmings';
+  }
+}
+
+function frameToPNG(frame) {
+  const png = new PNG({ width: frame.width, height: frame.height });
+  for (let y = 0; y < frame.height; y++) {
+    for (let x = 0; x < frame.width; x++) {
+      const idx = y * frame.width + x;
+      const rgba = frame.data[idx];
+      const p = idx * 4;
+      png.data[p    ] = rgba & 0xFF;
+      png.data[p + 1] = (rgba >> 8) & 0xFF;
+      png.data[p + 2] = (rgba >> 16) & 0xFF;
+      png.data[p + 3] = (rgba >> 24) & 0xFF;
+    }
+  }
+  return png;
+}
+
+(async () => {
+  const pack = process.argv[2] || loadDefaultPack();
+  const outDir = process.argv[3] || path.join('exports', 'cursor_test');
+  fs.mkdirSync(outDir, { recursive: true });
+
+  const provider = new NodeFileProvider('.');
+  const br = await provider.loadBinary(pack, 'MAIN.DAT');
+  const fc = new Lemmings.FileContainer(br);
+  const fr = fc.getPart(5);
+  const minSize = 8;
+  const maxSize = 24;
+  for (let width = minSize; width <= maxSize; width++) {
+    for (let height = minSize; height <= maxSize; height++) {
+      const pimg = new Lemmings.PaletteImage(width, height);
+      pimg.processImage(fr, 1);
+      pimg.processTransparentByColorIndex(0);
+      const pal = new Lemmings.ColorPalette();
+      pal.setColorRGB(1, 255, 255, 255);
+      const frame = pimg.createFrame(pal);
+      const png = frameToPNG(frame);
+      const name = `cursor_${width}x${height}.png`;
+      await new Promise(res =>
+        png.pack().pipe(fs.createWriteStream(path.join(outDir, name))).on('finish', res));
+    }
+  }
+})();


### PR DESCRIPTION
## Summary
- size cursor sprite buffer at 16x16
- exhaustively render cursor sizes from 8-24
- note cursor buffer detail in GameResources notes and tools note

## Testing
- `npm test`
- `node - <<'NODE' ...` to confirm cursor sprite is 16x16


------
https://chatgpt.com/codex/tasks/task_e_6840e9038574832d8da5f503ea09bcc5