### PR TITLE
Add bench pause overlay note

### DIFF
--- a/.agentInfo/index-detailed.md
+++ b/.agentInfo/index-detailed.md
@@ -36,3 +36,5 @@ This expanded listing preserves the original bullet format with short descriptio
 - **trigger-system, grid**: [notes/trigger-manager.md](notes/trigger-manager.md) - TriggerManager maintains spatial triggers such as exits, traps and blocker
 - **unpack-file-part**: [notes/unpack-file-part.md](notes/unpack-file-part.md) - UnpackFilePart represents a single compressed chunk inside a container. It
 - **todo, gui, stage**: [notes/gui-stage-tasks.md](notes/gui-stage-tasks.md) - Collection of UI fixes: panel placement, viewport scaling, selection visuals, skill auto-apply, cursor alignment, and cursor removal.
+- **bench-mode, gui**: [notes/pause-overlay.md](notes/pause-overlay.md) - Bench mode highlights the pause button rectangle with `startOverlayFade(rect)` instead of flashing the entire stage.
+

--- a/.agentInfo/index.md
+++ b/.agentInfo/index.md
@@ -38,3 +38,4 @@ todo-review.md: todo
 keyboard-shortcuts.md: keyboard
 note-review.md: todo
 
+pause-overlay.md: bench-mode gui

--- a/.agentInfo/notes/pause-overlay.md
+++ b/.agentInfo/notes/pause-overlay.md
@@ -1,0 +1,5 @@
+# Pause overlay highlight
+
+tags: bench-mode, gui
+
+Bench mode previously flashed the entire stage red while pausing. It now calls `startOverlayFade(rect)` to fade a rectangle over the pause button instead.


### PR DESCRIPTION
## Summary
- document bench mode overlay fade highlight for the pause button
- index the new note in both indexes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684121913fc8832d90feeb9023aa25a1