### PR TITLE
Improve error handling for export scripts

### DIFF
--- a/tools/archiveDir.js
+++ b/tools/archiveDir.js
@@ -16,7 +16,9 @@ export async function archiveDir(dir, format) {
     await tar.c({ gzip: true, cwd, file: `${dir}.tar.gz` }, [base]);
   } else if (format === 'rar') {
     const res = spawnSync('rar', ['a', `${base}.rar`, base], { cwd, stdio: 'inherit' });
-    if (res.error) throw new Error('rar command failed');
+    if (res.error || res.status !== 0) {
+      throw new Error('rar command failed');
+    }
   } else {
     throw new Error(`Unsupported archive format ${format}`);
   }

--- a/tools/exportAllPacks.js
+++ b/tools/exportAllPacks.js
@@ -27,5 +27,12 @@ for (const pack of packs) {
   const outDir = `export_${pack.name.replace(/\W+/g, '_')}`;
   fs.mkdirSync(outDir, { recursive: true });
   console.log(`Exporting ${pack.path} -> ${outDir}`);
-  spawnSync('node', ['tools/exportAllSprites.js', pack.path, outDir], { stdio: 'inherit' });
+  const res = spawnSync('node', ['tools/exportAllSprites.js', pack.path, outDir], {
+    stdio: 'inherit'
+  });
+  if (res.error) {
+    console.error(`Failed to run export for ${pack.path}:`, res.error);
+  } else if (res.status !== 0) {
+    console.error(`Export failed for ${pack.path} with status ${res.status}`);
+  }
 }


### PR DESCRIPTION
## Summary
- log export failures when spawning child processes for exports
- check `rar` exit code when archiving directories

## Testing
- `npm test` *(fails: Stage pointer events and updateStageSize tests)*

------
https://chatgpt.com/codex/tasks/task_e_68411b7f4794832da94a4a5ff4f08a7e