### PR TITLE
Update DisplayImage notes

### DIFF
--- a/.agentInfo/index-detailed.md
+++ b/.agentInfo/index-detailed.md
@@ -65,4 +65,5 @@ This expanded listing preserves the original bullet format with short descriptio
 - **webmidi, enumerations, doc**: [notes/webmidi-enumerations.md](notes/webmidi-enumerations.md) - `js/webmidi.js` defines several tables describing MIDI message codes.
 - **webmidi, environment, doc**: [notes/webmidi-environments.md](notes/webmidi-environments.md) - The official "Supported Environments" page outlines where WebMIDI.js works:
 - **policy, third-party**: [notes/third-party-policy.md](notes/third-party-policy.md) - Avoid modifying or formatting libraries under `js/vendor/` or other vendor folders.
+- **display, canvas, scaling, image**: [notes/display-image.md](notes/display-image.md) - `scaleNearest`, `scaleXbrz` and `scaleHqx` resize frames. `_blit()` picks one via `scaleMode`.
 

--- a/.agentInfo/index.md
+++ b/.agentInfo/index.md
@@ -53,3 +53,4 @@ webmidi-tasks.md: webmidi-todo
 webmidi.md: webmidi doc
 nl-pack-toolkit.md: pack-toolkit resources doc
 third-party-policy.md: policy third-party
+display-image.md: display canvas scaling image

--- a/.agentInfo/notes/display-image.md
+++ b/.agentInfo/notes/display-image.md
@@ -1,6 +1,6 @@
 # DisplayImage overview
 
-tags: display, canvas
+tags: display, canvas, scaling, image
 
 `DisplayImage` is an offscreen canvas that `Stage` uses for both the game area and the GUI layer.  Each instance owns an `ImageData` buffer which is created through `Stage.createImage()`.  A `Uint32Array` view (`buffer32`) aliases this buffer so drawing routines can operate on 32‑bit pixels directly.
 
@@ -11,3 +11,5 @@ The method `initSize(width, height)` (re)allocates this `ImageData` and buffer. 
 GameDisplay highlights lemmings with dashed outlines. Hover uses a dark grey rectangle while the selected lemming gets a brighter green (`0xFF30FF30`). Both use `drawDashedRect` with 1 px dashes and sit slightly above the feet. A redundant skill switches the selection outline to yellow (`0xFFFFFF00`).
 
 `drawCornerRect(x, y, size, r, g, b, length = 1, midLine = false, midLen = 0)` draws L-shaped corner marks. The `length` parameter controls the size of the corner arms while `midLine` and `midLen` can add centered side lines. GameDisplay uses the defaults so only the corners are drawn.
+
+`js/DisplayImage.js` now exposes three scaling helpers – `scaleNearest`, `scaleXbrz` and `scaleHqx`.  `_blit()` chooses between them using its `scaleMode` option which defaults to `'nearest'`.  The XBRZ and HQX paths require even scaling factors of 2–4 and fall back to nearest-neighbour otherwise.


### PR DESCRIPTION
## Summary
- describe new image scaling helpers and scaleMode
- tag display-image notes with `scaling` and `image`
- extend .agentInfo indexes

## Testing
- `npm run format`
- `npm test` *(fails: Stage pointer events and exportGroundImages tests)*

------
https://chatgpt.com/codex/tasks/task_e_68429b93ade4832d9fbbcd3916626866