### PR TITLE
Await finish event for PNG export

### DIFF
--- a/tools/exportPanelSprite.js
+++ b/tools/exportPanelSprite.js
@@ -38,5 +38,7 @@ function loadDefaultPack() {
   }
   fs.mkdirSync(outDir, { recursive: true });
   const outFile = `${outDir}/panelSprite.png`;
-  png.pack().pipe(fs.createWriteStream(outFile));
+  await new Promise(res =>
+    png.pack().pipe(fs.createWriteStream(outFile)).on('finish', res)
+  );
 })();


### PR DESCRIPTION
## Summary
- exportPanelSprite.js: wait for PNG file write to finish before resolving

## Testing
- `npm install`
- `npm run format`
- `npm test` *(fails: Stage pointer events and updateStageSize tests)*

------
https://chatgpt.com/codex/tasks/task_e_68411ca96408832db395745f00111c3f