### PR TITLE
Fix mouse position scaling

### DIFF
--- a/js/UserInputManager.js
+++ b/js/UserInputManager.js
@@ -196,8 +196,10 @@ class UserInputManager {
   }
   getRelativePosition(element, clientX, clientY) {
     const rect = element.getBoundingClientRect();
-    const x = (clientX - rect.left) / rect.width * element.width;
-    const y = (clientY - rect.top) / rect.height * element.height;
+    const scaleX = element.width / rect.width;
+    const scaleY = element.height / rect.height;
+    const x = (clientX - rect.left) * scaleX;
+    const y = (clientY - rect.top) * scaleY;
     return new Lemmings.Position2D(x, y);
   }
   handleMouseMove(position) {

--- a/test/userinput.test.js
+++ b/test/userinput.test.js
@@ -49,4 +49,20 @@ describe('UserInputManager', function() {
     expect(pos.x).to.equal(200);
     expect(pos.y).to.equal(120);
   });
+
+  it('accounts for offset rects', function() {
+    const offsetElement = {
+      width: 400,
+      height: 240,
+      addEventListener() {},
+      removeEventListener() {},
+      getBoundingClientRect() {
+        return { left: 50, top: 20, width: 200, height: 120 };
+      }
+    };
+    const uim = new UserInputManager(offsetElement);
+    const pos = uim.getRelativePosition(offsetElement, 150, 80);
+    expect(pos.x).to.equal(200);
+    expect(pos.y).to.equal(120);
+  });
 });


### PR DESCRIPTION
## Summary
- compute mouse positions using canvas client size
- test for offset canvas rects

## Testing
- `npm test` *(fails: export scripts after all hook ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6841054a72b0832dba02887394d64671