### PR TITLE
Improve spawnSync error logging

### DIFF
--- a/tools/exportAllPacks.js
+++ b/tools/exportAllPacks.js
@@ -27,5 +27,8 @@ for (const pack of packs) {
   const outDir = `export_${pack.name.replace(/\W+/g, '_')}`;
   fs.mkdirSync(outDir, { recursive: true });
   console.log(`Exporting ${pack.path} -> ${outDir}`);
-  spawnSync('node', ['tools/exportAllSprites.js', pack.path, outDir], { stdio: 'inherit' });
+  const res = spawnSync('node', ['tools/exportAllSprites.js', pack.path, outDir], { stdio: 'inherit' });
+  if (res.status !== 0) {
+    console.error(`Export failed for ${pack.name}`);
+  }
 }


### PR DESCRIPTION
## Summary
- check `spawnSync` status in exportAllPacks script and log failures

## Testing
- `npm test` *(fails: Stage.updateStageSize tests)*

------
https://chatgpt.com/codex/tasks/task_e_68411cb04554832d9181f4c14efd7d3b