### PR TITLE
Fix zoom clamping

### DIFF
--- a/js/Stage.js
+++ b/js/Stage.js
@@ -177,18 +177,17 @@ class Stage {
       this.draw(stageImage, imgData);
     }
 
-    // Now clamp or recenter viewPoint:
-    // — Y should always sit so the bottom of the level is flush with the HUD,
-    //   i.e. “glued” to the top of the HUD panel.
+    // Clamp the viewPoint so the viewport never shows space outside the level
     const gameH = stageImage.display.getHeight();
     const winH = stageImage.height;
     const scale = stageImage.viewPoint.scale;
-    // worldHeight = how many “world pixels” tall
-    const worldH = gameH;
-    // viewH_world = viewport height in world units
-    const viewH_world = winH / scale;
-    // To glue bottom: viewPoint.y = worldH - viewH_world
-    stageImage.viewPoint.y = worldH - viewH_world;
+    const worldH = gameH; // world height in world units
+    const viewH_world = winH / scale; // viewport height in world units
+    stageImage.viewPoint.y = this.limitValue(
+      worldH - viewH_world,
+      stageImage.viewPoint.y,
+      0
+    );
 
     // — X: if scale ≥ 2, simply clamp so nothing goes offscreen
     const gameW = stageImage.display.getWidth();


### PR DESCRIPTION
## Summary
- keep zoomed point stable by clamping Y instead of forcing it

## Testing
- `npm test` *(fails: Stage pointer events, Stage.updateStageSize, Stage.updateViewPoint, tools/exportGroundImages.js, UserInputManager)*

------
https://chatgpt.com/codex/tasks/task_e_6842e9f52c20832dba3032c4d0df382f