### PR TITLE
Fix async panel sprite export

### DIFF
--- a/tools/exportPanelSprite.js
+++ b/tools/exportPanelSprite.js
@@ -38,5 +38,7 @@ function loadDefaultPack() {
   }
   fs.mkdirSync(outDir, { recursive: true });
   const outFile = `${outDir}/panelSprite.png`;
-  png.pack().pipe(fs.createWriteStream(outFile));
+  await new Promise(res =>
+    png.pack().pipe(fs.createWriteStream(outFile)).on('finish', res)
+  );
 })();


### PR DESCRIPTION
## Summary
- await the PNG creation when exporting panel sprites so the script closes after the file is written

## Testing
- `npm test` *(fails: Stage.updateStageSize assertions)*

------
https://chatgpt.com/codex/tasks/task_e_68411b7cd154832dba65d39c04ac9e86