### PR TITLE
Fix sprite loading order

### DIFF
--- a/js/LevelLoader.js
+++ b/js/LevelLoader.js
@@ -60,6 +60,7 @@ class LevelLoader {
     // ----------------------------------------------------------------------- //
     // 3 · Fetch graphics set(s) in parallel                                   //
     // ----------------------------------------------------------------------- //
+    await Lemmings.loadSteelSprites();
     const vgagrFile    = this.fileProvider.loadBinary(
       this.config.path, `VGAGR${levelReader.graphicSet1}.DAT`);
     const groundFile   = this.fileProvider.loadBinary(
@@ -73,7 +74,6 @@ class LevelLoader {
     // 4 · Decode terrain / objects and render background                      //
     // ----------------------------------------------------------------------- //
     const vgaContainer = new Lemmings.FileContainer(vgagrBuf);
-    await Lemmings.loadSteelSprites();
     const groundReader = new Lemmings.GroundReader(
       groundBuf,
       vgaContainer.getPart(0),

--- a/tools/exportAllSprites.js
+++ b/tools/exportAllSprites.js
@@ -45,20 +45,34 @@ function frameToPNG(frame) {
   const panelSprites = await res.getSkillPanelSprite(pal);
 
   const panel = panelSprites.getPanelSprite();
-  frameToPNG(panel).pack().pipe(fs.createWriteStream(`${outDir}/panel.png`));
+  await new Promise(res =>
+    frameToPNG(panel)
+      .pack()
+      .pipe(fs.createWriteStream(`${outDir}/panel.png`))
+      .on('finish', res));
 
   const letters = ['%', '0','1','2','3','4','5','6','7','8','9','-','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z',' '];
   for (const letter of letters) {
     const frame = panelSprites.getLetterSprite(letter);
     const safe = encodeURIComponent(letter === ' ' ? 'space' : letter);
-    frameToPNG(frame).pack().pipe(fs.createWriteStream(`${outDir}/letter_${safe}.png`));
+    await new Promise(res =>
+      frameToPNG(frame)
+        .pack()
+        .pipe(fs.createWriteStream(`${outDir}/letter_${safe}.png`))
+        .on('finish', res));
   }
 
   for (let i = 0; i < 10; i++) {
-    frameToPNG(panelSprites.getNumberSpriteLeft(i))
-      .pack().pipe(fs.createWriteStream(`${outDir}/num_left_${i}.png`));
-    frameToPNG(panelSprites.getNumberSpriteRight(i))
-      .pack().pipe(fs.createWriteStream(`${outDir}/num_right_${i}.png`));
+    await new Promise(res =>
+      frameToPNG(panelSprites.getNumberSpriteLeft(i))
+        .pack()
+        .pipe(fs.createWriteStream(`${outDir}/num_left_${i}.png`))
+        .on('finish', res));
+    await new Promise(res =>
+      frameToPNG(panelSprites.getNumberSpriteRight(i))
+        .pack()
+        .pipe(fs.createWriteStream(`${outDir}/num_right_${i}.png`))
+        .on('finish', res));
   }
 
   // --- Lemming sprites ---
@@ -89,6 +103,7 @@ function frameToPNG(frame) {
   }
 
   // --- Map object sprites from ground files ---
+  await Lemmings.loadSteelSprites();
   for (let g = 0; g < 5; g++) {
     const groundFile = `GROUND${g}O.DAT`;
     const vgaFile    = `VGAGR${g}.DAT`;

--- a/tools/exportGroundImages.js
+++ b/tools/exportGroundImages.js
@@ -45,6 +45,7 @@ function frameToPNG(frame) {
   fs.mkdirSync(outDir, { recursive: true });
 
   const provider = new NodeFileProvider('.');
+  await Lemmings.loadSteelSprites();
   const groundBuf = await provider.loadBinary(dataPath, `GROUND${index}O.DAT`);
   const vgagrBuf = await provider.loadBinary(dataPath, `VGAGR${index}.DAT`);
   const vgaContainer = new Lemmings.FileContainer(vgagrBuf);


### PR DESCRIPTION
## Summary
- preload steel sprites before reading ground files
- ensure panel and number PNG writes await completion

## Testing
- `npm test` *(fails: GroundReader, Stage pointer, Stage.updateStageSize)*

------
https://chatgpt.com/codex/tasks/task_e_68411b7ebe40832d83f7cc7bbfc3892a