### PR TITLE
Update export paths

### DIFF
--- a/docs/exporting-sprites.md
+++ b/docs/exporting-sprites.md
@@ -5,10 +5,10 @@
 - Terminal:
   - `npm install`
   - `npm run`
-  - `npm run export-all-packs` *(optional)* – exports sprite folders for all level packs
-    - `zip -r export_lemmings.zip export_lemmings`
-    - `tar -czf export_lemmings.tgz export_lemmings`
-    - `rar a export_lemmings.rar export_lemmings`
+  - `npm run export-all-packs` *(optional)* – exports sprite folders for all level packs under `exports/`
+    - `zip -r export_lemmings.zip exports/export_lemmings`
+    - `tar -czf export_lemmings.tgz exports/export_lemmings`
+    - `rar a export_lemmings.rar exports/export_lemmings`
     - `npm run clean-exports` *(remove `export_*` folders)*
 - Other useful scripts:
   - `npm run export-panel-sprite` – export the skill panel sprite as `exports/panel_export`
@@ -17,6 +17,8 @@
   - `npm run export-all-sprites` – export the panel, lemmings and ground sprites for one level pack
   - `npm run list-sprites` – list sprite names with sizes and frame counts
   - `npm run patch-sprites` – verify a directory of edited sprites (patching not yet implemented)
+
+All exported assets now reside under the `exports/` directory.
 
 ### NodeFileProvider
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -15,7 +15,7 @@ node tools/exportAllPacks.js [pack1 pack2 ...]
 
 Exports panel, lemming and ground sprites for each pack. If no pack names are
 provided it reads `config.json` to determine pack paths. Assets are saved in
-`export_<pack>` directories.
+`exports/export_<pack>` directories.
 
 ## exportAllSprites.js
 
@@ -25,7 +25,7 @@ node tools/exportAllSprites.js [packPath] [outDir]
 
 Exports the skill panel, lemming animations and ground object sprites for a
 single pack. `packPath` defaults to the first entry in `config.json`. Output goes
-to `outDir` (`<pack>_all` by default).
+to `outDir` (`exports/<pack>_all` by default).
 
 ## exportPanelSprite.js
 
@@ -42,7 +42,7 @@ node tools/exportLemmingsSprites.js [packPath] [outDir]
 ```
 
 Exports every lemming animation as individual PNGs plus sprite sheets. The files
-are placed in `outDir` (`<pack>_sprites` by default).
+are placed in `outDir` (`exports/<pack>_sprites` by default).
 
 ## exportGroundImages.js
 
@@ -99,6 +99,6 @@ Removes all `export_*` directories created by the other scripts.
 
 ---
 
-Exported assets go in folders starting with `export_` or `exports/`. The game can
-load levels directly from packed archives, so you may keep your level packs
-compressed while still running these tools.
+Exported assets now live under the `exports/` directory. The game can load levels
+directly from packed archives, so you may keep your level packs compressed while
+still running these tools.

--- a/tools/exportAllPacks.js
+++ b/tools/exportAllPacks.js
@@ -13,6 +13,7 @@ function loadConfig() {
 }
 
 const defaultPacks = loadConfig().map(p => ({ name: p.name, path: p.path }));
+const BASE = 'exports';
 
 let packs;
 if (process.argv.length > 2) {
@@ -24,7 +25,7 @@ if (process.argv.length > 2) {
 }
 
 for (const pack of packs) {
-  const outDir = `export_${pack.name.replace(/\W+/g, '_')}`;
+  const outDir = path.join(BASE, `export_${pack.name.replace(/\W+/g, '_')}`);
   fs.mkdirSync(outDir, { recursive: true });
   console.log(`Exporting ${pack.path} -> ${outDir}`);
   spawnSync('node', ['tools/exportAllSprites.js', pack.path, outDir], { stdio: 'inherit' });

--- a/tools/exportAllSprites.js
+++ b/tools/exportAllSprites.js
@@ -34,7 +34,8 @@ function frameToPNG(frame) {
 
 (async () => {
   const dataPath = process.argv[2] || loadDefaultPack();
-  const outDir   = process.argv[3] || `${dataPath.replace(/\W+/g, '_')}_all`;
+  const BASE = 'exports';
+  const outDir   = process.argv[3] || path.join(BASE, `${dataPath.replace(/\W+/g, '_')}_all`);
   fs.mkdirSync(outDir, { recursive: true });
 
   const provider = new NodeFileProvider('.');

--- a/tools/exportLemmingsSprites.js
+++ b/tools/exportLemmingsSprites.js
@@ -34,7 +34,8 @@ function frameToPNG(frame) {
 
 (async () => {
   const dataPath = process.argv[2] || loadDefaultPack();
-  const outDir = process.argv[3] || `${dataPath.replace(/\W+/g, '_')}_sprites`;
+  const BASE = 'exports';
+  const outDir = process.argv[3] || path.join(BASE, `${dataPath.replace(/\W+/g, '_')}_sprites`);
   fs.mkdirSync(outDir, { recursive: true });
 
   const provider = new NodeFileProvider('.');


### PR DESCRIPTION
## Summary
- centralize exports under the `exports/` folder
- document new export locations

## Testing
- `npm run format`
- `npm test` *(fails: Stage pointer events)*

------
https://chatgpt.com/codex/tasks/task_e_68411cb19b38832da50bfa7f6b099750