### PR TITLE
Fix zoomed-out view disappearing

### DIFF
--- a/js/Stage.js
+++ b/js/Stage.js
@@ -410,33 +410,55 @@ class Stage {
     let outW = display.width;
     ctx.globalAlpha = 1;
     //- Display Layers
-    let dW = img.width - display.viewPoint.x; //- display width
-    if ((dW * display.viewPoint.scale) > outW) {
-      dW = outW / display.viewPoint.scale;
+    // Source rectangle
+    let sx = display.viewPoint.x;
+    let sy = display.viewPoint.y;
+    let sw = img.width - sx;
+    let sh = img.height - sy;
+    // Clamp against negative offsets
+    if (sx < 0) {
+      sw += sx;
+      sx = 0;
     }
-    let dH = img.height - display.viewPoint.y; //- display height
-    if ((dH * display.viewPoint.scale) > outH) {
-      dH = outH / display.viewPoint.scale;
+    if (sy < 0) {
+      sh += sy;
+      sy = 0;
+    }
+    // Clamp to image bounds
+    sw = Math.min(sw, img.width - sx);
+    sh = Math.min(sh, img.height - sy);
+    // Destination rectangle
+    let dx = display.x + Math.max(-display.viewPoint.x, 0) * display.viewPoint.scale;
+    let dy = display.y + Math.max(-display.viewPoint.y, 0) * display.viewPoint.scale;
+    let dw = sw * display.viewPoint.scale;
+    let dh = sh * display.viewPoint.scale;
+    if (dw > outW) {
+      sw = outW / display.viewPoint.scale;
+      dw = outW;
+    }
+    if (dh > outH) {
+      sh = outH / display.viewPoint.scale;
+      dh = outH;
     }
     //- drawImage(image,sx,sy,sw,sh,dx,dy,dw,dh)
-    ctx.drawImage(display.cav, display.viewPoint.x, display.viewPoint.y, dW, dH, display.x, display.y, Math.trunc(dW * display.viewPoint.scale), Math.trunc(dH * display.viewPoint.scale));
+    ctx.drawImage(display.cav, sx, sy, sw, sh, dx, dy, Math.trunc(dw), Math.trunc(dh));
     //- apply fading
     if (this.fadeAlpha != 0) {
       ctx.globalAlpha = this.fadeAlpha;
       ctx.fillStyle = 'black';
-      ctx.fillRect(display.x, display.y, Math.trunc(dW * display.viewPoint.scale), Math.trunc(dH * display.viewPoint.scale));
+      ctx.fillRect(display.x, display.y, Math.trunc(dw), Math.trunc(dh));
       ctx.globalAlpha = 1;
     }
     if (this.overlayAlpha > 0) {
       ctx.globalAlpha = this.overlayAlpha;
       ctx.fillStyle = this.overlayColor;
-      ctx.fillRect(display.x, display.y, Math.trunc(dW * display.viewPoint.scale), Math.trunc(dH * display.viewPoint.scale));
+      ctx.fillRect(display.x, display.y, Math.trunc(dw), Math.trunc(dh));
       ctx.globalAlpha = 1;
     }
     if (display === this.gameImgProps && this.overlayAlpha > 0) {
       ctx.globalAlpha = this.overlayAlpha;
       ctx.fillStyle = this.overlayColor;
-      ctx.fillRect(display.x, display.y, Math.trunc(dW * display.viewPoint.scale), Math.trunc(dH * display.viewPoint.scale));
+      ctx.fillRect(display.x, display.y, Math.trunc(dw), Math.trunc(dh));
     }
   }
 


### PR DESCRIPTION
## Summary
- handle negative viewport offsets when drawing to the canvas

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684120a3e91c832db86c55ba7e332745