### PR TITLE
Add WebMIDI tasks note

### DIFF
--- a/.agentInfo/index-detailed.md
+++ b/.agentInfo/index-detailed.md
@@ -37,4 +37,5 @@ This expanded listing preserves the original bullet format with short descriptio
 - **unpack-file-part**: [notes/unpack-file-part.md](notes/unpack-file-part.md) - UnpackFilePart represents a single compressed chunk inside a container. It
 - **todo, gui, stage**: [notes/gui-stage-tasks.md](notes/gui-stage-tasks.md) - Collection of UI fixes: panel placement, viewport scaling, selection visuals, skill auto-apply, cursor alignment, and cursor removal.
 - **bench-mode, gui**: [notes/pause-overlay.md](notes/pause-overlay.md) - Bench mode highlights the pause button rectangle with `startOverlayFade(rect)` instead of flashing the entire stage.
+- **webmidi-todo**: [notes/webmidi-tasks.md](notes/webmidi-tasks.md) - Follow-ups on WebMIDI TODOs such as master tuning and browser support for `Output.clear()`.
 

--- a/.agentInfo/index.md
+++ b/.agentInfo/index.md
@@ -37,5 +37,6 @@ pack-mechanics.md: mechanics
 todo-review.md: todo
 keyboard-shortcuts.md: keyboard
 note-review.md: todo
+webmidi-tasks.md: webmidi-todo
 
 pause-overlay.md: bench-mode gui

--- a/.agentInfo/notes/webmidi-tasks.md
+++ b/.agentInfo/notes/webmidi-tasks.md
@@ -1,0 +1,9 @@
+# WebMIDI follow-up tasks
+
+tags: webmidi-todo
+
+Several TODOs remain in `js/webmidi.js`.
+
+1. **Investigate `sendMasterTuning()`** – Line 3597 mentions allowing a MSB/LSB pair. Check how master tuning is encoded via Registered Parameter Number 0x0003 and support passing an array similar to `sendPitchBendRange()`. See the [RPN table](https://www.midi.org/specifications/midi-reference-tables/registered-parameter-numbers).
+2. **Standardize MSB/LSB handling** – `sendPitchBend()` and `sendPitchBendRange()` (around lines 3759‑3833) parse MSB and LSB values differently. Normalize argument formats. GitHub [issue #442](https://github.com/djipco/webmidi/issues/442) provides context on MSB/LSB processing.
+3. **Evaluate `Output.clear()` support** – Lines 4552‑4565 warn that `Output.clear()` is not widely implemented. Follow [issue #52](https://github.com/djipco/webmidi/issues/52) for browser support and consider using `sendChannelMode('allnotesoff')` as a fallback as recommended in the spec.


### PR DESCRIPTION
## Summary
- note WebMIDI follow-up items under `.agentInfo/notes/`
- reference the note in `.agentInfo/index.md`
- expand the detailed index

## Testing
- `npm install`
- `npm run format` *(fails: Parsing error in keyboardshortcuts.test.js)*
- `npm test` *(fails: SyntaxError in keyboardshortcuts.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_6841251b50d8832d90b6ef4f228bbbfb