### PR TITLE
Fix stage centering

### DIFF
--- a/js/Stage.js
+++ b/js/Stage.js
@@ -214,7 +214,7 @@ class Stage {
     this.guiImgProps.width = this.guiImgProps.display?.getWidth() || 720;
     if (this.guiImgProps.display) {
       const guiW = this.guiImgProps.display.getWidth();
-      this.guiImgProps.x = (stageWidth/4);
+      this.guiImgProps.x = Math.floor((stageWidth - guiW) / 2);
     }
     if (this.gameImgProps.display) {
       this.redraw();

--- a/test/exportScripts.test.js
+++ b/test/exportScripts.test.js
@@ -97,7 +97,7 @@ describe('export scripts', function () {
     const script = patchScript('exportPanelSprite.js');
     try {
       await runScript(script, [pack, outDir]);
-      await new Promise(r => setTimeout(r, 50));
+      await new Promise(r => setTimeout(r, 150));
       expect(fs.existsSync(path.join(outDir, 'panelSprite.png'))).to.be.true;
     } finally {
       fs.rmSync(pack, { recursive: true, force: true });
@@ -111,7 +111,7 @@ describe('export scripts', function () {
     const script = patchScript('exportGroundImages.js');
     try {
       await runScript(script, [pack, '0', outDir]);
-      await new Promise(r => setTimeout(r, 50));
+      await new Promise(r => setTimeout(r, 150));
       expect(fs.existsSync(path.join(outDir, 'terrain_0_0.png')) || fs.existsSync(path.join(outDir, 'object_0_0.png'))).to.be.true;
     } finally {
       fs.rmSync(pack, { recursive: true, force: true });
@@ -125,7 +125,7 @@ describe('export scripts', function () {
     const script = patchScript('exportAllSprites.js');
     try {
       await runScript(script, [pack, outDir]);
-      await new Promise(r => setTimeout(r, 50));
+      await new Promise(r => setTimeout(r, 150));
       expect(fs.existsSync(path.join(outDir, 'panel.png'))).to.be.true;
     } finally {
       fs.rmSync(pack, { recursive: true, force: true });

--- a/test/groundreader.test.js
+++ b/test/groundreader.test.js
@@ -6,7 +6,9 @@ import '../js/BitWriter.js';
 import '../js/PaletteImage.js';
 import '../js/Frame.js';
 import '../js/ColorPalette.js';
-import { GroundReader } from '../js/GroundReader.js';
+import '../js/BaseImageInfo.js';
+import '../js/ObjectImageInfo.js';
+import '../js/TerrainImageInfo.js';
 
 // Silence debug output
 globalThis.lemmings = { game: { showDebug: false } };
@@ -15,7 +17,9 @@ describe('GroundReader', function() {
   it('reads palettes and detects steel', async function() {
     const origFetch = globalThis.fetch;
     globalThis.fetch = async () => ({ json: async () => ({ lemmings: { 'GROUND0O.DAT': [0] } }) });
+    const mod = await import('../js/GroundReader.js?' + Date.now());
     await Lemmings.loadSteelSprites();
+    const { GroundReader } = mod;
     globalThis.fetch = origFetch;
 
     const buf = new Uint8Array(1056);

--- a/test/stage.updateStageSize.test.js
+++ b/test/stage.updateStageSize.test.js
@@ -67,7 +67,8 @@ describe('Stage.updateStageSize', function() {
 
     const guiW = display.getWidth();
     const panelH = display.getHeight();
-    expect(stage.guiImgProps.x).to.equal(200);
+    const center = Math.floor((canvas.width - guiW) / 2);
+    expect(stage.guiImgProps.x).to.equal(center);
     expect(stage.guiImgProps.y).to.equal(540);
     expect(stage.gameImgProps.height).to.equal(560);
     expect(stage.guiImgProps.height).to.equal(panelH);
@@ -86,8 +87,11 @@ describe('Stage.updateStageSize', function() {
     stage.guiImgProps.viewPoint.scale = 3;
     stage.updateStageSize();
 
+    const guiW = display.getWidth();
     const panelH = display.getHeight();
+    const center = Math.floor((canvas.width - guiW) / 2);
     expect(stage.guiImgProps.y).to.equal(540);
     expect(stage.gameImgProps.height).to.equal(560);
+    expect(stage.guiImgProps.x).to.equal(center);
   });
 });


### PR DESCRIPTION
## Summary
- center GUI image using raw display width
- adjust Stage.updateStageSize tests for new logic
- ensure GroundReader test always reloads module to reset steel sprites
- lengthen exportScripts waits for slow file writes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68411dc0dec0832d87f3560226c34724