### PR TITLE
Add HTML processing test

### DIFF
--- a/test/tools/processHtmlFile.test.js
+++ b/test/tools/processHtmlFile.test.js
@@ -1,0 +1,32 @@
+import { expect } from 'chai';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { pathToFileURL } from 'url';
+import { processHtmlFile } from '../../tools/processHtmlFile.js';
+
+describe('tools/processHtmlFile', function () {
+  it('rewrites relative asset links to file URLs', function () {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'html-'));
+    fs.mkdirSync(path.join(dir, 'js'));
+    fs.mkdirSync(path.join(dir, 'css'));
+    fs.mkdirSync(path.join(dir, 'img'));
+    fs.writeFileSync(path.join(dir, 'js', 'app.js'), 'console.log("hi");');
+    fs.writeFileSync(path.join(dir, 'css', 'style.css'), 'body{color:red;}');
+    fs.writeFileSync(path.join(dir, 'img', 'pic.png'), Buffer.from([0]));
+
+    const html = `<!DOCTYPE html><html><head>
+      <link rel="stylesheet" href="css/style.css">
+      <script src="js/app.js"></script>
+    </head><body><img src="img/pic.png"></body></html>`;
+    const file = path.join(dir, 'index.html');
+    fs.writeFileSync(file, html);
+
+    const result = processHtmlFile(file, { rewritePaths: true });
+    expect(result.snippets).to.be.an('array');
+    const processed = result.html;
+    expect(processed).to.include(pathToFileURL(path.join(dir, 'css', 'style.css')).href);
+    expect(processed).to.include(pathToFileURL(path.join(dir, 'js', 'app.js')).href);
+    expect(processed).to.include(pathToFileURL(path.join(dir, 'img', 'pic.png')).href);
+  });
+});

--- a/test/userinput.test.js
+++ b/test/userinput.test.js
@@ -5,6 +5,43 @@ import '../js/Position2D.js';
 import { UserInputManager } from '../js/UserInputManager.js';
 import { Stage } from '../js/Stage.js';
 
+function createStubCanvas(width = 800, height = 600) {
+  const ctx = {
+    canvas: { width, height },
+    fillRect() {},
+    drawImage() {},
+    putImageData() {}
+  };
+  return {
+    width,
+    height,
+    getContext() { return ctx; },
+    addEventListener() {},
+    removeEventListener() {}
+  };
+}
+
+function createDocumentStub() {
+  return {
+    createElement() {
+      const ctx = {
+        canvas: {},
+        fillRect() {},
+        drawImage() {},
+        putImageData() {},
+        createImageData(w, h) {
+          return { width: w, height: h, data: new Uint8ClampedArray(w * h * 4) };
+        }
+      };
+      return {
+        width: 0,
+        height: 0,
+        getContext() { ctx.canvas = this; return ctx; }
+      };
+    }
+  };
+}
+
 globalThis.lemmings = { game: { showDebug: false } };
 
 describe('UserInputManager', function() {
@@ -26,8 +63,10 @@ describe('UserInputManager', function() {
       } catch (err) {
         done(err);
       }
-    };
-  }
+    });
+    const pos = new Lemmings.Position2D(100, 50);
+    uim.handleWheel(pos, 120);
+  });
 
   before(function() {
     global.document = createDocumentStub();


### PR DESCRIPTION
## Summary
- extend `processHtmlFile` with optional asset path rewriting/inlining
- fix syntax in `userinput.test.js`
- add new test verifying rewritten asset paths

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684204eb4d60832d8349f1ba6191e09e