### PR TITLE
Improve export script tests

### DIFF
--- a/test/userinput.test.js
+++ b/test/userinput.test.js
@@ -5,6 +5,44 @@ import '../js/Position2D.js';
 import { UserInputManager } from '../js/UserInputManager.js';
 import { Stage } from '../js/Stage.js';
 
+// Minimal canvas/context stubs used by Stage and UserInputManager tests
+function createStubCanvas(width = 800, height = 600) {
+  const ctx = {
+    canvas: { width, height },
+    fillRect() {},
+    drawImage() {},
+    putImageData() {}
+  };
+  return {
+    width,
+    height,
+    getContext() { return ctx; },
+    addEventListener() {},
+    removeEventListener() {}
+  };
+}
+
+function createDocumentStub() {
+  return {
+    createElement() {
+      const ctx = {
+        canvas: {},
+        fillRect() {},
+        drawImage() {},
+        putImageData() {},
+        createImageData(w, h) {
+          return { width: w, height: h, data: new Uint8ClampedArray(w * h * 4) };
+        }
+      };
+      return {
+        width: 0,
+        height: 0,
+        getContext() { ctx.canvas = this; return ctx; }
+      };
+    }
+  };
+}
+
 globalThis.lemmings = { game: { showDebug: false } };
 
 describe('UserInputManager', function() {
@@ -26,8 +64,9 @@ describe('UserInputManager', function() {
       } catch (err) {
         done(err);
       }
-    };
-  }
+    });
+    uim.handleWheel(new Lemmings.Position2D(100, 50), 120);
+  });
 
   before(function() {
     global.document = createDocumentStub();


### PR DESCRIPTION
## Summary
- add missing helpers and fix syntax in `userinput.test.js`
- improve `runScript` helper to capture errors and allow running from temp dirs
- extend export script tests to cover default output directories
- add error case checks for invalid directories

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684204eddfc0832dbf8451adc4096e83