### PR TITLE
Update hover outline

### DIFF
--- a/.agentInfo/notes/draw-corner-rect.md
+++ b/.agentInfo/notes/draw-corner-rect.md
@@ -2,4 +2,4 @@
 
 tags: canvas, helper
 
-`DisplayImage.drawCornerRect(x, y, size, r, g, b, cornerSize = 2)` paints filled squares at the four corners of a rectangle. The optional `cornerSize` controls the square size in pixels. GameDisplay uses this to show 3 px corners around a hovered lemming.
+`DisplayImage.drawCornerRect(x, y, size, r, g, b, cornerSize = 2)` paints filled squares at the four corners of a rectangle. The optional `cornerSize` controls the square size in pixels. This helper is currently unused after hover outlines switched to dashed rectangles only.

--- a/.agentInfo/notes/game-display.md
+++ b/.agentInfo/notes/game-display.md
@@ -4,4 +4,4 @@ tags: render, display
 
 `js/GameDisplay.js` binds the game state to a GUI display. `setGuiDisplay()` attaches mouse handlers that select the nearest lemming on click and track the mouse position for debugging. The `render()` method draws the level, objects, and lemmings. When debug is off it highlights the selected lemming and the one under the cursor. `renderDebug()` paints additional debug information and shows a marching-ants rectangle around the nearest lemming.
 
-`#drawSelection()` now uses `drawDashedRect` and `drawCornerRect` to outline the current lemming with a bright green (`0xFF30FF30`) 1 px dashed rectangle. The dashes use length 1 so the box is thin. Hover outlines call `#drawHover()` which draws a dark grey rectangle raised slightly higher and adds 3 px corner squares via `drawCornerRect`.
+`#drawSelection()` now uses `drawDashedRect` to outline the current lemming with a bright green (`0xFF30FF30`) 1 px dashed rectangle. The dashes use length 1 so the box is thin. Hover outlines call `#drawHover()` which draws the same size rectangle in dark grey using `drawDashedRect` with a transparent secondary color.

--- a/js/GameDisplay.js
+++ b/js/GameDisplay.js
@@ -96,15 +96,7 @@ class GameDisplay {
     const y = lem.y - 9; // slight upward offset
     const color = 0xff555555; // mid-dark gray
 
-    this.display.drawDashedRect(x, y, 10, 13, dashLen, 0, color, 0xff000000);
-    this.display.drawCornerRect(
-      x,
-      y,
-      3,
-      (color >> 16) & 0xff,
-      (color >> 8) & 0xff,
-      color & 0xff
-    );
+    this.display.drawDashedRect(x, y, 10, 13, dashLen, 0, color, 0x00000000);
   }
 
   dispose() {


### PR DESCRIPTION
## Summary
- adjust hover outline to match selection thickness
- remove corner squares from hover note

## Testing
- `npm install`
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6841054645ec832d9e057c3654efd7e5