### PR TITLE
Add vendor code policy

### DIFF
--- a/.agentInfo/index-detailed.md
+++ b/.agentInfo/index-detailed.md
@@ -64,4 +64,5 @@ This expanded listing preserves the original bullet format with short descriptio
 - **stage, input, tests**: [notes/userinput-zoom.md](notes/userinput-zoom.md) - The mouse wheel now zooms around the pointer by converting the cursor's screen
 - **webmidi, enumerations, doc**: [notes/webmidi-enumerations.md](notes/webmidi-enumerations.md) - `js/webmidi.js` defines several tables describing MIDI message codes.
 - **webmidi, environment, doc**: [notes/webmidi-environments.md](notes/webmidi-environments.md) - The official "Supported Environments" page outlines where WebMIDI.js works:
+- **policy, third-party**: [notes/third-party-policy.md](notes/third-party-policy.md) - Avoid modifying or formatting libraries under `js/vendor/` or other vendor folders.
 

--- a/.agentInfo/index.md
+++ b/.agentInfo/index.md
@@ -52,3 +52,4 @@ webmidi-overview.md: webmidi doc overview
 webmidi-tasks.md: webmidi-todo
 webmidi.md: webmidi doc
 nl-pack-toolkit.md: pack-toolkit resources doc
+third-party-policy.md: policy third-party

--- a/.agentInfo/notes/third-party-policy.md
+++ b/.agentInfo/notes/third-party-policy.md
@@ -1,0 +1,5 @@
+# Third-party code policy
+
+tags: policy, third-party
+
+Avoid modifying files located in `js/vendor/` or other vendor directories. These libraries should remain exactly as shipped upstream. Do not run repository formatting tools on them.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,11 @@ Level packs follow the NeoLemmix folder layout described in
 The [NeoLemmix Pack Toolkit](docs/nl-pack-toolkit.md) explains how
 these folders are structured and bundled.
 
+## Third-party Code
+External libraries live in folders such as `js/vendor/` or other vendor
+directories. Do **not** modify these files, and do not run formatting
+tools on them.
+
 ## Commit policy
 - Keep commit messages concise.
 - Run `npm test` and ensure all tests pass before committing.


### PR DESCRIPTION
## Summary
- document rule against editing `js/vendor` or other third-party directories
- add a note about this restriction in `.agentInfo`

## Testing
- `npm run format`
- `npm test` *(fails: Error: ENOENT: no such file or directory, open '/tmp/out-TiVDw3/terrain_19_0.png')*

------
https://chatgpt.com/codex/tasks/task_e_684298711270832d8d1d4d4b41d4f359