### PR TITLE
Add overlay region support

### DIFF
--- a/js/GameView.js
+++ b/js/GameView.js
@@ -110,7 +110,7 @@ class GameView extends Lemmings.BaseLogger {
     }
     this.game.getGameTimer().suspend();
     if (this.stage?.startOverlayFade) {
-      this.stage.startOverlayFade(color);
+      this.stage.startOverlayFade(color, { x: 160, y: 32, w: 16, h: 10 });
     }
   }
 

--- a/js/Stage.js
+++ b/js/Stage.js
@@ -8,6 +8,7 @@ class Stage {
     this.overlayColor = 'black';
     this.overlayAlpha = 0;
     this.overlayTimer = 0;
+    this.overlayRect = null;
     this.cursorCanvas = null;
     this.cursorX = 0;
     this.cursorY = 0;
@@ -316,6 +317,7 @@ class Stage {
   resetFade() {
     this.fadeAlpha = 0;
     this.overlayAlpha = 0;
+    this.overlayRect = null;
     if (this.fadeTimer != 0) {
       clearInterval(this.fadeTimer);
       this.fadeTimer = 0;
@@ -326,17 +328,20 @@ class Stage {
     }
   }
 
-  startOverlayFade() {
+  startOverlayFade(color, rect = null) {
     if (this.overlayTimer) {
       clearInterval(this.overlayTimer);
       this.overlayTimer = 0;
     }
+    if (color) this.overlayColor = color;
+    this.overlayRect = rect;
     this.overlayAlpha = 1;
     this.overlayTimer = setInterval(() => {
       this.overlayAlpha = Math.max(this.overlayAlpha - 0.02, 0);
       if (this.overlayAlpha <= 0) {
         clearInterval(this.overlayTimer);
         this.overlayTimer = 0;
+        this.overlayRect = null;
       }
     }, 40);
   }
@@ -359,21 +364,6 @@ class Stage {
     }, 40);
   }
 
-  startOverlayFade(color) {
-    if (this.overlayTimer) {
-      clearInterval(this.overlayTimer);
-      this.overlayTimer = 0;
-    }
-    this.overlayColor = color;
-    this.overlayAlpha = 1;
-    this.overlayTimer = setInterval(() => {
-      this.overlayAlpha = Math.max(this.overlayAlpha - 0.02, 0);
-      if (this.overlayAlpha <= 0) {
-        clearInterval(this.overlayTimer);
-        this.overlayTimer = 0;
-      }
-    }, 40);
-  }
   dispose() {
     this.resetFade();
     if (this.fadeTimer) {
@@ -430,13 +420,17 @@ class Stage {
     if (this.overlayAlpha > 0) {
       ctx.globalAlpha = this.overlayAlpha;
       ctx.fillStyle = this.overlayColor;
-      ctx.fillRect(display.x, display.y, Math.trunc(dW * display.viewPoint.scale), Math.trunc(dH * display.viewPoint.scale));
+      if (this.overlayRect) {
+        const scale = display.viewPoint.scale;
+        const x = display.x + Math.trunc(this.overlayRect.x * scale);
+        const y = display.y + Math.trunc(this.overlayRect.y * scale);
+        const w = Math.trunc(this.overlayRect.w * scale);
+        const h = Math.trunc(this.overlayRect.h * scale);
+        ctx.fillRect(x, y, w, h);
+      } else {
+        ctx.fillRect(display.x, display.y, Math.trunc(dW * display.viewPoint.scale), Math.trunc(dH * display.viewPoint.scale));
+      }
       ctx.globalAlpha = 1;
-    }
-    if (display === this.gameImgProps && this.overlayAlpha > 0) {
-      ctx.globalAlpha = this.overlayAlpha;
-      ctx.fillStyle = this.overlayColor;
-      ctx.fillRect(display.x, display.y, Math.trunc(dW * display.viewPoint.scale), Math.trunc(dH * display.viewPoint.scale));
     }
   }
 


### PR DESCRIPTION
## Summary
- add `overlayRect` state to `Stage`
- fade overlay within an optional rectangle when drawing
- clear `overlayRect` in `resetFade`
- specify pause button region in `suspendWithColor`

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841218ae898832da95af0dd8966cd19