### PR TITLE
Fix selection outline colors

### DIFF
--- a/js/GameDisplay.js
+++ b/js/GameDisplay.js
@@ -87,7 +87,7 @@ class GameDisplay {
       }
     }
 
-    this.display.drawDashedRect(x, y, 10, 13, dashLen, 0, color, 0xff000000);
+    this.display.drawDashedRect(x, y, 10, 13, dashLen, 0, color, 0x00000000);
   }
 
   #drawHover(lem) {


### PR DESCRIPTION
## Summary
- selection outlines no longer use solid black segments

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68410544d340832da7cde026f2d48f45