### PR TITLE
Fix Stage GUI centering

### DIFF
--- a/js/Stage.js
+++ b/js/Stage.js
@@ -218,7 +218,9 @@ class Stage {
     this.gameImgProps.width = stageWidth;
     this.guiImgProps.y = stageHeight - 100;
     this.guiImgProps.height = 100;
-    this.guiImgProps.width = stageWidth;
+    this.guiImgProps.width = this.guiImgProps.display
+      ? this.guiImgProps.display.getWidth()
+      : stageWidth;
     if (this.guiImgProps.display) {
       const guiW = this.guiImgProps.display.getWidth() * this.guiImgProps.viewPoint.scale;
       this.guiImgProps.x = Math.floor((stageWidth - guiW) / 2);

--- a/test/stage.updateStageSize.test.js
+++ b/test/stage.updateStageSize.test.js
@@ -1,0 +1,72 @@
+import { expect } from 'chai';
+import { Lemmings } from '../js/LemmingsNamespace.js';
+import '../js/EventHandler.js';
+import '../js/Position2D.js';
+import '../js/ViewPoint.js';
+import '../js/StageImageProperties.js';
+import '../js/DisplayImage.js';
+import '../js/UserInputManager.js';
+import { Stage } from '../js/Stage.js';
+
+function createStubCanvas(width = 800, height = 600) {
+  const ctx = {
+    canvas: { width, height },
+    fillRect() {},
+    drawImage() {},
+    putImageData() {}
+  };
+  return {
+    width,
+    height,
+    getContext() { return ctx; },
+    addEventListener() {},
+    removeEventListener() {}
+  };
+}
+
+function createDocumentStub() {
+  return {
+    createElement() {
+      const ctx = {
+        canvas: {},
+        fillRect() {},
+        drawImage() {},
+        putImageData() {},
+        createImageData(w, h) {
+          return { width: w, height: h, data: new Uint8ClampedArray(w * h * 4) };
+        }
+      };
+      return {
+        width: 0,
+        height: 0,
+        getContext() { ctx.canvas = this; return ctx; }
+      };
+    }
+  };
+}
+
+globalThis.lemmings = { game: { showDebug: false } };
+
+describe('Stage.updateStageSize', function() {
+  before(function() {
+    global.document = createDocumentStub();
+  });
+
+  it('centers GUI panel after canvas resize', function() {
+    const canvas = createStubCanvas(400, 600);
+    const stage = new Stage(canvas);
+    stage.clear = () => {};
+    stage.draw = () => {};
+
+    const display = stage.getGuiDisplay();
+    display.initSize(160, 20);
+
+    canvas.width = 800;
+    canvas.getContext().canvas.width = 800;
+    stage.updateStageSize();
+
+    const guiW = display.getWidth() * stage.guiImgProps.viewPoint.scale;
+    expect(stage.guiImgProps.x).to.equal(Math.floor((800 - guiW) / 2));
+    expect(stage.guiImgProps.width).to.equal(display.getWidth());
+  });
+});


### PR DESCRIPTION
## Summary
- center GUI panel according to display width in `updateStageSize`
- add regression test for GUI positioning when resizing the canvas

## Testing
- `npm test` *(fails: benchSpeedAdjust recovery)*

------
https://chatgpt.com/codex/tasks/task_e_6840fef2f338832d935c8c34e29ca0c6