### PR TITLE
Update viewpoint zoom logic

### DIFF
--- a/js/Stage.js
+++ b/js/Stage.js
@@ -162,13 +162,9 @@ class Stage {
     if (stageImage.viewPoint.scale < 1) {
       const scale = stageImage.viewPoint.scale;
       const wDiff = stageImage.width - stageImage.display.getWidth() * scale;
-      const hDiff = stageImage.height - stageImage.display.getHeight() * scale;
       if (wDiff > 0) stageImage.viewPoint.x = -wDiff / (2 * scale);
-      if (hDiff > 0) {
-        stageImage.viewPoint.y = stageImage.height - stageImage.display.getHeight() / scale;
-      } else {
-        stageImage.viewPoint.y = 0;
-      }
+      stageImage.viewPoint.y =
+        stageImage.height - stageImage.display.getHeight() / scale;
     } else {
       const xCeiling = Math.max(0, stageImage.viewPoint.x);
       const xFloorLimit = stageImage.display.getWidth() - stageImage.width / stageImage.viewPoint.scale;

--- a/test/stage.updateviewpoint.test.js
+++ b/test/stage.updateviewpoint.test.js
@@ -1,0 +1,82 @@
+import { expect } from 'chai';
+import { Lemmings } from '../js/LemmingsNamespace.js';
+import '../js/EventHandler.js';
+import '../js/Position2D.js';
+import '../js/ViewPoint.js';
+import '../js/StageImageProperties.js';
+import '../js/DisplayImage.js';
+import '../js/UserInputManager.js';
+import { Stage } from '../js/Stage.js';
+
+function createStubCanvas(width = 800, height = 600) {
+  const ctx = {
+    canvas: { width, height },
+    fillRect() {},
+    drawImage() {},
+    putImageData() {}
+  };
+  return {
+    width,
+    height,
+    getContext() { return ctx; },
+    addEventListener() {},
+    removeEventListener() {}
+  };
+}
+
+function createDocumentStub() {
+  return {
+    createElement() {
+      const ctx = {
+        canvas: {},
+        fillRect() {},
+        drawImage() {},
+        putImageData() {},
+        createImageData(w, h) {
+          return { width: w, height: h, data: new Uint8ClampedArray(w * h * 4) };
+        }
+      };
+      return {
+        width: 0,
+        height: 0,
+        getContext() { ctx.canvas = this; return ctx; }
+      };
+    }
+  };
+}
+
+globalThis.lemmings = { game: { showDebug: false } };
+
+describe('Stage updateViewPoint', function() {
+  before(function() {
+    global.document = createDocumentStub();
+  });
+
+  after(function() {
+    delete global.document;
+  });
+
+  it('centers horizontally and bottom aligns when zoomed out', function() {
+    const canvas = createStubCanvas();
+    const stage = new Stage(canvas);
+    stage.clear = () => {};
+    stage.draw = () => {};
+
+    const display = stage.getGameDisplay();
+    display.initSize(1000, 1200);
+
+    const scale = 0.5;
+    stage.gameImgProps.viewPoint.scale = scale;
+    stage.gameImgProps.viewPoint.x = 10;
+    stage.gameImgProps.viewPoint.y = 20;
+
+    stage.updateViewPoint(stage.gameImgProps, 0, 0, 0);
+
+    const wDiff = stage.gameImgProps.width - display.getWidth() * scale;
+    const expectedX = -wDiff / (2 * scale);
+    const expectedY = stage.gameImgProps.height - display.getHeight() / scale;
+
+    expect(stage.gameImgProps.viewPoint.x).to.equal(expectedX);
+    expect(stage.gameImgProps.viewPoint.y).to.equal(expectedY);
+  });
+});


### PR DESCRIPTION
## Summary
- keep game view horizontally centered and bottom aligned when zoomed out
- test Stage.updateViewPoint centering and alignment

## Testing
- `npm test` *(fails: bench-speed-adjust and export scripts)*

------
https://chatgpt.com/codex/tasks/task_e_6840fef421a4832d8b6674e22d600aac