### PR TITLE
Add cleanExports test

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "scripts": {
     "start": "http-server --cors=*",
     "check-undefined": "node tools/check-undefined.js",
-    "test": "mocha",
-    "coverage": "c8 mocha",
+    "test": "mocha --recursive",
+    "coverage": "c8 mocha --recursive",
     "export-panel-sprite": "node tools/exportPanelSprite.js",
     "export-lemmings-sprites": "node tools/exportLemmingsSprites.js",
     "export-ground-images": "node tools/exportGroundImages.js",

--- a/test/tools/cleanExports.test.js
+++ b/test/tools/cleanExports.test.js
@@ -1,0 +1,24 @@
+import { expect } from 'chai';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { spawnSync } from 'child_process';
+
+const script = path.resolve('tools/cleanExports.js');
+
+describe('tools/cleanExports.js', function () {
+  it('removes export_ folders', function () {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'exports-'));
+    fs.mkdirSync(path.join(dir, 'export_a'));
+    fs.mkdirSync(path.join(dir, 'export_b'));
+    fs.writeFileSync(path.join(dir, 'not_export'), '');
+
+    const res = spawnSync('node', [script], { cwd: dir, encoding: 'utf8' });
+    expect(res.status).to.equal(0);
+    expect(fs.existsSync(path.join(dir, 'export_a'))).to.be.false;
+    expect(fs.existsSync(path.join(dir, 'export_b'))).to.be.false;
+    expect(fs.existsSync(path.join(dir, 'not_export'))).to.be.true;
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+});

--- a/test/tools/exportScripts.test.js
+++ b/test/tools/exportScripts.test.js
@@ -1,0 +1,23 @@
+import { expect } from 'chai';
+import fs from 'fs';
+import path from 'path';
+
+const scripts = [
+  'exportAllPacks.js',
+  'exportAllSprites.js',
+  'exportGroundImages.js',
+  'exportLemmingsSprites.js',
+  'exportPanelSprite.js',
+  'renderCursorSizes.js',
+  'scanGreenPanel.js',
+];
+
+describe('export scripts default path', function () {
+  for (const file of scripts) {
+    it(`${file} exports under ./exports`, function () {
+      const content = fs.readFileSync(path.join('tools', file), 'utf8');
+      expect(content).to.match(/['"]exports['"]/);
+      expect(/path\.join\(['"]exports['"]/.test(content) || /const\s+BASE\s*=\s*['"]exports['"]/.test(content)).to.be.true;
+    });
+  }
+});

--- a/test/userinput.test.js
+++ b/test/userinput.test.js
@@ -5,6 +5,48 @@ import '../js/Position2D.js';
 import { UserInputManager } from '../js/UserInputManager.js';
 import { Stage } from '../js/Stage.js';
 
+function createStubCanvas(width = 800, height = 600) {
+  const ctx = {
+    canvas: { width, height },
+    fillRect() {},
+    drawImage() {},
+    putImageData() {}
+  };
+  return {
+    width,
+    height,
+    getContext() {
+      return ctx;
+    },
+    addEventListener() {},
+    removeEventListener() {}
+  };
+}
+
+function createDocumentStub() {
+  return {
+    createElement() {
+      const ctx = {
+        canvas: {},
+        fillRect() {},
+        drawImage() {},
+        putImageData() {},
+        createImageData(w, h) {
+          return { width: w, height: h, data: new Uint8ClampedArray(w * h * 4) };
+        }
+      };
+      return {
+        width: 0,
+        height: 0,
+        getContext() {
+          ctx.canvas = this;
+          return ctx;
+        }
+      };
+    }
+  };
+}
+
 globalThis.lemmings = { game: { showDebug: false } };
 
 describe('UserInputManager', function() {
@@ -26,8 +68,9 @@ describe('UserInputManager', function() {
       } catch (err) {
         done(err);
       }
-    };
-  }
+    });
+    uim.handleWheel(new Lemmings.Position2D(100, 50), 120);
+  });
 
   before(function() {
     global.document = createDocumentStub();


### PR DESCRIPTION
## Summary
- ensure mocha runs tests recursively
- add test for `cleanExports.js`
- test that export scripts use `./exports/` directory
- fix syntax in `userinput.test.js` so tests pass

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684204f221d8832da3477227ed00b03c