### PR TITLE
Ensure steel sprites loaded before GroundReader

### DIFF
--- a/tools/exportAllSprites.js
+++ b/tools/exportAllSprites.js
@@ -101,6 +101,7 @@ function frameToPNG(frame) {
     }
     fs.mkdirSync(`${outDir}/ground${g}`, { recursive: true });
     const vgaContainer = new Lemmings.FileContainer(vgaBuf);
+    await Lemmings.loadSteelSprites();
     const groundReader = new Lemmings.GroundReader(
       groundBuf,
       vgaContainer.getPart(0),

--- a/tools/exportGroundImages.js
+++ b/tools/exportGroundImages.js
@@ -48,6 +48,7 @@ function frameToPNG(frame) {
   const groundBuf = await provider.loadBinary(dataPath, `GROUND${index}O.DAT`);
   const vgagrBuf = await provider.loadBinary(dataPath, `VGAGR${index}.DAT`);
   const vgaContainer = new Lemmings.FileContainer(vgagrBuf);
+  await Lemmings.loadSteelSprites();
   const groundReader = new Lemmings.GroundReader(
     groundBuf,
     vgaContainer.getPart(0),


### PR DESCRIPTION
## Summary
- load steel sprite data before constructing `GroundReader`
- used in export tools to ensure steel sprite detection

## Testing
- `npm test` *(fails: 5 failing)*

------
https://chatgpt.com/codex/tasks/task_e_68411b7de3c4832d88b453300c3afa8e