### PR TITLE
Add KeyN shortcut to clear selection

### DIFF
--- a/js/KeyboardShortcuts.js
+++ b/js/KeyboardShortcuts.js
@@ -256,6 +256,9 @@ class KeyboardShortcuts {
     case 'Tab':
       this._cycleSkill();
       break;
+    case 'KeyN':
+      this.view.game.getLemmingManager()?.setSelectedLemming(null);
+      break;
     case 'Backquote':
       this.view.game.getLemmingManager()?.cycleSelection(e.shiftKey ? -1 : 1);
       break;

--- a/test/keyboardshortcuts.test.js
+++ b/test/keyboardshortcuts.test.js
@@ -6,12 +6,13 @@ import '../js/CommandSelectSkill.js';
 globalThis.lemmings = { game: { showDebug: false } };
 
 describe('KeyboardShortcuts', function() {
-  function createShortcuts(timer, manager) {
+  function createShortcuts(timer, manager, lemMgr = null) {
     const game = {
       commandManager: manager,
       gameGui: { drawSpeedChange() {}, skillSelectionChanged: false },
       getGameTimer() { return timer; },
-      queueCommand(cmd) { manager.queueCommand(cmd); }
+      queueCommand(cmd) { manager.queueCommand(cmd); },
+      getLemmingManager() { return lemMgr; }
     };
     const view = { game };
     global.window = { addEventListener() {}, removeEventListener() {} };
@@ -39,5 +40,17 @@ describe('KeyboardShortcuts', function() {
     const evt = { code: 'Minus', shiftKey: false, ctrlKey: false, metaKey: false, preventDefault() {} };
     ks._onKeyDown(evt);
     expect(timer.speedFactor).to.be.below(2);
+  });
+
+  it('clears selected lemming with KeyN', function() {
+    const manager = { queueCommand() {} };
+    let selected = 'foo';
+    const lemMgr = { setSelectedLemming(arg) { selected = arg; } };
+    const timer = { speedFactor: 1 };
+    const ks = createShortcuts(timer, manager, lemMgr);
+
+    const evt = { code: 'KeyN', shiftKey: false, ctrlKey: false, metaKey: false, preventDefault() {} };
+    ks._onKeyDown(evt);
+    expect(selected).to.equal(null);
   });
 });


### PR DESCRIPTION
## Summary
- clear current lemming selection with `N`
- add test for the new shortcut

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684121808f88832dbb4c9fe80e4aed2b