### PR TITLE
Remove README level pack section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,9 @@ quotes, and semicolons across the JavaScript codebase.
 - The `js/` directory runs in the browser, so avoid Node-only modules like `fs`, `path`, or `process` in that code.
 
 ### Level packs
-Level packs follow the NeoLemmix folder layout described in [docs/levelpacks.md](docs/levelpacks.md).
+Level packs follow the NeoLemmix folder layout described in
+[docs/levelpacks.md](docs/levelpacks.md), which lists the expected
+`levels/`, `music/`, `styles/` and other directories.
 The [NeoLemmix Pack Toolkit](docs/nl-pack-toolkit.md) explains how
 these folders are structured and bundled.
 

--- a/README.md
+++ b/README.md
@@ -155,15 +155,6 @@ The goal is to create a solid, performant port first. Then build out the sequenc
 - See [docs/config.md](docs/config.md) for configuration details.
 - See [contributing.md](CONTRIBUTING.md) for contribution guidelines.
 
-## Level Packs
-
-The directories `lemmings/`, `lemmings_ohNo/`, `xmas91/`, `xmas92/`,
-`holiday93/` and `holiday94/` are extracted NeoLemmix packs. They use a
-simple folder structure so the Node tools can load files directly from
-directories or archives. See [docs/levelpacks.md](docs/levelpacks.md)
-for a short description of the layout and
-[docs/nl-pack-toolkit.md](docs/nl-pack-toolkit.md) for a summary of the
-NeoLemmix Pack Toolkit.
 
 ### Progressive Web App
 

--- a/docs/levelpacks.md
+++ b/docs/levelpacks.md
@@ -1,10 +1,11 @@
 
 # Level pack folder layout
 
-This document summarizes the typical folder structure used for NeoLemmix-style level packs. Each pack lives in its own directory so that Node tools can read the resources directly from disk or from a matching archive.
+This document summarizes the folder structure used for NeoLemmix-style level packs. Each pack lives in its own directory so the Node tools can load assets directly from disk or from a matching archive.
 
 ## Directory overview
 
+- `info.nxmi` – pack title, author and other meta information.
 - `levels/` – contains subfolders for each rank (e.g. `rank1/`, `rank2/`). Each level is stored as a `.lvl` file.
 - `music/` – optional music tracks in formats like OGG, IT, MOD or WAV.
 - `styles/` – custom graphic set data such as `.dat` or `VGASPEC` files.


### PR DESCRIPTION
## Summary
- delete incorrect level pack section from README

## Testing
- `npm run format`
- `npm test` *(fails: Cannot find module '/js/LemmingsNamespace.js')*

------
https://chatgpt.com/codex/tasks/task_e_6842904dbd88832d9628c11eeb8013ef