### PR TITLE
Remove unused normTickCount field

### DIFF
--- a/.agentInfo/notes/norm-tick-count-removal.md
+++ b/.agentInfo/notes/norm-tick-count-removal.md
@@ -4,4 +4,5 @@ tags: cleanup, game-timer
 
 The obsolete `normTickCount` field in `GameTimer` was folded into
 `#stableTicks` and its accessor methods removed. Bench mode now updates
-`#stableTicks` directly.
+`#stableTicks` directly and the last assignment to `normTickCount`
+was deleted.

--- a/js/GameTimer.js
+++ b/js/GameTimer.js
@@ -189,7 +189,6 @@ class GameTimer {
         this.suspend();
       }
     }
-    this.normTickCount = this.#stableTicks;
   }
 
   #catchupSpeedAdjust(steps) {


### PR DESCRIPTION
## Summary
- drop the leftover `normTickCount` assignment
- note complete removal in agent docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68412f8a4da4832db4d1da0d321e0d26