### PR TITLE
Fix GUI panel scaling

### DIFF
--- a/js/Stage.js
+++ b/js/Stage.js
@@ -203,18 +203,22 @@ class Stage {
   updateStageSize() {
     const stageHeight = this.stageCav.height;
     const stageWidth = this.stageCav.width;
-    const panelRawHeight = this.guiImgProps.display?.getHeight() || 80;
-    const gamePanelOffset = (stageHeight - panelRawHeight - 20);
+    const scale = this.guiImgProps.viewPoint.scale;
+    const rawHeight = this.guiImgProps.display?.getHeight() || 80;
+    const rawWidth = this.guiImgProps.display?.getWidth() || 720;
+
+    const panelHeight = rawHeight * scale;
+    const panelWidth = rawWidth * scale;
+    const gamePanelOffset = stageHeight - panelHeight - 20;
     this.gameImgProps.y = -20;
     this.gameImgProps.x = 0;
-    this.gameImgProps.height = stageHeight - panelRawHeight;
+    this.gameImgProps.height = stageHeight - panelHeight;
     this.gameImgProps.width = stageWidth;
     this.guiImgProps.y = gamePanelOffset;
-    this.guiImgProps.height = panelRawHeight;
-    this.guiImgProps.width = this.guiImgProps.display?.getWidth() || 720;
+    this.guiImgProps.height = panelHeight;
+    this.guiImgProps.width = panelWidth;
     if (this.guiImgProps.display) {
-      const guiW = this.guiImgProps.display.getWidth();
-      this.guiImgProps.x = (stageWidth/4);
+      this.guiImgProps.x = (stageWidth - panelWidth) / 2;
     }
     if (this.gameImgProps.display) {
       this.redraw();

--- a/test/stage.updateStageSize.test.js
+++ b/test/stage.updateStageSize.test.js
@@ -65,11 +65,12 @@ describe('Stage.updateStageSize', function() {
     canvas.getContext().canvas.width = 800;
     stage.updateStageSize();
 
-    const guiW = display.getWidth();
-    const panelH = display.getHeight();
-    expect(stage.guiImgProps.x).to.equal(200);
-    expect(stage.guiImgProps.y).to.equal(540);
-    expect(stage.gameImgProps.height).to.equal(560);
+    const scale = stage.guiImgProps.viewPoint.scale;
+    const guiW = display.getWidth() * scale;
+    const panelH = display.getHeight() * scale;
+    expect(stage.guiImgProps.x).to.equal(240);
+    expect(stage.guiImgProps.y).to.equal(500);
+    expect(stage.gameImgProps.height).to.equal(520);
     expect(stage.guiImgProps.height).to.equal(panelH);
     expect(stage.guiImgProps.width).to.equal(guiW);
   });
@@ -86,8 +87,9 @@ describe('Stage.updateStageSize', function() {
     stage.guiImgProps.viewPoint.scale = 3;
     stage.updateStageSize();
 
-    const panelH = display.getHeight();
-    expect(stage.guiImgProps.y).to.equal(540);
-    expect(stage.gameImgProps.height).to.equal(560);
+    const scale = stage.guiImgProps.viewPoint.scale;
+    const panelH = display.getHeight() * scale;
+    expect(stage.guiImgProps.y).to.equal(460);
+    expect(stage.gameImgProps.height).to.equal(480);
   });
 });


### PR DESCRIPTION
## Summary
- scale GUI panel size using its ViewPoint
- center bottom panel based on scaled width
- update tests for new panel calculations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841218219f0832d9307bffe017c2588