### PR TITLE
Fix panel positioning when resizing stage

### DIFF
--- a/js/Stage.js
+++ b/js/Stage.js
@@ -208,11 +208,13 @@ class Stage {
   updateStageSize() {
     const stageHeight = this.stageCav.height;
     const stageWidth = this.stageCav.width;
+    const panelRawHeight = this.guiImgProps.display?.getHeight() || 40;
+    const panelH = panelRawHeight * this.guiImgProps.viewPoint.scale;
     this.gameImgProps.y = 0;
-    this.gameImgProps.height = stageHeight - 100;
+    this.gameImgProps.height = stageHeight - panelH;
     this.gameImgProps.width = stageWidth;
-    this.guiImgProps.y = stageHeight - 100;
-    this.guiImgProps.height = 100;
+    this.guiImgProps.y = stageHeight - panelH;
+    this.guiImgProps.height = panelRawHeight;
     this.guiImgProps.width = this.guiImgProps.display
       ? this.guiImgProps.display.getWidth()
       : stageWidth;

--- a/test/stage.updateStageSize.test.js
+++ b/test/stage.updateStageSize.test.js
@@ -59,14 +59,35 @@ describe('Stage.updateStageSize', function() {
     stage.draw = () => {};
 
     const display = stage.getGuiDisplay();
-    display.initSize(160, 20);
+    display.initSize(160, 40);
 
     canvas.width = 800;
     canvas.getContext().canvas.width = 800;
     stage.updateStageSize();
 
     const guiW = display.getWidth() * stage.guiImgProps.viewPoint.scale;
+    const panelH = display.getHeight() * stage.guiImgProps.viewPoint.scale;
     expect(stage.guiImgProps.x).to.equal(Math.floor((800 - guiW) / 2));
+    expect(stage.guiImgProps.y).to.equal(600 - panelH);
+    expect(stage.gameImgProps.height).to.equal(600 - panelH);
+    expect(stage.guiImgProps.height).to.equal(display.getHeight());
     expect(stage.guiImgProps.width).to.equal(display.getWidth());
+  });
+
+  it('keeps panel at bottom for different zoom levels', function() {
+    const canvas = createStubCanvas(400, 600);
+    const stage = new Stage(canvas);
+    stage.clear = () => {};
+    stage.draw = () => {};
+
+    const display = stage.getGuiDisplay();
+    display.initSize(160, 40);
+
+    stage.guiImgProps.viewPoint.scale = 3;
+    stage.updateStageSize();
+
+    const panelH = display.getHeight() * stage.guiImgProps.viewPoint.scale;
+    expect(stage.guiImgProps.y).to.equal(600 - panelH);
+    expect(stage.gameImgProps.height).to.equal(600 - panelH);
   });
 });


### PR DESCRIPTION
## Summary
- position GUI panel based on its scaled height
- keep raw panel height constant at 40px
- test GUI placement at different scales

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68410540b73c832d93f240a1d48ccc54