### PR TITLE
Add xBRZ scaling option

### DIFF
--- a/js/DisplayImage.js
+++ b/js/DisplayImage.js
@@ -1,6 +1,7 @@
 /* -------------------- DisplayImage.js -------------------- */
 import './LogHandler.js';
 import { Lemmings } from './LemmingsNamespace.js';
+import { scaleImage } from './xbrz/xbrz.js';
 
 // a simple but high quality 53-bit hash
 const cyrb53 = (str, seed = 0) => {
@@ -252,7 +253,8 @@ class DisplayImage extends Lemmings.BaseLogger {
       noOverwrite   = false,
       upsideDown    = false,
       groundMask    = null,
-      size          = null // { width, height }
+      size          = null, // { width, height }
+      scaleMode     = 'nearest'
     } = opts ?? {};
 
     // If no scaling requested or size matches source → fall back to original fast path
@@ -285,8 +287,8 @@ class DisplayImage extends Lemmings.BaseLogger {
       return;
     }
 
-    // Scaled path – nearest‑neighbour sampling
-    scaleNearest(frame, dstW, dstH, {
+    // Scaled path – choose algorithm
+    const scaleOpts = {
       dest32,
       destW,
       destH,
@@ -298,7 +300,13 @@ class DisplayImage extends Lemmings.BaseLogger {
       noOverwrite,
       upsideDown,
       groundMask
-    });
+    };
+
+    if (scaleMode === 'xbrz') {
+      scaleXbrz(frame, dstW, dstH, scaleOpts);
+    } else {
+      scaleNearest(frame, dstW, dstH, scaleOpts);
+    }
   }
 
   drawFrame(frame, x, y,) {
@@ -413,6 +421,84 @@ function scaleNearest(
   }
 }
 
+function scaleXbrz(
+  frame,
+  dstWidth,
+  dstHeight,
+  opts = {}
+) {
+  const {
+    dest32,
+    destW,
+    destH,
+    baseX,
+    baseY,
+    nullColor32 = null,
+    checkGround = false,
+    onlyOverwrite = false,
+    noOverwrite = false,
+    upsideDown = false,
+    groundMask = null
+  } = opts;
+
+  if (!dest32) return;
+
+  const { width: srcW, height: srcH } = frame;
+  const scale = Math.round(dstWidth / srcW);
+  if (scale < 2 || scale > 4 || dstWidth !== srcW * scale || dstHeight !== srcH * scale) {
+    scaleNearest(frame, dstWidth, dstHeight, opts);
+    return;
+  }
+
+  const srcBuf = frame.getBuffer();
+  const srcMask = frame.getMask();
+  const temp = new Uint32Array(srcBuf.length);
+  for (let i = 0; i < srcBuf.length; i++) {
+    temp[i] = srcMask[i] ? srcBuf[i] : 0;
+  }
+
+  const scaled = new Uint32Array(dstWidth * dstHeight);
+  scaleImage(scale, temp, scaled, srcW, srcH, 0, srcH);
+
+  const scaledMask = new Uint8Array(dstWidth * dstHeight);
+  for (let dy = 0; dy < dstHeight; dy++) {
+    const sy = Math.floor(dy / scale);
+    const srcRow = sy * srcW;
+    const dstRow = dy * dstWidth;
+    for (let dx = 0; dx < dstWidth; dx++) {
+      const sx = Math.floor(dx / scale);
+      scaledMask[dstRow + dx] = srcMask[srcRow + sx];
+    }
+  }
+
+  for (let dy = 0; dy < dstHeight; dy++) {
+    const srcY = upsideDown ? dstHeight - 1 - dy : dy;
+    const outY = dy + baseY;
+    if (outY < 0 || outY >= destH) continue;
+
+    let srcRow = srcY * dstWidth;
+    let destRow = outY * destW + baseX;
+
+    for (let dx = 0; dx < dstWidth; dx++, srcRow++, destRow++) {
+      const outX = dx + baseX;
+      if (outX < 0 || outX >= destW) continue;
+
+      if (!scaledMask[srcRow]) {
+        if (nullColor32 !== null) dest32[destRow] = nullColor32;
+        continue;
+      }
+
+      if (checkGround) {
+        const hasGround = groundMask?.hasGroundAt(outX, outY);
+        if (noOverwrite && hasGround) continue;
+        if (onlyOverwrite && !hasGround) continue;
+      }
+
+      dest32[destRow] = scaled[srcRow];
+    }
+  }
+}
+
 function drawMarchingAntRect(
   display,
   x,
@@ -466,4 +552,5 @@ function drawDashedRect(
 
 Lemmings.drawMarchingAntRect = drawMarchingAntRect;
 Lemmings.drawDashedRect = drawDashedRect;
-export { DisplayImage, drawMarchingAntRect, drawDashedRect };
+Lemmings.scaleXbrz = scaleXbrz;
+export { DisplayImage, drawMarchingAntRect, drawDashedRect, scaleXbrz };

--- a/js/xbrz/scalers/Blender.js
+++ b/js/xbrz/scalers/Blender.js
@@ -1,0 +1,25 @@
+const redMask = 0xff0000;
+const greenMask = 0x00ff00;
+const blueMask = 0x0000ff;
+
+function blendComponent (mask, n, m, inPixel, setPixel) {
+  const inChan = inPixel & mask;
+  const setChan = setPixel & mask;
+  const blend = setChan * n + inChan * (m - n);
+  return mask & (blend / m);
+}
+
+function alphaBlend (n, m, dstPtr, col) {
+  // assert n < 256 : "possible overflow of (col & redMask) * N";
+  // assert m < 256 : "possible overflow of (col & redMask) * N + (dst & redMask) * (M - N)";
+  // assert 0 < n && n < m : "0 < N && N < M";
+
+  const dst = dstPtr.get();
+  const redComponent = blendComponent(redMask, n, m, dst, col);
+  const greenComponent = blendComponent(greenMask, n, m, dst, col);
+  const blueComponent = blendComponent(blueMask, n, m, dst, col);
+  const blend = (redComponent | greenComponent | blueComponent);
+  dstPtr.set(blend | 0xff000000);
+}
+
+export { alphaBlend };

--- a/js/xbrz/scalers/Scaler2x.js
+++ b/js/xbrz/scalers/Scaler2x.js
@@ -1,0 +1,35 @@
+import { alphaBlend } from './Blender.js';
+
+export default class Scaler2x {
+  constructor () {
+    this.scale = 2;
+  }
+
+  scale () {
+    return this.scale;
+  }
+
+  blendLineShallow (col, out) {
+    alphaBlend(1, 4, out.ref(this.scale - 1, 0), col);
+    alphaBlend(3, 4, out.ref(this.scale - 1, 1), col);
+  }
+
+  blendLineSteep (col, out) {
+    alphaBlend(1, 4, out.ref(0, this.scale - 1), col);
+    alphaBlend(3, 4, out.ref(1, this.scale - 1), col);
+  }
+
+  blendLineSteepAndShallow (col, out) {
+    alphaBlend(1, 4, out.ref(1, 0), col);
+    alphaBlend(1, 4, out.ref(0, 1), col);
+    alphaBlend(5, 6, out.ref(1, 1), col);
+  }
+
+  blendLineDiagonal (col, out) {
+    alphaBlend(1, 2, out.ref(1, 1), col);
+  }
+
+  blendCorner (col, out) {
+    alphaBlend(21, 100, out.ref(1, 1), col);
+  }
+}

--- a/js/xbrz/scalers/Scaler3x.js
+++ b/js/xbrz/scalers/Scaler3x.js
@@ -1,0 +1,49 @@
+import { alphaBlend } from './Blender.js';
+import Scaler2x from './Scaler2x.js';
+
+export default class Scaler3x extends Scaler2x{
+  constructor () {
+    super();
+    this.scale = 3;
+  }
+
+  blendLineShallow (col, out) {
+    super.blendLineShallow(col, out);
+    // alphaBlend(1, 4, out.ref(this.scale - 1, 0), col)
+    alphaBlend(1, 4, out.ref(this.scale - 2, 2), col);
+
+    // alphaBlend(3, 4, out.ref(this.scale - 1, 1), col)
+
+    out.ref(this.scale - 1, 2).set(col);
+  }
+
+  blendLineSteep (col, out) {
+    super.blendLineSteep(col, out);
+    // alphaBlend(1, 4, out.ref(0, this.scale - 1), col)
+    alphaBlend(1, 4, out.ref(2, this.scale - 2), col);
+
+    // alphaBlend(3, 4, out.ref(1, this.scale - 1), col)
+
+    out.ref(2, this.scale - 1).set(col);
+  }
+
+  blendLineSteepAndShallow (col, out) {
+    alphaBlend(1, 4, out.ref(2, 0), col);
+    alphaBlend(1, 4, out.ref(0, 2), col);
+
+    alphaBlend(3, 4, out.ref(2, 1), col);
+    alphaBlend(3, 4, out.ref(1, 2), col);
+
+    out.ref(2, 2).set(col);
+  }
+
+  blendLineDiagonal (col, out) {
+    alphaBlend(1, 8, out.ref(1, 2), col);
+    alphaBlend(1, 8, out.ref(2, 1), col);
+    alphaBlend(7, 8, out.ref(2, 2), col);
+  }
+
+  blendCorner (col, out) {
+    alphaBlend(45, 100, out.ref(2, 2), col);
+  }
+}

--- a/js/xbrz/scalers/Scaler4x.js
+++ b/js/xbrz/scalers/Scaler4x.js
@@ -1,0 +1,58 @@
+import { alphaBlend } from './Blender.js';
+import Scaler3x from './Scaler3x.js';
+
+export default class Scaler4x extends Scaler3x {
+  constructor () {
+    super();
+    this.scale = 4;
+  }
+
+  blendLineShallow (col, out) {
+    super.blendLineShallow(col, out);
+    // alphaBlend(1, 4, out.ref(this.scale - 1, 0), col)
+    // alphaBlend(1, 4, out.ref(this.scale - 2, 2), col)
+
+    // alphaBlend(3, 4, out.ref(this.scale - 1, 1), col)
+    alphaBlend(3, 4, out.ref(this.scale - 2, 3), col);
+
+    // out.ref(this.scale - 1, 2).set(col)
+    out.ref(this.scale - 1, 3).set(col);
+  }
+
+  blendLineSteep (col, out) {
+    super.blendLineSteep(col, out);
+    // alphaBlend(1, 4, out.ref(0, this.scale - 1), col)
+    // alphaBlend(1, 4, out.ref(2, this.scale - 2), col)
+
+    // alphaBlend(3, 4, out.ref(1, this.scale - 1), col)
+    alphaBlend(3, 4, out.ref(3, this.scale - 2), col);
+
+    // out.ref(2, this.scale - 1).set(col)
+    out.ref(3, this.scale - 1).set(col);
+  }
+
+  blendLineSteepAndShallow (col, out) {
+    alphaBlend(3, 4, out.ref(3, 1), col);
+    alphaBlend(3, 4, out.ref(1, 3), col);
+    alphaBlend(1, 4, out.ref(3, 0), col);
+    alphaBlend(1, 4, out.ref(0, 3), col);
+
+    alphaBlend(1, 3, out.ref(2, 2), col);
+
+    out.ref(3, 3).set(col);
+    out.ref(3, 2).set(col);
+    out.ref(2, 3).set(col);
+  }
+
+  blendLineDiagonal (col, out) {
+    alphaBlend(1, 2, out.ref(this.scale - 1, this.scale / 2), col);
+    alphaBlend(1, 2, out.ref(this.scale - 2, this.scale / 2 + 1), col);
+    out.ref(this.scale - 1, this.scale - 1).set(col);
+  }
+
+  blendCorner (col, out) {
+    alphaBlend(68, 100, out.ref(3, 3), col);
+    alphaBlend(9, 100, out.ref(3, 2), col);
+    alphaBlend(9, 100, out.ref(2, 3), col);
+  }
+}

--- a/js/xbrz/scalers/index.js
+++ b/js/xbrz/scalers/index.js
@@ -1,0 +1,5 @@
+import Scaler4x from './Scaler4x.js';
+import Scaler3x from './Scaler3x.js';
+import Scaler2x from './Scaler2x.js';
+
+export { Scaler2x, Scaler3x, Scaler4x };

--- a/js/xbrz/xbrz.js
+++ b/js/xbrz/xbrz.js
@@ -1,0 +1,522 @@
+/*
+ * Source: https://github.com/will-wyx/xbrz
+ * License: MIT
+ * Simplified for 2x-4x scale only
+ */
+import { Scaler4x, Scaler3x, Scaler2x } from './scalers/index.js';
+
+const redMask = 0xff0000;
+const greenMask = 0x00ff00;
+const blueMask = 0x0000ff;
+
+class IntPtr {
+  constructor (intArray) {
+    this.arr = intArray;
+    this.ptr = 0;
+  }
+
+  position (pos) {
+    this.ptr = pos;
+  }
+
+  get () {
+    return this.arr[this.ptr];
+  }
+
+  set (val) {
+    this.arr[this.ptr] = val;
+  }
+}
+
+class BlendResult {
+  constructor () {
+    this.f = 0;
+    this.g = 0;
+    this.j = 0;
+    this.k = 0;
+  }
+
+  reset () {
+    this.f = 0;
+    this.g = 0;
+    this.j = 0;
+    this.k = 0;
+  }
+}
+
+const maxRots = 4;
+const maxScale = 6;
+const maxScaleSq = maxScale * maxScale;
+
+class OutputMatrix {
+  constructor (scale, out, outWidth) {
+    this.out = new IntPtr(out);
+    this.n = (scale - 2) * (maxRots * maxScaleSq);
+    this.outWidth = outWidth;
+    this.outi = 0;
+    this.nr = 0;
+  }
+
+  move (rotDeg, outi) {
+    this.nr = this.n + rotDeg * maxScaleSq;
+    this.outi = outi;
+  }
+
+  ref (i, j) {
+    i = parseInt(i);
+    j = parseInt(j);
+    const rot = matrixRotation[this.nr + i * maxScale + j];
+    this.out.position(this.outi + rot.J + rot.I * this.outWidth);
+    return this.out;
+  }
+}
+
+const Rot = (function () {
+  /*
+  |0|6|8|2|1|3|
+  |7|5|2|0|6|8|
+  |3|8|5|1|4|4|
+  |4|4|5|1|3|7|
+  |6|8|2|0|7|5|
+  |1|3|8|2|0|7|
+   */
+  let arr = [];
+  const
+    a = 0, b = 1, c = 2,
+    d = 3, e = 4, f = 5,
+    g = 6, h = 7, i = 8;
+
+  const deg0 = [
+    a, b, c,
+    d, e, f,
+    g, h, i
+  ];
+
+  const deg90 = [
+    g, d, a,
+    h, e, b,
+    i, f, c
+  ];
+
+  const deg180 = [
+    i, h, g,
+    f, e, d,
+    c, b, a
+  ];
+
+  const deg270 = [
+    c, f, i,
+    b, e, h,
+    a, d, g
+  ];
+
+  const rotation = [
+    deg0, deg90, deg180, deg270
+  ];
+
+  for (let rotDeg = 0; rotDeg < 4; rotDeg++) {
+    for (let x = 0; x < 9; x++) {
+      arr[(x << 2) + rotDeg] = rotation[rotDeg][x];
+    }
+  }
+  return arr;
+})();
+
+const BlendType = {
+  'BLEND_NONE': 0,
+  'BLEND_NORMAL': 1,
+  'BLEND_DOMINANT': 2
+};
+
+const blendResult = new BlendResult();
+
+function square (value) {
+  return value * value;
+}
+
+// 用指定颜色填充区块
+function fillBlock (trg, trgi, pitch, col, blockSize) {
+  for (let y = 0; y < blockSize; ++y, trgi += pitch) {
+    for (let x = 0; x < blockSize; ++x) {
+      trg[trgi + x] = col;
+    }
+  }
+}
+
+function distYCbCr (pix1, pix2, lumaWeight) {
+  const r_diff = ((pix1 & redMask) - (pix2 & redMask)) >> 16;
+  const g_diff = ((pix1 & greenMask) - (pix2 & greenMask)) >> 8;
+  const b_diff = ((pix1 & blueMask) - (pix2 & blueMask));
+
+  const k_b = 0.0722, k_r = 0.2126, k_g = 1 - k_b - k_r;
+  const scale_b = 0.5 / (1 - k_b), scale_r = 0.5 / (1 - k_r);
+
+  const y = k_r * r_diff + k_g * g_diff + k_b * b_diff;
+  const c_b = scale_b * (b_diff - y);
+  const c_r = scale_r * (r_diff - y);
+  return square(lumaWeight * y) + square(c_b) + square(c_r);
+}
+
+function colorDist (pix1, pix2, luminanceWeight) {
+  if (pix1 === pix2) {
+    return 0;
+  }
+  return distYCbCr(pix1, pix2, luminanceWeight);
+}
+
+let config = {
+  dominantDirectionThreshold: 3.6,
+  luminanceWeight: 1.0,
+  equalColorTolerance: 30.0,
+  steepDirectionThreshold: 2.2
+};
+
+function preProcessCorners_colorDist_ (col1, col2) {
+  col1 = col1 & 0xffffffff;
+  col2 = col2 & 0xffffffff;
+  return colorDist(col1, col2, config.luminanceWeight);
+}
+
+const eqColorThres = square(config.equalColorTolerance);
+
+function scalePixel_colorEq_ (col1, col2) {
+  return colorDist(col1, col2, config.luminanceWeight) < eqColorThres;
+}
+
+function scalePixel_colorDist_ (col1, col2) {
+  return colorDist(col1, col2, config.luminanceWeight);
+}
+
+function buildMatrixRotation (rotDeg, I, J, N) {
+  let I_old = 0, J_old = 0;
+  if (rotDeg === 0) {
+    I_old = I;
+    J_old = J;
+  } else {
+    const old = buildMatrixRotation(rotDeg - 1, I, J, N);
+    I_old = N - 1 - old.J;
+    J_old = old.I;
+  }
+  return { I: I_old, J: J_old };
+}
+
+let matrixRotation = (function () {
+  let matrixRotation = [];
+  for (let n = 2; n < maxScale + 1; n++) {
+    for (let r = 0; r < maxRots; r++) {
+      let nr = (n - 2) * (maxRots * maxScaleSq) + r * maxScaleSq;
+      for (let i = 0; i < maxScale; i++) {
+        for (let j = 0; j < maxScale; j++) {
+          matrixRotation[nr + i * maxScale + j] = buildMatrixRotation(r, i, j, n);
+        }
+      }
+    }
+  }
+  return matrixRotation;
+})();
+
+function preProcessCorners (ker4x4) {
+  blendResult.reset();
+  if ((ker4x4.f === ker4x4.g && ker4x4.j === ker4x4.k) ||
+    (ker4x4.f === ker4x4.j && ker4x4.g === ker4x4.k)) {
+    return;
+  }
+
+  const dist = preProcessCorners_colorDist_;
+
+  const weight = 4;
+  const jg =
+    dist(ker4x4.i, ker4x4.f) +
+    dist(ker4x4.f, ker4x4.c) +
+    dist(ker4x4.n, ker4x4.k) +
+    dist(ker4x4.k, ker4x4.h) +
+    weight * dist(ker4x4.j, ker4x4.g);
+  const fk =
+    dist(ker4x4.e, ker4x4.j) +
+    dist(ker4x4.j, ker4x4.o) +
+    dist(ker4x4.b, ker4x4.g) +
+    dist(ker4x4.g, ker4x4.l) +
+    weight * dist(ker4x4.f, ker4x4.k);
+
+  const dominantGradient = config.dominantDirectionThreshold * jg < fk;
+  if (jg < fk) {
+    if (ker4x4.f !== ker4x4.g && ker4x4.f !== ker4x4.j) {
+      blendResult.f = dominantGradient ? BlendType.BLEND_DOMINANT : BlendType.BLEND_NORMAL;
+    }
+    if (ker4x4.k !== ker4x4.g && ker4x4.k !== ker4x4.j) {
+      blendResult.k = dominantGradient ? BlendType.BLEND_DOMINANT : BlendType.BLEND_NORMAL;
+    }
+  } else if (fk < jg) {
+    if (ker4x4.j !== ker4x4.f && ker4x4.j !== ker4x4.k) {
+      blendResult.j = dominantGradient ? BlendType.BLEND_DOMINANT : BlendType.BLEND_NORMAL;
+    }
+    if (ker4x4.g !== ker4x4.f && ker4x4.g !== ker4x4.k) {
+      blendResult.g = dominantGradient ? BlendType.BLEND_DOMINANT : BlendType.BLEND_NORMAL;
+    }
+  }
+}
+
+const BlendInfo = {
+  getTopL (b) {
+    return (b & 0x3) & 0xff;
+  },
+  getTopR (b) {
+    return ((b >> 2) & 0x3) & 0xff;
+  },
+  getBottomR (b) {
+    return ((b >> 4) & 0x3) & 0xff;
+  },
+  getBottomL (b) {
+    return ((b >> 6) & 0x3) & 0xff;
+  },
+  setTopL (b, bt) {
+    return (b | bt) & 0xff;
+  },
+  setTopR (b, bt) {
+    return (b | bt << 2) & 0xff;
+  },
+  setBottomR (b, bt) {
+    return (b | bt << 4) & 0xff;
+  },
+  setBottomL (b, bt) {
+    return (b | (bt << 6)) & 0xff;
+  },
+  rotate (b, rotDeg) {
+    // assert rotDeg >= 0 && rotDeg < 4 : "RotationDegree enum does not have type: " + rotDeg;
+    const l = rotDeg << 1;
+    const r = 8 - l;
+    return (b << l | b >> r) & 0xff;
+  }
+};
+
+let outputMatrix;
+
+function scalePixel (scaler, rotDeg, ker3x3, trg, trgi, trgWidth, blendInfo) {
+  const b = ker3x3[Rot[(1 << 2) + rotDeg]];
+  const c = ker3x3[Rot[(2 << 2) + rotDeg]];
+  const d = ker3x3[Rot[(3 << 2) + rotDeg]];
+  const e = ker3x3[Rot[(4 << 2) + rotDeg]];
+  const f = ker3x3[Rot[(5 << 2) + rotDeg]];
+  const g = ker3x3[Rot[(6 << 2) + rotDeg]];
+  const h = ker3x3[Rot[(7 << 2) + rotDeg]];
+  const i = ker3x3[Rot[(8 << 2) + rotDeg]];
+
+  const blend = BlendInfo.rotate(blendInfo, rotDeg);
+  if (BlendInfo.getBottomR(blend) === BlendType.BLEND_NONE) {
+    return;
+  }
+
+  const eq = scalePixel_colorEq_;
+  const dist = scalePixel_colorDist_;
+
+  let doLineBlend;
+
+  if (BlendInfo.getBottomR(blend) >= BlendType.BLEND_DOMINANT) {
+    doLineBlend = true;
+  } else if (BlendInfo.getTopR(blend) !== BlendType.BLEND_NONE && !eq(e, g)) {
+    doLineBlend = false;
+  } else if (BlendInfo.getBottomL(blend) !== BlendType.BLEND_NONE && !eq(e, c)) {
+    doLineBlend = false;
+  } else {
+    doLineBlend = !(eq(g, h) && eq(h, i) && eq(i, f) && eq(f, c) && !eq(e, i));
+  }
+
+  const px = dist(e, f) <= dist(e, h) ? f : h;
+
+  const out = outputMatrix;
+  out.move(rotDeg, trgi);
+
+  if (!doLineBlend) {
+    scaler.blendCorner(px, out);
+    return;
+  }
+
+  const fg = dist(f, g);
+  const hc = dist(h, c);
+
+  const haveShallowLine = config.steepDirectionThreshold * fg <= hc && e !== g && d !== g;
+  const haveSteepLine = config.steepDirectionThreshold * hc <= fg && e !== c && b !== c;
+
+  if (haveShallowLine) {
+    if (haveSteepLine) {
+      scaler.blendLineSteepAndShallow(px, out);
+    } else {
+      scaler.blendLineShallow(px, out);
+    }
+  } else {
+    if (haveSteepLine) {
+      scaler.blendLineSteep(px, out);
+    } else {
+      scaler.blendLineDiagonal(px, out);
+    }
+  }
+}
+
+export function scaleImage (scaleSize, src, trg, srcWidth, srcHeight, yFirst, yLast) {
+  yFirst = Math.max(yFirst, 0);
+  yLast = Math.min(yLast, srcHeight);
+
+  if (yFirst >= yLast || srcWidth <= 0) {
+    return;
+  }
+
+  const trgWidth = srcWidth * scaleSize;
+
+  let preProcBuffer = [];
+  let ker4 = {
+    a: 0, b: 0, c: 0, d: 0,
+    e: 0, f: 0, g: 0, h: 0,
+    i: 0, j: 0, k: 0, l: 0,
+    m: 0, n: 0, o: 0, p: 0,
+  };
+
+  if (yFirst > 0) {
+    const y = yFirst - 1;
+    const s_m1 = srcWidth * Math.max(y - 1, 0);
+    const s_0 = srcWidth * y;
+    const s_p1 = srcWidth * Math.min(y + 1, srcHeight - 1);
+    const s_p2 = srcWidth * Math.min(y + 2, srcHeight - 1);
+
+    for (let x = 0; x < srcWidth; ++x) {
+      const x_m1 = Math.max(x - 1, 0);
+      const x_p1 = Math.min(x + 1, srcWidth - 1);
+      const x_p2 = Math.min(x + 2, srcWidth - 1);
+
+      ker4.a = src[s_m1 + x_m1];
+      ker4.b = src[s_m1 + x];
+      ker4.c = src[s_m1 + x_p1];
+      ker4.d = src[s_m1 + x_p2];
+
+      ker4.e = src[s_0 + x_m1];
+      ker4.f = src[s_0 + x];
+      ker4.g = src[s_0 + x_p1];
+      ker4.h = src[s_0 + x_p2];
+
+      ker4.i = src[s_p1 + x_m1];
+      ker4.j = src[s_p1 + x];
+      ker4.k = src[s_p1 + x_p1];
+      ker4.l = src[s_p1 + x_p2];
+
+      ker4.m = src[s_p2 + x_m1];
+      ker4.n = src[s_p2 + x];
+      ker4.o = src[s_p2 + x_p1];
+      ker4.p = src[s_p2 + x_p2];
+
+      preProcessCorners(ker4);
+
+      preProcBuffer[x] = BlendInfo.setTopR(preProcBuffer[x], blendResult.j);
+      if (x + 1 < srcWidth) {
+        preProcBuffer[x + 1] = BlendInfo.setTopL(preProcBuffer[x + 1] & 0xff, blendResult.k);
+      }
+    }
+  }
+
+  outputMatrix = new OutputMatrix(scaleSize, trg, trgWidth);
+
+  let blend_xy = 0;
+  let blend_xy1 = 0;
+
+  let ker3 = [];
+
+  for (let y = yFirst; y < yLast; ++y) {
+    let trgi = scaleSize * y * trgWidth;
+    const s_m1 = srcWidth * Math.max(y - 1, 0);
+    const s_0 = srcWidth * y;
+    const s_p1 = srcWidth * Math.min(y + 1, srcHeight - 1);
+    const s_p2 = srcWidth * Math.min(y + 2, srcHeight - 1);
+
+    blend_xy1 = 0;
+
+    for (let x = 0; x < srcWidth; ++x, trgi += scaleSize) {
+      const x_m1 = Math.max(x - 1, 0);
+      const x_p1 = Math.min(x + 1, srcWidth - 1);
+      const x_p2 = Math.min(x + 2, srcWidth - 1);
+      {
+        ker4.a = src[s_m1 + x_m1];
+        ker4.b = src[s_m1 + x];
+        ker4.c = src[s_m1 + x_p1];
+        ker4.d = src[s_m1 + x_p2];
+
+        ker4.e = src[s_0 + x_m1];
+        ker4.f = src[s_0 + x];
+        ker4.g = src[s_0 + x_p1];
+        ker4.h = src[s_0 + x_p2];
+
+        ker4.i = src[s_p1 + x_m1];
+        ker4.j = src[s_p1 + x];
+        ker4.k = src[s_p1 + x_p1];
+        ker4.l = src[s_p1 + x_p2];
+
+        ker4.m = src[s_p2 + x_m1];
+        ker4.n = src[s_p2 + x];
+        ker4.o = src[s_p2 + x_p1];
+        ker4.p = src[s_p2 + x_p2];
+        preProcessCorners(ker4);
+
+        blend_xy = BlendInfo.setBottomR(preProcBuffer[x], blendResult.f);
+        blend_xy1 = BlendInfo.setTopR(blend_xy1, blendResult.j);
+        preProcBuffer[x] = blend_xy1;
+
+        blend_xy1 = BlendInfo.setTopL(0, blendResult.k);
+        if (x + 1 < srcWidth) {
+          preProcBuffer[x + 1] = BlendInfo.setBottomL(preProcBuffer[x + 1], blendResult.g);
+        }
+      }
+
+      fillBlock(trg, trgi, trgWidth, src[s_0 + x], scaleSize);
+
+      if (blend_xy === 0) {
+        continue;
+      }
+
+      const a = 0, b = 1, c = 2, d = 3, e = 4, f = 5, g = 6, h = 7, i = 8;
+
+      ker3[a] = src[s_m1 + x_m1];
+      ker3[b] = src[s_m1 + x];
+      ker3[c] = src[s_m1 + x_p1];
+
+      ker3[d] = src[s_0 + x_m1];
+      ker3[e] = src[s_0 + x];
+      ker3[f] = src[s_0 + x_p1];
+
+      ker3[g] = src[s_p1 + x_m1];
+      ker3[h] = src[s_p1 + x];
+      ker3[i] = src[s_p1 + x_p1];
+
+      let scaler;
+      switch (scaleSize) {
+      case 2:
+        scaler = new Scaler2x();
+        break;
+      case 3:
+        scaler = new Scaler3x();
+        break;
+      case 4:
+        scaler = new Scaler4x();
+        break;
+      default:
+        scaler = new Scaler4x();
+        break;
+      }
+
+      scalePixel(scaler, 0, ker3, trg, trgi, trgWidth, blend_xy);
+      scalePixel(scaler, 1, ker3, trg, trgi, trgWidth, blend_xy);
+      scalePixel(scaler, 2, ker3, trg, trgi, trgWidth, blend_xy);
+      scalePixel(scaler, 3, ker3, trg, trgi, trgWidth, blend_xy);
+    }
+  }
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
## Summary
- vendor a minimal MIT-licensed xBRZ implementation
- add `scaleXbrz` with sprite mask support
- expose the scaler via `Lemmings.scaleXbrz`
- allow `_blit` to choose between nearest and xBRZ scaling

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68422c80960c832da9b7cc7cb90ef044