### PR TITLE
Update notes on selection visuals

### DIFF
--- a/.agentInfo/notes/draw-corner-rect.md
+++ b/.agentInfo/notes/draw-corner-rect.md
@@ -2,4 +2,4 @@
 
 tags: canvas, helper
 
-`DisplayImage.drawCornerRect(x, y, size, r, g, b, cornerSize = 2)` paints filled squares at the four corners of a rectangle. The optional `cornerSize` controls the square size in pixels. This helper is currently unused after hover outlines switched to dashed rectangles only.
+`DisplayImage.drawCornerRect(x, y, size, r, g, b, cornerSize = 2)` paints filled squares at the four corners of a rectangle. The optional `cornerSize` controls the square size in pixels. Hover outlines use this helper with small corners to highlight lemmings without drawing full edges.

--- a/.agentInfo/notes/game-display.md
+++ b/.agentInfo/notes/game-display.md
@@ -4,4 +4,4 @@ tags: render, display
 
 `js/GameDisplay.js` binds the game state to a GUI display. `setGuiDisplay()` attaches mouse handlers that select the nearest lemming on click and track the mouse position for debugging. The `render()` method draws the level, objects, and lemmings. When debug is off it highlights the selected lemming and the one under the cursor. `renderDebug()` paints additional debug information and shows a marching-ants rectangle around the nearest lemming.
 
-`#drawSelection()` now uses `drawDashedRect` to outline the current lemming with a bright green (`0xFF30FF30`) 1 px dashed rectangle. The dashes use length 1 so the box is thin. Hover outlines call `#drawHover()` which draws the same size rectangle in dark grey using `drawDashedRect` with a transparent secondary color.
+`#drawSelection()` now draws bright green corner rectangles using `drawCornerRect`. Each corner uses a 2 px square so the outline looks minimal but stands out. Hover outlines call `#drawHover()` which draws lighter grey corners to indicate the focused lemming without the vivid green.


### PR DESCRIPTION
## Summary
- clarify lemming selection and hover outlines
- describe how drawCornerRect is used for hover

## Testing
- `npm test` *(fails: ENOENT num_left_6.png)*

------
https://chatgpt.com/codex/tasks/task_e_6841218302d4832d93c26f263e6071cd