### PR TITLE
Document WebMIDI setup

### DIFF
--- a/.agentInfo/index-detailed.md
+++ b/.agentInfo/index-detailed.md
@@ -38,3 +38,5 @@ This expanded listing preserves the original bullet format with short descriptio
 - **todo, gui, stage**: [notes/gui-stage-tasks.md](notes/gui-stage-tasks.md) - Collection of UI fixes: panel placement, viewport scaling, selection visuals, skill auto-apply, cursor alignment, and cursor removal.
 - **bench-mode, gui**: [notes/pause-overlay.md](notes/pause-overlay.md) - Bench mode highlights the pause button rectangle with `startOverlayFade(rect)` instead of flashing the entire stage.
 
+
+- **webmidi, browser**: [notes/webmidi.md](notes/webmidi.md) - WebMIDI works only in secure contexts and requires user permission for device access.

--- a/.agentInfo/index.md
+++ b/.agentInfo/index.md
@@ -39,3 +39,5 @@ keyboard-shortcuts.md: keyboard
 note-review.md: todo
 
 pause-overlay.md: bench-mode gui
+
+webmidi.md: webmidi doc

--- a/.agentInfo/notes/webmidi.md
+++ b/.agentInfo/notes/webmidi.md
@@ -1,0 +1,5 @@
+# WebMIDI in browsers
+
+tags: webmidi, browser
+
+Browsers only expose WebMIDI on secure origins (`https:` or `localhost`). When `index.html` calls `WebMidi.enable()`, the user must grant permission for MIDI device access. See the MIDI section in `AGENTS.md` for quick setup details.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,12 @@ quotes, and semicolons across the JavaScript codebase.
 - `npm run lint` checks source files with ESLint.
 - JavaScript code uses **two-space indentation** (see `js/BitReader.js` for examples).
 - The `js/` directory runs in the browser, so avoid Node-only modules like `fs`, `path`, or `process` in that code.
+### WebMIDI
+- Browsers only enable WebMIDI on HTTPS or localhost.
+- Running `WebMidi.enable()` prompts the user to allow MIDI device access.
+- See `.agentInfo/notes/webmidi.md` for details.
+- The call in `index.html` lines 22-24 is commented out; enable it for MIDI tests.
+
 
 ## Commit policy
 - Keep commit messages concise.

--- a/test/keyboardshortcuts.test.js
+++ b/test/keyboardshortcuts.test.js
@@ -14,7 +14,9 @@ describe('KeyboardShortcuts', function() {
       getGameTimer() { return timer; },
       queueCommand(cmd) { manager.queueCommand(cmd); },
       getGameSkills() { return { getSelectedSkill() { return Lemmings.SkillTypes.CLIMBER; }, setSelectedSkill() {} }; },
-      getLemmingManager() { return { getSelectedLemming() { return { id: 1 }; } }; }
+      getLemmingManager() {
+        return lemMgr || { getSelectedLemming() { return { id: 1 }; }, setSelectedLemming() {} };
+      }
     };
     const view = { game };
     global.window = { addEventListener() {}, removeEventListener() {} };
@@ -80,6 +82,8 @@ describe('KeyboardShortcuts', function() {
     ks._onKeyDown(evt);
     expect(log).to.have.lengthOf(1);
     expect(log[0]).to.be.instanceOf(Lemmings.CommandLemmingsAction);
+  });
+
   it('clears selected lemming with KeyN', function() {
     const manager = { queueCommand() {} };
     let selected = 'foo';


### PR DESCRIPTION
## Summary
- note that WebMIDI works only in secure contexts and requires user permission
- mention that index.html has commented MIDI initialization lines
- add `.agentInfo` note describing WebMIDI browser requirements
- fix test utility so KeyboardShortcuts tests pass

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841251a5be0832da5f47e9cf89ca286