### PR TITLE
Remove custom cursor

### DIFF
--- a/css/game.css
+++ b/css/game.css
@@ -16,7 +16,7 @@ body * {
     overflow: hidden;
 }
 .gameCanvas {
-    cursor: none;
+    /* cursor: none; keep the system cursor */
 }
 
 @media (orientation: landscape) {

--- a/js/GameView.js
+++ b/js/GameView.js
@@ -56,7 +56,9 @@ class GameView extends Lemmings.BaseLogger {
       game.setGameDisplay(this.stage.getGameDisplay());
       game.setGuiDisplay(this.stage.getGuiDisplay());
       game.getGameTimer().speedFactor = this.gameSpeedFactor;
-      game.gameResources.getCursorSprite().then(f => this.stage.setCursorSprite(f));
+      // The stage previously set a custom cursor sprite here, but we now keep
+      // the system cursor visible so no sprite is loaded.
+      // game.gameResources.getCursorSprite().then(f => this.stage.setCursorSprite(f));
       game.start();
       this.changeHtmlText(this.elementGameState, Lemmings.GameStateTypes.toString(Lemmings.GameStateTypes.RUNNING));
       game.onGameEnd.on(state => this.onGameEnd(state));


### PR DESCRIPTION
## Summary
- stop calling `getCursorSprite()` in `GameView.start`
- keep the system cursor visible in css

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841054ebe68832d8a3f9a48f62f1861