### PR TITLE
Add packLevels sorted order test

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "scripts": {
     "start": "http-server --cors=*",
     "check-undefined": "node tools/check-undefined.js",
-    "test": "mocha",
-    "coverage": "c8 mocha",
+    "test": "mocha \"test/**/*.test.js\"",
+    "coverage": "c8 mocha \"test/**/*.test.js\"",
     "export-panel-sprite": "node tools/exportPanelSprite.js",
     "export-lemmings-sprites": "node tools/exportLemmingsSprites.js",
     "export-ground-images": "node tools/exportGroundImages.js",

--- a/test/tools/packLevels.test.js
+++ b/test/tools/packLevels.test.js
@@ -1,0 +1,55 @@
+import { expect } from 'chai';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { spawnSync } from 'child_process';
+
+import { Lemmings } from '../../js/LemmingsNamespace.js';
+import '../../js/LogHandler.js';
+import { BinaryReader } from '../../js/BinaryReader.js';
+import { BitReader } from '../../js/BitReader.js';
+import { BitWriter } from '../../js/BitWriter.js';
+import { PackFilePart } from '../../js/PackFilePart.js';
+import '../../js/UnpackFilePart.js';
+import { FileContainer } from '../../js/FileContainer.js';
+
+const script = path.resolve('tools/packLevels.js');
+
+globalThis.lemmings = { game: { showDebug: false } };
+
+describe('tools/packLevels.js sorted packing', function () {
+  it('packs .nxlv files in sorted order', function () {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nxlv-'));
+    const files = {
+      'B.nxlv': Uint8Array.from({ length: 2048 }, (_, i) => i % 256),
+      'A.nxlv': Uint8Array.from({ length: 2048 }, (_, i) => (i * 3) % 256),
+      'C.nxlv': Uint8Array.from({ length: 2048 }, (_, i) => (255 - i) % 256)
+    };
+    for (const [name, data] of Object.entries(files)) {
+      fs.writeFileSync(path.join(dir, name), data);
+    }
+    const outFile = path.join(dir, 'out.dat');
+
+    const result = spawnSync('node', [script, dir, outFile], { encoding: 'utf8' });
+    expect(result.status).to.equal(0);
+
+    const buf = fs.readFileSync(outFile);
+    const fc = new FileContainer(new BinaryReader(new Uint8Array(buf)));
+    expect(fc.count()).to.equal(3);
+
+    const expectedOrder = Object.keys(files).sort();
+    expectedOrder.forEach((name, idx) => {
+      const data = files[name];
+      const part = fc.parts[idx];
+      const unpacked = fc.getPart(idx);
+      expect(Array.from(unpacked.data.slice(0, unpacked.length)))
+        .to.eql(Array.from(data));
+      const packed = PackFilePart.pack(data);
+      expect(part.checksum).to.equal(packed.checksum);
+      expect(part.initialBufferLen).to.equal(packed.initialBits);
+    });
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+});
+

--- a/test/userinput.test.js
+++ b/test/userinput.test.js
@@ -2,8 +2,48 @@ import { expect } from 'chai';
 import { Lemmings } from '../js/LemmingsNamespace.js';
 import '../js/EventHandler.js';
 import '../js/Position2D.js';
+import '../js/ViewPoint.js';
+import '../js/StageImageProperties.js';
+import '../js/DisplayImage.js';
 import { UserInputManager } from '../js/UserInputManager.js';
 import { Stage } from '../js/Stage.js';
+
+function createStubCanvas(width = 800, height = 600) {
+  const ctx = {
+    canvas: { width, height },
+    fillRect() {},
+    drawImage() {},
+    putImageData() {}
+  };
+  return {
+    width,
+    height,
+    getContext() { return ctx; },
+    addEventListener() {},
+    removeEventListener() {}
+  };
+}
+
+function createDocumentStub() {
+  return {
+    createElement() {
+      const ctx = {
+        canvas: {},
+        fillRect() {},
+        drawImage() {},
+        putImageData() {},
+        createImageData(w, h) {
+          return { width: w, height: h, data: new Uint8ClampedArray(w * h * 4) };
+        }
+      };
+      return {
+        width: 0,
+        height: 0,
+        getContext() { ctx.canvas = this; return ctx; }
+      };
+    }
+  };
+}
 
 globalThis.lemmings = { game: { showDebug: false } };
 
@@ -26,8 +66,9 @@ describe('UserInputManager', function() {
       } catch (err) {
         done(err);
       }
-    };
-  }
+    });
+    uim.handleWheel(new Lemmings.Position2D(100, 50), 120);
+  });
 
   before(function() {
     global.document = createDocumentStub();


### PR DESCRIPTION
## Summary
- add a mocha glob so subfolders run
- fix `UserInputManager` test setup
- create `test/tools/packLevels.test.js` verifying sorted packing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684204ec6794832d9a42a9e5078fcfd2