### PR TITLE
Fix command in exporting-sprites guide

### DIFF
--- a/docs/exporting-sprites.md
+++ b/docs/exporting-sprites.md
@@ -4,7 +4,7 @@
 - Clone: `git clone https://github.com/doublemover/LemmingsJS-MIDI`
 - Terminal:
   - `npm install`
-  - `npm run`
+  - `npm start`
   - `npm run export-all-packs` *(optional)* – exports sprite folders for all level packs under `exports/`
     - `zip -r export_lemmings.zip exports/export_lemmings`
     - `tar -czf export_lemmings.tgz exports/export_lemmings`


### PR DESCRIPTION
## Summary
- update instructions to run `npm start` instead of `npm run`

## Testing
- `npm install`
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68413133b7c0832da4160e9d9cda3ac8