### PR TITLE
Update selection highlight tint

### DIFF
--- a/js/GameDisplay.js
+++ b/js/GameDisplay.js
@@ -76,11 +76,11 @@ class GameDisplay {
   }
 
   #drawSelection(lem) {
-    const dashLen = 2;
+    const dashLen = 1;
     const x = lem.x - 5;
     const y = lem.y - 9; // slight upward offset
 
-    let color = 0xff00ff00; // bright green
+    let color = 0xff30ff30; // lighter green
     const skills = this.game?.getGameSkills?.();
     if (skills) {
       const selectedSkill = skills.getSelectedSkill();


### PR DESCRIPTION
## Summary
- lighten the default selection outline in `GameDisplay`
- use a 1px dash for a subtler effect

## Testing
- `npm run format`
- `npm test` *(fails: benchSpeedAdjust recovery)*

------
https://chatgpt.com/codex/tasks/task_e_684100cb5274832d9303f35650a24496