### PR TITLE
Update GameDisplay hover visuals

### DIFF
--- a/.agentInfo/notes/draw-corner-rect.md
+++ b/.agentInfo/notes/draw-corner-rect.md
@@ -2,4 +2,4 @@
 
 tags: canvas, helper
 
-`DisplayImage.drawCornerRect(x, y, size, r, g, b, cornerSize = 2)` paints filled squares at the four corners of a rectangle. The optional `cornerSize` controls the square size in pixels. This helper is currently unused after hover outlines switched to dashed rectangles only.
+`DisplayImage.drawCornerRect(x, y, size, r, g, b, cornerSize = 2)` paints filled squares at the four corners of a rectangle. The optional `cornerSize` controls the square size in pixels. GameDisplay now calls this helper for both selection and hover outlines.

--- a/.agentInfo/notes/game-display.md
+++ b/.agentInfo/notes/game-display.md
@@ -4,4 +4,4 @@ tags: render, display
 
 `js/GameDisplay.js` binds the game state to a GUI display. `setGuiDisplay()` attaches mouse handlers that select the nearest lemming on click and track the mouse position for debugging. The `render()` method draws the level, objects, and lemmings. When debug is off it highlights the selected lemming and the one under the cursor. `renderDebug()` paints additional debug information and shows a marching-ants rectangle around the nearest lemming.
 
-`#drawSelection()` now uses `drawDashedRect` to outline the current lemming with a bright green (`0xFF30FF30`) 1 px dashed rectangle. The dashes use length 1 so the box is thin. Hover outlines call `#drawHover()` which draws the same size rectangle in dark grey using `drawDashedRect` with a transparent secondary color.
+`#drawSelection()` now calls `drawCornerRect` to paint 2 px squares at each corner of the 10 × 13 rectangle (`x-5`, `y-11`).  The default colour is bright green (`0x00FF00`) but turns yellow when the selected skill would do nothing.  `#drawHover()` uses the same helper with a grey about 10 % lighter than `0x555555`.

--- a/js/GameDisplay.js
+++ b/js/GameDisplay.js
@@ -67,11 +67,10 @@ class GameDisplay {
   }
 
   #drawSelection(lem) {
-    const dashLen = 1;
     const x = lem.x - 5;
-    const y = lem.y - 9; // slight upward offset
+    const y = lem.y - 11; // sits a bit higher
 
-    let color = 0xff30ff30; // lighter green
+    let color = 0x00ff00; // bright green
     const skills = this.game?.getGameSkills?.();
     if (skills) {
       const selectedSkill = skills.getSelectedSkill();
@@ -87,16 +86,15 @@ class GameDisplay {
       }
     }
 
-    this.display.drawDashedRect(x, y, 10, 13, dashLen, 0, color, 0x00000000);
+    this.display.drawCornerRect(x, y, { width: 10, height: 13 }, color & 0xff, (color >> 8) & 0xff, (color >> 16) & 0xff);
   }
 
   #drawHover(lem) {
-    const dashLen = 2;
     const x = lem.x - 5;
-    const y = lem.y - 9; // slight upward offset
-    const color = 0xff555555; // mid-dark gray
+    const y = lem.y - 11; // sits a bit higher
+    const color = 0x5e5e5e; // slightly lighter grey
 
-    this.display.drawDashedRect(x, y, 10, 13, dashLen, 0, color, 0x00000000);
+    this.display.drawCornerRect(x, y, { width: 10, height: 13 }, color & 0xff, (color >> 8) & 0xff, (color >> 16) & 0xff);
   }
 
   dispose() {


### PR DESCRIPTION
## Summary
- tweak GameDisplay selection and hover outlines
- document new corner-based outlines in agent notes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841217e39bc832d9c24eeb7f841b07e