### PR TITLE
Improve keyboard skill cycling

### DIFF
--- a/js/CommandSelectSkill.js
+++ b/js/CommandSelectSkill.js
@@ -2,13 +2,10 @@ import { Lemmings } from './LemmingsNamespace.js';
 import './LogHandler.js';
 
 class CommandSelectSkill extends Lemmings.BaseLogger {
-  constructor(skill) {
+  constructor(skill = Lemmings.SkillTypes.UNKNOWN, apply = true) {
     super();
-    if (!skill) {
-      this.log.log('error, skill is null');
-      return;
-    }
     this.skill = skill;
+    this.apply = apply;
   }
 
   execute(game) {
@@ -16,20 +13,25 @@ class CommandSelectSkill extends Lemmings.BaseLogger {
     if (!gameSkills) return false;
     const lemmingManager = game.getLemmingManager?.();
     const changed = gameSkills.setSelectedSkill(this.skill);
-    const lem = lemmingManager?.getSelectedLemming?.();
-    if (lem && gameSkills.canReuseSkill(this.skill) &&
-        lemmingManager.doLemmingAction?.(lem, this.skill)) {
-      gameSkills.reuseSkill(this.skill);
+    if (this.apply) {
+      const lem = lemmingManager?.getSelectedLemming?.();
+      if (lem && gameSkills.canReuseSkill(this.skill) &&
+          lemmingManager.doLemmingAction?.(lem, this.skill)) {
+        gameSkills.reuseSkill(this.skill);
+      }
     }
     return changed;
   }
 
   load(values) {
-    this.skillType = values[0];
+    this.skill = +(values[0]);
+    this.apply = values.length > 1 ? !!(+values[1]) : true;
   }
 
   save() {
-    return [+(this.skill)];
+    const out = [+(this.skill)];
+    if (!this.apply) out.push(0);
+    return out;
   }
 
   getCommandKey() {

--- a/js/KeyboardShortcuts.js
+++ b/js/KeyboardShortcuts.js
@@ -118,11 +118,12 @@ class KeyboardShortcuts {
     }
   }
 
-  _cycleSkill() {
+  _cycleSkill(dir = 1) {
     const skills = this.view.game.getGameSkills();
-    let next = skills.getSelectedSkill() + 1;
+    let next = skills.getSelectedSkill() + dir;
     if (next > Lemmings.SkillTypes.DIGGER) next = Lemmings.SkillTypes.CLIMBER;
-    this.view.game.queueCommand(new Lemmings.CommandSelectSkill(next));
+    if (next < Lemmings.SkillTypes.CLIMBER) next = Lemmings.SkillTypes.DIGGER;
+    this.view.game.queueCommand(new Lemmings.CommandSelectSkill(next, false));
     this.view.game.gameGui.skillSelectionChanged = true;
   }
 
@@ -254,8 +255,13 @@ class KeyboardShortcuts {
       this.zoom.reset = 2; this._startLoop();
       break;
     case 'Tab':
-      this._cycleSkill();
+      this._cycleSkill(e.shiftKey ? -1 : 1);
       break;
+    case 'KeyK': {
+      const mgr = this.view.game.getLemmingManager?.();
+      const lem = mgr?.getSelectedLemming?.();
+      if (lem) this.view.game.queueCommand(new Lemmings.CommandLemmingsAction(lem.id));
+      break; }
     case 'Backquote':
       this.view.game.getLemmingManager()?.cycleSelection(e.shiftKey ? -1 : 1);
       break;

--- a/test/keyboardshortcuts.test.js
+++ b/test/keyboardshortcuts.test.js
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import { Lemmings } from '../js/LemmingsNamespace.js';
 import { KeyboardShortcuts } from '../js/KeyboardShortcuts.js';
 import '../js/CommandSelectSkill.js';
+import '../js/CommandLemmingsAction.js';
 
 globalThis.lemmings = { game: { showDebug: false } };
 
@@ -11,7 +12,9 @@ describe('KeyboardShortcuts', function() {
       commandManager: manager,
       gameGui: { drawSpeedChange() {}, skillSelectionChanged: false },
       getGameTimer() { return timer; },
-      queueCommand(cmd) { manager.queueCommand(cmd); }
+      queueCommand(cmd) { manager.queueCommand(cmd); },
+      getGameSkills() { return { getSelectedSkill() { return Lemmings.SkillTypes.CLIMBER; }, setSelectedSkill() {} }; },
+      getLemmingManager() { return { getSelectedLemming() { return { id: 1 }; } }; }
     };
     const view = { game };
     global.window = { addEventListener() {}, removeEventListener() {} };
@@ -39,5 +42,43 @@ describe('KeyboardShortcuts', function() {
     const evt = { code: 'Minus', shiftKey: false, ctrlKey: false, metaKey: false, preventDefault() {} };
     ks._onKeyDown(evt);
     expect(timer.speedFactor).to.be.below(2);
+  });
+
+  it('cycles skill with Tab without applying', function() {
+    const log = [];
+    const manager = { queueCommand(cmd) { log.push(cmd); } };
+    const timer = { speedFactor: 1 };
+    const ks = createShortcuts(timer, manager);
+
+    const evt = { code: 'Tab', shiftKey: false, ctrlKey: false, metaKey: false, preventDefault() {} };
+    ks._onKeyDown(evt);
+    expect(log).to.have.lengthOf(1);
+    expect(log[0]).to.be.instanceOf(Lemmings.CommandSelectSkill);
+    expect(log[0].apply).to.be.false;
+  });
+
+  it('cycles skill backward with Shift+Tab', function() {
+    const log = [];
+    const manager = { queueCommand(cmd) { log.push(cmd); } };
+    const timer = { speedFactor: 1 };
+    const ks = createShortcuts(timer, manager);
+
+    const evt = { code: 'Tab', shiftKey: true, ctrlKey: false, metaKey: false, preventDefault() {} };
+    ks._onKeyDown(evt);
+    expect(log).to.have.lengthOf(1);
+    expect(log[0]).to.be.instanceOf(Lemmings.CommandSelectSkill);
+    expect(log[0].apply).to.be.false;
+  });
+
+  it('assigns skill with KeyK', function() {
+    const log = [];
+    const manager = { queueCommand(cmd) { log.push(cmd); } };
+    const timer = { speedFactor: 1 };
+    const ks = createShortcuts(timer, manager);
+
+    const evt = { code: 'KeyK', shiftKey: false, ctrlKey: false, metaKey: false, preventDefault() {} };
+    ks._onKeyDown(evt);
+    expect(log).to.have.lengthOf(1);
+    expect(log[0]).to.be.instanceOf(Lemmings.CommandLemmingsAction);
   });
 });


### PR DESCRIPTION
## Summary
- modify `CommandSelectSkill` to allow skipping auto-use
- prevent Tab cycling from using skills and support Shift+Tab
- add KeyK binding to assign current skill
- extend keyboard shortcut tests for new behaviour

## Testing
- `npm run format`
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841221ff834832d88f5bb5ee36ea789