### PR TITLE
Add WebMIDI environment notes

### DIFF
--- a/.agentInfo/index-detailed.md
+++ b/.agentInfo/index-detailed.md
@@ -43,3 +43,4 @@ This expanded listing preserves the original bullet format with short descriptio
 
 
 - **webmidi, browser**: [notes/webmidi.md](notes/webmidi.md) - WebMIDI works only in secure contexts and requires user permission for device access.
+- **webmidi, environment, doc**: [notes/webmidi-environments.md](notes/webmidi-environments.md) - Supported browsers, Node.js usage and Electron setup.

--- a/.agentInfo/index.md
+++ b/.agentInfo/index.md
@@ -45,3 +45,4 @@ level-packs.md: level-packs resources doc
 pause-overlay.md: bench-mode gui
 
 webmidi.md: webmidi doc
+webmidi-environments.md: webmidi environment doc

--- a/.agentInfo/notes/webmidi-environments.md
+++ b/.agentInfo/notes/webmidi-environments.md
@@ -1,0 +1,27 @@
+# WebMIDI supported environments
+
+tags: webmidi, environment, doc
+
+The official "Supported Environments" page outlines where WebMIDI.js works:
+
+* **Browser support** – Edge 79+, Chrome 43+, Opera 30+ and Firefox 108+ natively implement the Web MIDI API.
+* **Jazz-Plugin fallback** – Installing Jazz-Plugin v1.4+ enables Safari and Internet Explorer.
+* **Node.js** – Version 3 adds full Node.js support via Jazz-Soft's JZZ module. The docs list GNU/Linux, macOS, Windows and Raspberry Pi as compatible.
+* **Electron** – Permission handlers must allow MIDI access:
+
+```javascript
+mainWindow.webContents.session.setPermissionRequestHandler((webContents, permission, callback, details) => {
+  if (permission === 'midi' || permission === 'midiSysex') {
+    callback(true);
+  } else {
+    callback(false);
+  }
+})
+
+mainWindow.webContents.session.setPermissionCheckHandler((webContents, permission, requestingOrigin) => {
+  if (permission === 'midi' || permission === 'midiSysex') {
+    return true;
+  }
+  return false;
+});
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ Level packs follow the NeoLemmix folder layout described in [docs/levelpacks.md]
 - Call `WebMidi.enable({sysex: true})` if you need to send or receive
 - `.agentInfo/notes/webmidi-overview.md` provides detailed usage examples
   and API summaries.
+- `.agentInfo/notes/webmidi-environments.md` lists supported browsers, Node.js and Electron setup.
 - The call in `index.html` lines 22-24 is commented out; enable it for MIDI tests.
 
 

--- a/README.md
+++ b/README.md
@@ -203,4 +203,5 @@ URL parameters (shortcut in brackets):
 
 The `.agentInfo/` directory holds short design notes and TODOs. Each file begins with a `tags:` line so agents can search by keyword.
 See [`.agentInfo/index.md`](.agentInfo/index.md) for an overview of available notes. Make an effort to read and update these as much as you can.
---> 
+WebMIDI docs live in [`.agentInfo/notes/webmidi-overview.md`](.agentInfo/notes/webmidi-overview.md) and the environment summary in [`.agentInfo/notes/webmidi-environments.md`](.agentInfo/notes/webmidi-environments.md).
+-->


### PR DESCRIPTION
## Summary
- document supported WebMIDI environments in `.agentInfo/notes/webmidi-environments.md`
- index the note in `.agentInfo/index.md` and `index-detailed.md`
- reference the note from `AGENTS.md` and `README.md`

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841eb0912e4832d8395b15923aece74