### PR TITLE
Call steel sprite loader before GroundReader

### DIFF
--- a/js/GroundReader.js
+++ b/js/GroundReader.js
@@ -22,6 +22,7 @@ async function loadSteelSprites() {
 }
 
 Lemmings.loadSteelSprites = loadSteelSprites;
+Lemmings.resetSteelSprites = () => { steelSprites = null; };
 
 const OBJECT_COUNT          = 16;
 const TERRAIN_COUNT         = 64;

--- a/tools/exportAllSprites.js
+++ b/tools/exportAllSprites.js
@@ -101,6 +101,7 @@ function frameToPNG(frame) {
     }
     fs.mkdirSync(`${outDir}/ground${g}`, { recursive: true });
     const vgaContainer = new Lemmings.FileContainer(vgaBuf);
+    await Lemmings.loadSteelSprites();
     const groundReader = new Lemmings.GroundReader(
       groundBuf,
       vgaContainer.getPart(0),
@@ -119,4 +120,5 @@ function frameToPNG(frame) {
       }
     }
   }
+  Lemmings.resetSteelSprites();
 })();

--- a/tools/exportGroundImages.js
+++ b/tools/exportGroundImages.js
@@ -48,6 +48,7 @@ function frameToPNG(frame) {
   const groundBuf = await provider.loadBinary(dataPath, `GROUND${index}O.DAT`);
   const vgagrBuf = await provider.loadBinary(dataPath, `VGAGR${index}.DAT`);
   const vgaContainer = new Lemmings.FileContainer(vgagrBuf);
+  await Lemmings.loadSteelSprites();
   const groundReader = new Lemmings.GroundReader(
     groundBuf,
     vgaContainer.getPart(0),
@@ -78,4 +79,5 @@ function frameToPNG(frame) {
       await new Promise(res => png.pack().pipe(fs.createWriteStream(file)).on('finish', res));
     }
   }
+  Lemmings.resetSteelSprites();
 })();


### PR DESCRIPTION
## Summary
- load steel sprite definitions before constructing `GroundReader` in export tools
- add `resetSteelSprites` helper to clear the cached sprite table
- keep PNG writing promises intact

## Testing
- `npm test` *(fails: Stage pointer events and Stage.updateStageSize)*

------
https://chatgpt.com/codex/tasks/task_e_68411cad7b88832dbacdccd82de4c2a9