### PR TITLE
Update lemming selection on click

### DIFF
--- a/js/GameDisplay.js
+++ b/js/GameDisplay.js
@@ -19,11 +19,12 @@ class GameDisplay {
   setGuiDisplay(display) {
     this.display = display;
     this._mouseHandler = (e) => {
-      //console.log(e.x +" "+ e.y);
-      let lem = this.lemmingManager.getNearestLemming(e.x, e.y);
-      if (!lem)
-        return;
-      this.game.queueCommand(new Lemmings.CommandLemmingsAction(lem.id));
+      const lem = this.lemmingManager.getNearestLemming(e.x, e.y);
+      if (lem) {
+        this.lemmingManager.setSelectedLemming(lem);
+      } else {
+        this.lemmingManager.setSelectedLemming(null);
+      }
     };
     this.display.onMouseDown.on(this._mouseHandler);
     this._mouseMoveHandler = (e) => {


### PR DESCRIPTION
## Summary
- when clicking the playfield, select the nearest lemming instead of queuing a command
- keep hover functionality intact

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684122530b44832db0dc277fe14a5e3e