### PR TITLE
Fix canvas sizing

### DIFF
--- a/css/game.css
+++ b/css/game.css
@@ -34,8 +34,6 @@ body * {
 }
 
 canvas {
-    width: 100% !important;
-    height: 100% !important;
     object-fit: contain;
     image-rendering: pixelated;
 }
@@ -44,16 +42,12 @@ canvas {
     display: block;
     touch-action: none;
     margin: auto;
-    width: 100%;
-    height: 100%;
 }
 
 .game_container {
     display: block;
     touch-action: none;
     margin: auto;
-    width: 100%;
-    height: 100%;
 }
 
 @media (orientation: landscape) {

--- a/js/Stage.js
+++ b/js/Stage.js
@@ -210,9 +210,8 @@ class Stage {
     return Math.round(clamped / step) * step;
   }
   updateStageSize() {
-    let ctx = this.stageCav.getContext('2d', { alpha: false });
-    let stageHeight = ctx.canvas.height;
-    let stageWidth = ctx.canvas.width;
+    const stageHeight = this.stageCav.height;
+    const stageWidth = this.stageCav.width;
     this.gameImgProps.y = 0;
     this.gameImgProps.height = stageHeight - 100;
     this.gameImgProps.width = stageWidth;


### PR DESCRIPTION
## Summary
- stop CSS from scaling the canvas or container to the full screen
- base Stage sizing on the canvas dimensions directly

## Testing
- `npm test` *(fails: benchSpeedAdjust recovery)*

------
https://chatgpt.com/codex/tasks/task_e_6840fef0fc7c832dafd8f04373cc9fa0