### PR TITLE
Fix overlay fade rect reset timing

### DIFF
--- a/.searchHistory
+++ b/.searchHistory
@@ -35,3 +35,5 @@
 {"time":"2025-06-06T07:48:07.958Z","query":"select lemming","mdFiles":35,"codeFiles":186,"ms":549}
 {"time":"2025-06-06T07:41:48.183Z","query":"scaleNearest","mdFiles":11,"codeFiles":28,"ms":184}
 {"time":"2025-06-06T07:41:50.563Z","query":"nearest","mdFiles":5,"codeFiles":6,"ms":83}
+{"time":"2025-06-06T13:16:40.635Z","query":"startOverlayFade","mdFiles":22,"codeFiles":28,"ms":133}
+{"time":"2025-06-06T13:16:56.735Z","query":"overlayRect","mdFiles":12,"codeFiles":28,"ms":157}

--- a/.searchMetrics
+++ b/.searchMetrics
@@ -1,3024 +1,639 @@
 {
   ".agentInfo/index-detailed.md": {
-
-    "md": 32,
+    "md": 2,
     "code": 0,
     "terms": [
-      "rect",
-      "marching",
-      "x",
-      "y",
-      "if",
-      "else",
-      "spawn",
-      "bench",
-      "ants",
-      "line",
-      "selection",
-      "draw",
-      "corner",
-      "select",
-      "lemming",
-      "cursor"
-      "scale",
-      "nearest"
+      "start",
+      "overlay",
+      "fade",
+      "rect"
     ]
   },
-  ".agentInfo/index.md": {
-    "md": 26,
+  "README.md": {
+    "md": 2,
     "code": 0,
     "terms": [
-      "rect",
-      "marching",
-      "bench",
-      "ants",
-      "selection",
-      "draw",
-      "corner",
-      "select",
-      "lemming"
-    ]
-  },
-  ".agentInfo/notes/display-image.md": {
-    "md": 16,
-    "code": 0,
-    "terms": [
-      "rect",
-      "x",
-      "y",
-      "selection",
-      "draw",
-      "corner",
-      "select",
-      "lemming",
-      "cursor"
-    ]
-  },
-  ".agentInfo/notes/draw-corner-rect.md": {
-    "md": 15,
-    "code": 0,
-    "terms": [
-      "rect",
-      "x",
-      "y",
-      "selection",
-      "draw",
-      "corner",
-      "select",
-      "lemming",
-      "cursor"
-    ]
-  },
-  ".agentInfo/notes/drawMarchingAntRect.md": {
-    "md": 16,
-    "code": 0,
-    "terms": [
-      "rect",
-      "marching",
-      "ants",
-      "selection",
-      "draw",
-      "corner",
-      "select",
-      "lemming",
-      "cursor"
-    ]
-  },
-  ".agentInfo/notes/game-display.md": {
-    "md": 17,
-    "md": 13,
-    "code": 0,
-    "terms": [
-      "rect",
-      "marching",
-      "ants",
-      "selection",
-      "draw",
-      "corner",
-      "select",
-      "lemming",
-      "cursor"
-      "scale",
-      "nearest"
-    ]
-  },
-  ".agentInfo/notes/game-view.md": {
-    "md": 9,
-    "code": 0,
-    "terms": [
-      "rect",
-      "selection",
-      "draw",
-      "corner"
+      "start",
+      "overlay",
+      "fade",
+      "rect"
     ]
   },
   ".agentInfo/notes/pause-overlay.md": {
-    "md": 19,
+    "md": 2,
     "code": 0,
     "terms": [
-      "rect",
-      "bench",
-      "selection",
-      "draw",
-      "corner"
+      "start",
+      "overlay",
+      "fade",
+      "rect"
+    ]
+  },
+  "docs/level-file-format.md": {
+    "md": 1,
+    "code": 0,
+    "terms": [
+      "start",
+      "overlay",
+      "fade"
     ]
   },
   "docs/nl-file-format.md": {
-    "md": 19,
-    "md": 15,
+    "md": 2,
     "code": 0,
     "terms": [
-      "rect",
-      "x",
-      "y",
-      "if",
-      "else",
-      "line",
-      "selection",
-      "draw",
-      "corner",
-      "select",
-      "lemming",
-      "cursor"
-      "scale",
-      "nearest"
+      "start",
+      "overlay",
+      "fade",
+      "rect"
     ]
   },
-  "js/DisplayImage.js": {
-    "md": 0,
-    "code": 21,
-    "code": 18,
+  "AGENTS.md": {
+    "md": 1,
+    "code": 0,
     "terms": [
-      "rect",
-      "marching",
-      "x",
-      "y",
-      "pos",
-      "if",
-      "else",
-      "ants",
-      "line",
-      "selection",
-      "draw",
-      "corner",
-      "select",
-      "lemming"
-      "scale",
-      "nearest"
+      "start",
+      "overlay",
+      "fade"
     ]
   },
-  "js/Stage.js": {
-    "md": 0,
-    "code": 19,
-    "code": 14,
+  ".agentInfo/notes/easing-functions.md": {
+    "md": 1,
+    "code": 0,
     "terms": [
-      "rect",
-      "x",
-      "y",
-      "pos",
-      "if",
-      "else",
-      "selection",
-      "draw",
-      "corner",
-      "select",
-      "lemming",
-      "cursor"
-      "scale",
-      "nearest"
+      "start",
+      "overlay",
+      "fade"
     ]
   },
-  "js/GameGui.js": {
-    "md": 0,
-    "code": 31,
+  ".agentInfo/notes/game-view.md": {
+    "md": 2,
+    "code": 0,
     "terms": [
-      "rect",
-      "marching",
-      "x",
-      "y",
-      "if",
-      "else",
-      "bench",
-      "ants",
-      "line",
-      "selection",
-      "draw",
-      "corner",
-      "select",
-      "lemming",
-      "cursor"
+      "start",
+      "overlay",
+      "fade",
+      "rect"
     ]
   },
-  "js/Level.js": {
-    "md": 0,
-    "code": 17,
+  ".agentInfo/notes/game.md": {
+    "md": 1,
+    "code": 0,
     "terms": [
-      "rect",
-      "x",
-      "y",
-      "if",
-      "else",
-      "selection",
-      "draw",
-      "corner",
-      "select",
-      "lemming"
+      "start",
+      "overlay",
+      "fade"
     ]
   },
-  "js/Frame.js": {
-    "md": 0,
-    "code": 21,
+  ".agentInfo/notes/level-reader.md": {
+    "md": 1,
+    "code": 0,
     "terms": [
-      "rect",
-      "marching",
-      "x",
-      "y",
-      "pos",
-      "if",
-      "else",
-      "ants",
-      "line",
-      "selection",
-      "draw",
-      "corner",
-      "select",
-      "lemming"
+      "start",
+      "overlay",
+      "fade"
     ]
   },
-  "js/GameDisplay.js": {
-    "md": 0,
-    "code": 18,
-    "code": 14,
+  ".agentInfo/notes/mechanics-flags.md": {
+    "md": 1,
+    "code": 0,
     "terms": [
-      "rect",
-      "x",
-      "y",
-      "if",
-      "else",
-      "selection",
-      "draw",
-      "corner",
-      "select",
-      "lemming",
-      "cursor"
-      "scale",
-      "nearest"
+      "start",
+      "overlay",
+      "fade"
     ]
   },
-  "js/GameTimer.js": {
-    "md": 0,
-    "code": 27,
-    "code": 23,
+  ".agentInfo/notes/overview.md": {
+    "md": 1,
+    "code": 0,
     "terms": [
-      "rect",
-      "x",
-      "y",
-      "if",
-      "else",
-      "bench",
-      "selection",
-      "draw",
-      "corner",
-      "select",
-      "lemming"
-      "scale",
-      "nearest"
+      "start",
+      "overlay",
+      "fade"
+    ]
+  },
+  ".agentInfo/notes/stage.md": {
+    "md": 1,
+    "code": 0,
+    "terms": [
+      "start",
+      "overlay",
+      "fade"
+    ]
+  },
+  ".agentInfo/notes/webmidi-overview.md": {
+    "md": 1,
+    "code": 0,
+    "terms": [
+      "start",
+      "overlay",
+      "fade"
+    ]
+  },
+  "docs/compression-format.md": {
+    "md": 1,
+    "code": 0,
+    "terms": [
+      "start",
+      "overlay",
+      "fade"
+    ]
+  },
+  "docs/config.md": {
+    "md": 1,
+    "code": 0,
+    "terms": [
+      "start",
+      "overlay",
+      "fade"
+    ]
+  },
+  "docs/exporting-sprites.md": {
+    "md": 1,
+    "code": 0,
+    "terms": [
+      "start",
+      "overlay",
+      "fade"
+    ]
+  },
+  "docs/nl-objects.md": {
+    "md": 1,
+    "code": 0,
+    "terms": [
+      "start",
+      "overlay",
+      "fade"
+    ]
+  },
+  "docs/nl-skills.md": {
+    "md": 1,
+    "code": 0,
+    "terms": [
+      "start",
+      "overlay",
+      "fade"
+    ]
+  },
+  ".agentInfo/index.md": {
+    "md": 2,
+    "code": 0,
+    "terms": [
+      "start",
+      "overlay",
+      "fade",
+      "rect"
+    ]
+  },
+  ".agentInfo/notes/trigger-manager.md": {
+    "md": 2,
+    "code": 0,
+    "terms": [
+      "start",
+      "overlay",
+      "fade",
+      "rect"
+    ]
+  },
+  "CHANGELOG.md": {
+    "md": 2,
+    "code": 0,
+    "terms": [
+      "start",
+      "overlay",
+      "fade",
+      "rect"
     ]
   },
   "js/GameView.js": {
     "md": 0,
-    "code": 29,
-    "code": 24,
+    "code": 2,
     "terms": [
-      "rect",
-      "x",
-      "y",
-      "if",
-      "else",
-      "spawn",
-      "bench",
-      "selection",
-      "draw",
-      "corner",
-      "select",
-      "lemming",
-      "cursor"
-      "scale",
-      "nearest"
-    ]
-  },
-  "js/MiniMap.js": {
-    "md": 0,
-    "code": 20,
-    "code": 15,
-    "terms": [
-      "rect",
-      "marching",
-      "x",
-      "y",
-      "if",
-      "else",
-      "ants",
-      "selection",
-      "draw",
-      "corner",
-      "select",
-      "lemming",
-      "cursor"
-      "scale",
-      "nearest"
-    ]
-  },
-  "js/Trigger.js": {
-    "md": 0,
-    "code": 17,
-    "terms": [
-      "rect",
-      "x",
-      "y",
-      "if",
-      "else",
-      "selection",
-      "draw",
-      "corner",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/TriggerManager.js": {
-    "md": 0,
-    "code": 17,
-    "terms": [
-      "rect",
-      "x",
-      "y",
-      "if",
-      "else",
-      "selection",
-      "draw",
-      "corner",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/UserInputManager.js": {
-    "md": 0,
-    "code": 19,
-    "code": 14,
-    "terms": [
-      "rect",
-      "x",
-      "y",
-      "pos",
-      "if",
-      "else",
-      "selection",
-      "draw",
-      "corner",
-      "select",
-      "lemming",
-      "cursor"
-      "scale",
-      "nearest"
-    ]
-  },
-  "test/displayimage.test.js": {
-    "md": 0,
-    "code": 16,
-    "code": 12,
-    "terms": [
-      "rect",
-      "x",
-      "y",
-      "line",
-      "selection",
-      "draw",
-      "corner",
-      "select",
-      "lemming"
-      "scale",
-      "nearest"
-    ]
-  },
-  "test/gameview.suspendWithColor.test.js": {
-    "md": 0,
-    "code": 26,
-    "code": 21,
-    "terms": [
-      "rect",
-      "x",
-      "y",
-      "bench",
-      "selection",
-      "draw",
-      "corner",
-      "select",
-      "lemming",
-      "cursor"
-      "scale",
-      "nearest"
-    ]
-  },
-  "test/gameview.test.js": {
-    "md": 0,
-    "code": 15,
-    "terms": [
-      "rect",
-      "selection",
-      "draw",
-      "corner",
-      "select",
-      "lemming",
-      "cursor"
-    ]
-  },
-  "test/geometry.test.js": {
-    "md": 0,
-    "code": 16,
-    "terms": [
-      "rect",
-      "x",
-      "y",
-      "pos",
-      "selection",
-      "draw",
-      "corner",
-      "select",
-      "lemming"
-    ]
-  },
-  "test/minimap.test.js": {
-    "md": 0,
-    "code": 17,
-    "code": 13,
-    "terms": [
-      "rect",
-      "x",
-      "y",
-      "if",
-      "else",
-      "selection",
-      "draw",
-      "corner",
-      "select",
-      "lemming"
-      "scale",
-      "nearest"
-    ]
-  },
-  "test/rectangle.test.js": {
-    "md": 0,
-    "code": 14,
-    "terms": [
-      "rect",
-      "selection",
-      "draw",
-      "corner",
-      "select",
-      "lemming"
-    ]
-  },
-  "test/stage.overlayfade.test.js": {
-    "md": 0,
-    "code": 15,
-    "terms": [
-      "rect",
-      "x",
-      "y",
-      "selection",
-      "draw",
-      "corner",
-      "select",
-      "lemming"
-    ]
-  },
-  "test/stage.test.js": {
-    "md": 0,
-    "code": 16,
-    "code": 12,
-    "terms": [
-      "rect",
-      "x",
-      "y",
-      "pos",
-      "selection",
-      "draw",
-      "corner",
-      "select",
-      "lemming"
-      "scale",
-      "nearest"
-    ]
-  },
-  "test/stage.updateStageSize.test.js": {
-    "md": 0,
-    "code": 15,
-    "code": 11,
-    "terms": [
-      "rect",
-      "x",
-      "y",
-      "selection",
-      "draw",
-      "corner",
-      "select",
-      "lemming"
-      "scale",
-      "nearest"
-    ]
-  },
-  "test/stage.updateviewpoint.test.js": {
-    "md": 0,
-    "code": 15,
-    "code": 11,
-    "terms": [
-      "rect",
-      "x",
-      "y",
-      "selection",
-      "draw",
-      "corner",
-      "select",
-      "lemming"
-      "scale",
-      "nearest"
-    ]
-  },
-  "test/stageimageprops.test.js": {
-    "md": 0,
-    "code": 14,
-    "terms": [
-      "rect",
-      "selection",
-      "draw",
-      "corner",
-      "select",
-      "lemming"
-    ]
-  },
-  "test/trigger.test.js": {
-    "md": 0,
-    "code": 14,
-    "terms": [
-      "rect",
-      "selection",
-      "draw",
-      "corner",
-      "select",
-      "lemming"
-    ]
-  },
-  "test/triggermanager.test.js": {
-    "md": 0,
-    "code": 15,
-    "terms": [
-      "rect",
-      "x",
-      "y",
-      "selection",
-      "draw",
-      "corner",
-      "select",
-      "lemming"
-    ]
-  },
-  "test/userinput.test.js": {
-    "md": 0,
-    "code": 19,
-    "code": 14,
-    "terms": [
-      "rect",
-      "x",
-      "y",
-      "pos",
-      "if",
-      "else",
-      "selection",
-      "draw",
-      "corner",
-      "select",
-      "lemming",
-      "cursor"
-      "scale",
-      "nearest"
-    ]
-  },
-  ".agentInfo/notes/game-gui.md": {
-    "md": 16,
-    "code": 0,
-    "terms": [
-      "marching",
-      "x",
-      "y",
-      "if",
-      "else",
-      "ants",
-      "selection",
-      "rect",
-      "draw",
-      "corner",
-      "select",
-      "lemming",
-      "cursor"
-    ]
-  },
-  ".agentInfo/notes/level-reader.md": {
-    "md": 10,
-    "code": 0,
-    "terms": [
-      "x",
-      "y",
-      "draw",
-      "corner",
-      "rect",
-      "select",
-      "lemming"
-    ]
-  },
-  "docs/level-file-format.md": {
-    "md": 13,
-    "md": 10,
-    "code": 0,
-    "terms": [
-      "x",
-      "y",
-      "pos",
-      "if",
-      "else",
-      "draw",
-      "corner",
-      "rect",
-      "select",
-      "lemming"
-    ]
-  },
-  "README.md": {
-    "md": 22,
-      "scale",
-      "nearest"
-    ]
-  },
-  "README.md": {
-    "md": 17,
-    "code": 0,
-    "terms": [
-      "x",
-      "y",
-      "if",
-      "else",
-      "spawn",
-      "bench",
-      "line",
-      "selection",
-      "rect",
-      "select",
-      "lemming",
-      "cursor"
-      "scale",
-      "nearest"
-    ]
-  },
-  ".agentInfo/notes/trigger-manager.md": {
-    "md": 5,
-    "code": 0,
-    "terms": [
-      "x",
-      "y",
-      "draw",
-      "corner",
+      "start",
+      "overlay",
+      "fade",
       "rect"
     ]
   },
-  "js/LemmingManager.js": {
+  "js/Stage.js": {
     "md": 0,
-    "code": 21,
-    "code": 17,
+    "code": 2,
     "terms": [
-      "x",
-      "y",
-      "if",
-      "else",
-      "spawn",
-      "bench",
-      "selection",
-      "rect",
-      "select",
-      "lemming",
-      "cursor"
-      "scale",
-      "nearest"
+      "start",
+      "overlay",
+      "fade",
+      "rect"
     ]
   },
-  "js/SolidLayer.js": {
+  "js/GameTimer.js": {
     "md": 0,
-    "code": 9,
+    "code": 2,
     "terms": [
-      "x",
-      "y",
-      "pos",
-      "if",
-      "else",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/ParticleTable.js": {
-    "md": 0,
-    "code": 13,
-    "terms": [
-      "x",
-      "y",
-      "pos",
-      "if",
-      "else",
-      "draw",
-      "corner",
-      "rect",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/xbrz/xbrz.js": {
-    "md": 0,
-    "code": 10,
-    "terms": [
-      "x",
-      "y",
-      "pos",
-      "if",
-      "else",
-      "line",
-      "draw",
-      "corner",
-      "rect",
-      "scale",
-      "nearest"
-    ]
-  },
-  "js/SkillPanelSprites.js": {
-    "md": 0,
-    "code": 6,
-    "terms": [
-      "x",
-      "y",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/KeyboardShortcuts.js": {
-    "md": 0,
-    "code": 14,
-    "code": 9,
-    "terms": [
-      "x",
-      "y",
-      "if",
-      "else",
-      "selection",
-      "rect",
-      "draw",
-      "corner",
-      "select",
-      "lemming",
-      "cursor"
-      "scale",
-      "nearest"
-    ]
-  },
-  "js/LevelReader.js": {
-    "md": 0,
-    "code": 13,
-    "terms": [
-      "x",
-      "y",
-      "pos",
-      "if",
-      "else",
-      "draw",
-      "corner",
-      "rect",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/Lemming.js": {
-    "md": 0,
-    "code": 12,
-    "terms": [
-      "x",
-      "y",
-      "if",
-      "else",
-      "draw",
-      "corner",
-      "rect",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/LemmingsSprite.js": {
-    "md": 0,
-    "code": 9,
-    "terms": [
-      "x",
-      "y",
-      "if",
-      "else",
-      "line",
-      "select",
-      "lemming"
-    ]
-  },
-  "tools/exportAllSprites.js": {
-    "md": 0,
-    "code": 12,
-    "terms": [
-      "x",
-      "y",
-      "if",
-      "else",
-      "draw",
-      "corner",
-      "rect",
-      "select",
-      "lemming"
-    ]
-  },
-  "fileformat.txt": {
-    "md": 0,
-    "code": 13,
-    "code": 10,
-    "terms": [
-      "x",
-      "y",
-      "pos",
-      "if",
-      "else",
-      "draw",
-      "corner",
-      "rect",
-      "select",
-      "lemming"
-      "scale",
-      "nearest"
-    ]
-  },
-  "js/ActionBashSystem.js": {
-    "md": 0,
-    "code": 8,
-    "terms": [
-      "x",
-      "y",
-      "if",
-      "else",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/Animation.js": {
-    "md": 0,
-    "code": 10,
-    "terms": [
-      "x",
-      "y",
-      "if",
-      "else",
-      "selection",
-      "rect",
-      "select",
-      "lemming",
-      "cursor"
-    ]
-  },
-  "test/solidlayer.test.js": {
-    "md": 0,
-    "code": 6,
-    "terms": [
-      "x",
-      "y",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/ActionDiggSystem.js": {
-    "md": 0,
-    "code": 8,
-    "terms": [
-      "x",
-      "y",
-      "if",
-      "else",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/ActionWalkSystem.js": {
-    "md": 0,
-    "code": 8,
-    "terms": [
-      "x",
-      "y",
-      "if",
-      "else",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/LevelWriter.js": {
-    "md": 0,
-    "code": 13,
-    "terms": [
-      "x",
-      "y",
-      "pos",
-      "if",
-      "else",
-      "draw",
-      "corner",
-      "rect",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/Mask.js": {
-    "md": 0,
-    "code": 8,
-    "terms": [
-      "x",
-      "y",
-      "if",
-      "else",
-      "select",
-      "lemming"
-    ]
-  },
-  "test/mask.test.js": {
-    "md": 0,
-    "code": 6,
-    "terms": [
-      "x",
-      "y",
-      "select",
-      "lemming"
-    ]
-  },
-  "tools/exportLemmingsSprites.js": {
-    "md": 0,
-    "code": 8,
-    "terms": [
-      "x",
-      "y",
-      "if",
-      "else",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/ActionBlockerSystem.js": {
-    "md": 0,
-    "code": 8,
-    "terms": [
-      "x",
-      "y",
-      "if",
-      "else",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/ActionBuildSystem.js": {
-    "md": 0,
-    "code": 8,
-    "terms": [
-      "x",
-      "y",
-      "if",
-      "else",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/ActionClimbSystem.js": {
-    "md": 0,
-    "code": 8,
-    "terms": [
-      "x",
-      "y",
-      "if",
-      "else",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/ActionDrowningSystem.js": {
-    "md": 0,
-    "code": 12,
-    "terms": [
-      "x",
-      "y",
-      "if",
-      "else",
-      "draw",
-      "corner",
-      "rect",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/ActionFryingSystem.js": {
-    "md": 0,
-    "code": 12,
-    "terms": [
-      "x",
-      "y",
-      "if",
-      "else",
-      "draw",
-      "corner",
-      "rect",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/ActionJumpSystem.js": {
-    "md": 0,
-    "code": 12,
-    "terms": [
-      "x",
-      "y",
-      "if",
-      "else",
-      "draw",
-      "corner",
-      "rect",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/ActionOhNoSystem.js": {
-    "md": 0,
-    "code": 12,
-    "terms": [
-      "x",
-      "y",
-      "if",
-      "else",
-      "draw",
-      "corner",
-      "rect",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/GroundReader.js": {
-    "md": 0,
-    "code": 9,
-    "terms": [
-      "x",
-      "y",
-      "pos",
-      "if",
-      "else",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/GroundRenderer.js": {
-    "md": 0,
-    "code": 12,
-    "terms": [
-      "x",
-      "y",
-      "if",
-      "else",
-      "draw",
-      "corner",
-      "rect",
-      "select",
-      "lemming"
+      "start",
+      "overlay",
+      "fade",
+      "rect"
     ]
   },
   "test/bench-speed-adjust.test.js": {
     "md": 0,
-    "code": 16,
-    "code": 12,
-    "terms": [
-      "x",
-      "y",
-      "bench",
-      "select",
-      "lemming"
-      "scale",
-      "nearest"
-    ]
-  },
-  "test/gamedisplay.test.js": {
-    "md": 0,
-    "code": 14,
-    "code": 10,
-    "terms": [
-      "x",
-      "y",
-      "if",
-      "else",
-      "selection",
-      "rect",
-      "draw",
-      "corner",
-      "select",
-      "lemming",
-      "cursor"
-      "scale",
-      "nearest"
-    ]
-  },
-  "test/getNearestLemming.test.js": {
-    "md": 0,
-    "code": 16,
-    "code": 13,
-    "terms": [
-      "x",
-      "y",
-      "bench",
-      "select",
-      "lemming"
-      "scale",
-      "nearest"
-    ]
-  },
-  "test/groundrenderer.test.js": {
-    "md": 0,
-    "code": 12,
-    "terms": [
-      "x",
-      "y",
-      "if",
-      "else",
-      "draw",
-      "corner",
-      "rect",
-      "select",
-      "lemming"
-    ]
-  },
-  "test/lemming.test.js": {
-    "md": 0,
-    "code": 16,
-    "terms": [
-      "x",
-      "y",
-      "bench",
-      "select",
-      "lemming"
-    ]
-  },
-  "test/walk-wall-collision.test.js": {
-    "md": 0,
-    "code": 6,
-    "terms": [
-      "x",
-      "y",
-      "select",
-      "lemming"
-    ]
-  },
-  "tools/scanGreenPanel.js": {
-    "md": 0,
-    "code": 8,
-    "terms": [
-      "x",
-      "y",
-      "if",
-      "else",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/ActionExplodingSystem.js": {
-    "md": 0,
-    "code": 12,
-    "terms": [
-      "x",
-      "y",
-      "if",
-      "else",
-      "draw",
-      "corner",
-      "rect",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/ActionHoistSystem.js": {
-    "md": 0,
-    "code": 12,
-    "terms": [
-      "x",
-      "y",
-      "if",
-      "else",
-      "draw",
-      "corner",
-      "rect",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/ViewPoint.js": {
-    "md": 0,
-    "code": 6,
-    "terms": [
-      "x",
-      "y",
-      "select",
-      "lemming"
     "code": 2,
     "terms": [
-      "x",
-      "y",
-      "scale",
-      "nearest"
-    ]
-  },
-  "tools/renderCursorSizes.js": {
-    "md": 0,
-    "code": 6,
-    "terms": [
-      "x",
-      "y",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/ActionBaseSystem.js": {
-    "md": 0,
-    "code": 12,
-    "terms": [
-      "x",
-      "y",
-      "if",
-      "else",
-      "draw",
-      "corner",
-      "rect",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/ActionCountdownSystem.js": {
-    "md": 0,
-    "code": 12,
-    "terms": [
-      "x",
-      "y",
-      "if",
-      "else",
-      "draw",
-      "corner",
-      "rect",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/ActionFallSystem.js": {
-    "md": 0,
-    "code": 12,
-    "terms": [
-      "x",
-      "y",
-      "if",
-      "else",
-      "draw",
-      "corner",
-      "rect",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/ActionFloatingSystem.js": {
-    "md": 0,
-    "code": 12,
-    "terms": [
-      "x",
-      "y",
-      "if",
-      "else",
-      "draw",
-      "corner",
-      "rect",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/ActionMineSystem.js": {
-    "md": 0,
-    "code": 8,
-    "terms": [
-      "x",
-      "y",
-      "if",
-      "else",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/ActionSplatterSystem.js": {
-    "md": 0,
-    "code": 12,
-    "terms": [
-      "x",
-      "y",
-      "if",
-      "else",
-      "draw",
-      "corner",
-      "rect",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/LevelElement.js": {
-    "md": 0,
-    "code": 6,
-    "terms": [
-      "x",
-      "y",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/MapObject.js": {
-    "md": 0,
-    "code": 13,
-    "terms": [
-      "x",
-      "y",
-      "if",
-      "else",
-      "spawn",
-      "draw",
-      "corner",
-      "rect",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/MaskList.js": {
-    "md": 0,
-    "code": 8,
-    "terms": [
-      "x",
-      "y",
-      "if",
-      "else",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/ObjectManager.js": {
-    "md": 0,
-    "code": 10,
-    "terms": [
-      "x",
-      "y",
-      "draw",
-      "corner",
-      "rect",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/PaletteImage.js": {
-    "md": 0,
-    "code": 13,
-    "terms": [
-      "x",
-      "y",
-      "pos",
-      "if",
-      "else",
-      "draw",
-      "corner",
-      "rect",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/Position2D.js": {
-    "md": 0,
-    "code": 6,
-    "terms": [
-      "x",
-      "y",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/Range.js": {
-    "md": 0,
-    "code": 6,
-    "terms": [
-      "x",
-      "y",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/Rectangle.js": {
-    "md": 0,
-    "code": 6,
-    "terms": [
-      "x",
-      "y",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/StageImageProperties.js": {
-    "md": 0,
-    "code": 6,
-    "terms": [
-      "x",
-      "y",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/VGASpecReader.js": {
-    "md": 0,
-    "code": 14,
-    "terms": [
-      "x",
-      "y",
-      "pos",
-      "if",
-      "else",
-      "line",
-      "draw",
-      "corner",
-      "rect",
-      "select",
-      "lemming"
+      "start",
+      "overlay",
+      "fade",
+      "rect"
     ]
   },
   "test/gametimer.test.js": {
     "md": 0,
-    "code": 18,
-    "code": 14,
+    "code": 2,
     "terms": [
-      "x",
-      "y",
-      "if",
-      "else",
-      "bench",
-      "select",
-      "lemming"
-      "scale",
-      "nearest"
+      "start",
+      "overlay",
+      "fade",
+      "rect"
     ]
   },
-  "test/levelwriter.test.js": {
+  "test/gameview.suspendWithColor.test.js": {
     "md": 0,
-    "code": 10,
+    "code": 2,
     "terms": [
-      "x",
-      "y",
-      "draw",
-      "corner",
-      "rect",
-      "select",
-      "lemming"
+      "start",
+      "overlay",
+      "fade",
+      "rect"
     ]
   },
-  "test/range.test.js": {
+  "test/stage.overlayfade.test.js": {
     "md": 0,
-    "code": 6,
+    "code": 2,
     "terms": [
-      "x",
-      "y",
-      "select",
-      "lemming"
+      "start",
+      "overlay",
+      "fade",
+      "rect"
     ]
   },
-  "test/tools/scanGreenPanel.test.js": {
+  "fileformat.txt": {
     "md": 0,
-    "code": 8,
+    "code": 1,
     "terms": [
-      "x",
-      "y",
-      "if",
-      "else",
-      "select",
-      "lemming"
+      "start",
+      "overlay",
+      "fade"
     ]
   },
-  "tools/exportGroundImages.js": {
+  "test/gameview.test.js": {
     "md": 0,
-    "code": 12,
+    "code": 2,
     "terms": [
-      "x",
-      "y",
-      "if",
-      "else",
-      "draw",
-      "corner",
-      "rect",
-      "select",
-      "lemming"
-    ]
-  },
-  "tools/exportPanelSprite.js": {
-    "md": 0,
-    "code": 6,
-    "terms": [
-      "x",
-      "y",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/Game.js": {
-    "md": 0,
-    "code": 8,
-    "terms": [
-      "x",
-      "y",
-      "if",
-      "else",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/LevelLoader.js": {
-    "md": 0,
-    "code": 8,
-    "terms": [
-      "x",
-      "y",
-      "if",
-      "else",
-      "select",
-      "lemming"
-    ]
-  },
-  "test/commandmanager.test.js": {
-    "md": 0,
-    "code": 8,
-    "terms": [
-      "x",
-      "y",
-      "if",
-      "else",
-      "select",
-      "lemming"
-    ]
-  },
-  "tools/listSprites.js": {
-    "md": 0,
-    "code": 9,
-    "terms": [
-      "x",
-      "y",
-      "if",
-      "else",
-      "line",
-      "select",
-      "lemming"
-    ]
-  },
-  "tools/patchSprites.js": {
-    "md": 0,
-    "code": 8,
-    "terms": [
-      "x",
-      "y",
-      "if",
-      "else",
-      "select",
-      "lemming"
-    ]
-  },
-  "tools/search.js": {
-    "md": 0,
-    "code": 10,
-    "terms": [
-      "pos",
-      "if",
-      "else",
-      "ants",
-      "line",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/BinaryReader.js": {
-    "md": 0,
-    "code": 9,
-    "terms": [
-      "pos",
-      "if",
-      "else",
-      "select",
-      "lemming",
-      "cursor"
-    ]
-  },
-  "js/BitWriter.js": {
-    "md": 0,
-    "code": 8,
-    "terms": [
-      "pos",
-      "if",
-      "else",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/BitReader.js": {
-    "md": 0,
-    "code": 8,
-    "terms": [
-      "pos",
-      "if",
-      "else",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/FileContainer.js": {
-    "md": 0,
-    "code": 8,
-    "terms": [
-      "pos",
-      "if",
-      "else",
-      "select",
-      "lemming"
-    ]
-  },
-  "test/oddtable.test.js": {
-    "md": 0,
-    "code": 8,
-    "terms": [
-      "pos",
-      "if",
-      "else",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/PackFilePart.js": {
-    "md": 0,
-    "code": 8,
-    "terms": [
-      "pos",
-      "if",
-      "else",
-      "select",
-      "lemming"
-    ]
-  },
-  "test/vgaspecreader.test.js": {
-    "md": 0,
-    "code": 6,
-    "terms": [
-      "pos",
-      "select",
-      "lemming"
-    ]
-  },
-  "docs/compression-format.md": {
-    "md": 18,
-    "code": 0,
-    "terms": [
-      "if",
-      "else",
-      "bench",
-      "select",
-      "lemming",
-      "cursor"
-    ]
-  },
-  "AGENTS.md": {
-    "md": 8,
-    "code": 0,
-    "terms": [
-      "if",
-      "else",
-      "line",
-      "select",
-      "lemming"
-    ]
-  },
-  ".agentInfo/notes/webmidi-environments.md": {
-    "md": 2,
-    "code": 0,
-    "terms": [
-      "if",
-      "else"
-    ]
-  },
-  "docs/nl-skills.md": {
-    "md": 7,
-    "code": 0,
-    "terms": [
-      "if",
-      "else",
-      "select",
-      "lemming"
-    ]
-  },
-  ".agentInfo/AGENTS.md": {
-    "md": 7,
-    "code": 0,
-    "terms": [
-      "if",
-      "else",
-      "select",
-      "lemming"
-    ]
-  },
-  ".agentInfo/notes/bench-mode.md": {
-    "md": 18,
-    "code": 0,
-    "terms": [
-      "if",
-      "else",
-      "spawn",
-      "bench",
-      "select",
-      "lemming"
-    ]
-  },
-  ".agentInfo/notes/check-undefined.md": {
-    "md": 2,
-    "code": 0,
-    "terms": [
-      "if",
-      "else"
-    ]
-  },
-  ".agentInfo/notes/command-manager.md": {
-    "md": 2,
-    "code": 0,
-    "terms": [
-      "if",
-      "else"
-    ]
-  },
-  ".agentInfo/notes/gui-stage-tasks.md": {
-    "md": 13,
-    "md": 8,
-    "code": 0,
-    "terms": [
-      "if",
-      "else",
-      "selection",
-      "rect",
-      "draw",
-      "corner",
-      "select",
-      "lemming",
-      "cursor"
-      "scale",
-      "nearest"
-    ]
-  },
-  ".agentInfo/notes/note-review.md": {
-    "md": 2,
-    "code": 0,
-    "terms": [
-      "if",
-      "else"
-    ]
-  },
-  ".agentInfo/notes/pack-mechanics.md": {
-    "md": 7,
-    "code": 0,
-    "terms": [
-      "if",
-      "else",
-      "select",
-      "lemming"
-    ]
-  },
-  "docs/nl-objects.md": {
-    "md": 7,
-    "code": 0,
-    "terms": [
-      "if",
-      "else",
-      "select",
-      "lemming"
-    ]
-  },
-  "docs/tools.md": {
-    "md": 9,
-    "code": 0,
-    "terms": [
-      "if",
-      "else",
-      "selection",
-      "rect",
-      "select",
-      "lemming",
-      "cursor"
-    ]
-  },
-  "tools/check-undefined.js": {
-    "md": 0,
-    "code": 3,
-    "terms": [
-      "if",
-      "else",
-      "line"
-    ]
-  },
-  "tools/NodeFileProvider.js": {
-    "md": 0,
-    "code": 7,
-    "terms": [
-      "if",
-      "else",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/FileProvider.js": {
-    "md": 0,
-    "code": 7,
-    "terms": [
-      "if",
-      "else",
-      "select",
-      "lemming"
+      "start",
+      "overlay",
+      "fade",
+      "rect"
     ]
   },
   "tools/build_index.js": {
     "md": 0,
-    "code": 7,
+    "code": 1,
     "terms": [
-      "if",
-      "else",
-      "select",
-      "lemming"
-    "code": 3,
-    "terms": [
-      "if",
-      "else",
-      "scale",
-      "nearest"
+      "start",
+      "overlay",
+      "fade"
     ]
   },
-  "test/exportScripts.test.js": {
+  "tools/search.js": {
     "md": 0,
-    "code": 11,
+    "code": 1,
     "terms": [
-      "if",
-      "else",
-      "draw",
-      "corner",
-      "rect",
-      "select",
-      "lemming"
+      "start",
+      "overlay",
+      "fade"
     ]
   },
-  "index.html": {
-    "md": 0,
-    "code": 9,
-    "code": 4,
-    "terms": [
-      "if",
-      "else",
-      "selection",
-      "rect",
-      "select",
-      "lemming",
-      "cursor"
-      "scale",
-      "nearest"
-    ]
-  },
-  "js/UnpackFilePart.js": {
-    "md": 0,
-    "code": 7,
-    "terms": [
-      "if",
-      "else",
-      "select",
-      "lemming"
-    ]
-  },
-  "tools/processHtmlFile.js": {
+  "js/Level.js": {
     "md": 0,
     "code": 2,
     "terms": [
-      "if",
-      "else"
+      "start",
+      "overlay",
+      "fade",
+      "rect"
     ]
   },
-  "js/CommandManager.js": {
+  "js/BinaryReader.js": {
     "md": 0,
-    "code": 9,
+    "code": 1,
     "terms": [
-      "if",
-      "else",
-      "selection",
-      "rect",
-      "select",
-      "lemming",
-      "cursor"
+      "start",
+      "overlay",
+      "fade"
+    ]
+  },
+  "js/LemmingManager.js": {
+    "md": 0,
+    "code": 1,
+    "terms": [
+      "start",
+      "overlay",
+      "fade"
+    ]
+  },
+  "js/ActionBuildSystem.js": {
+    "md": 0,
+    "code": 1,
+    "terms": [
+      "start",
+      "overlay",
+      "fade"
+    ]
+  },
+  "js/Animation.js": {
+    "md": 0,
+    "code": 1,
+    "terms": [
+      "start",
+      "overlay",
+      "fade"
+    ]
+  },
+  "js/FileProvider.js": {
+    "md": 0,
+    "code": 1,
+    "terms": [
+      "start",
+      "overlay",
+      "fade"
+    ]
+  },
+  "js/Game.js": {
+    "md": 0,
+    "code": 1,
+    "terms": [
+      "start",
+      "overlay",
+      "fade"
     ]
   },
   "js/LogHandler.js": {
     "md": 0,
-    "code": 7,
+    "code": 1,
     "terms": [
-      "if",
-      "else",
-      "select",
-      "lemming"
+      "start",
+      "overlay",
+      "fade"
     ]
   },
-  "tools/archiveDir.js": {
+  "js/PackFilePart.js": {
     "md": 0,
-    "code": 3,
+    "code": 1,
     "terms": [
-      "if",
-      "else",
-      "spawn"
+      "start",
+      "overlay",
+      "fade"
     ]
   },
-  "js/GameSkills.js": {
+  "js/PaletteImage.js": {
     "md": 0,
-    "code": 9,
+    "code": 1,
     "terms": [
-      "if",
-      "else",
-      "selection",
-      "rect",
-      "select",
-      "lemming",
-      "cursor"
+      "start",
+      "overlay",
+      "fade"
     ]
   },
-  "js/GameVictoryCondition.js": {
-    "md": 0,
-    "code": 17,
-    "terms": [
-      "if",
-      "else",
-      "bench",
-      "select",
-      "lemming"
-    ]
-  },
-  "test/filecontainer.test.js": {
-    "md": 0,
-    "code": 7,
-    "terms": [
-      "if",
-      "else",
-      "select",
-      "lemming"
-    ]
-  },
-  "test/fileprovider.test.js": {
-    "md": 0,
-    "code": 7,
-    "terms": [
-      "if",
-      "else",
-      "select",
-      "lemming"
-    ]
-  },
-  "tools/exportAllPacks.js": {
-    "md": 0,
-    "code": 8,
-    "terms": [
-      "if",
-      "else",
-      "spawn",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/CommandSelectSkill.js": {
-    "md": 0,
-    "code": 9,
-    "terms": [
-      "if",
-      "else",
-      "selection",
-      "rect",
-      "select",
-      "lemming",
-      "cursor"
-    ]
-  },
-  "js/ConfigReader.js": {
-    "md": 0,
-    "code": 7,
-    "terms": [
-      "if",
-      "else",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/GameFactory.js": {
-    "md": 0,
-    "code": 7,
-    "terms": [
-      "if",
-      "else",
-      "select",
-      "lemming"
-    ]
-  },
-  "test/bitstream.test.js": {
-    "md": 0,
-    "code": 7,
-    "terms": [
-      "if",
-      "else",
-      "select",
-      "lemming"
-    ]
-  },
-  "test/nodefileprovider.test.js": {
-    "md": 0,
-    "code": 3,
-    "terms": [
-      "if",
-      "else",
-      "spawn"
-    ]
-  },
-  "js/ActionExitingSystem.js": {
-    "md": 0,
-    "code": 11,
-    "terms": [
-      "if",
-      "else",
-      "draw",
-      "corner",
-      "rect",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/ActionShrugSystem.js": {
-    "md": 0,
-    "code": 11,
-    "terms": [
-      "if",
-      "else",
-      "draw",
-      "corner",
-      "rect",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/CommandLemmingsAction.js": {
-    "md": 0,
-    "code": 9,
-    "terms": [
-      "if",
-      "else",
-      "selection",
-      "rect",
-      "select",
-      "lemming",
-      "cursor"
-    ]
-  },
-  "js/CommandNuke.js": {
-    "md": 0,
-    "code": 7,
-    "terms": [
-      "if",
-      "else",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/CommandReleaseRateDecrease.js": {
-    "md": 0,
-    "code": 7,
-    "terms": [
-      "if",
-      "else",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/CommandReleaseRateIncrease.js": {
-    "md": 0,
-    "code": 7,
-    "terms": [
-      "if",
-      "else",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/DrawProperties.js": {
-    "md": 0,
-    "code": 11,
-    "terms": [
-      "if",
-      "else",
-      "draw",
-      "corner",
-      "rect",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/EventHandler.js": {
-    "md": 0,
-    "code": 7,
-    "terms": [
-      "if",
-      "else",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/GameResources.js": {
-    "md": 0,
-    "code": 8,
-    "terms": [
-      "if",
-      "else",
-      "select",
-      "lemming",
-      "cursor"
-    ]
-  },
-  "js/GameTypes.js": {
-    "md": 0,
-    "code": 7,
-    "terms": [
-      "if",
-      "else",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/LemmingsNamespace.js": {
-    "md": 0,
-    "code": 7,
-    "terms": [
-      "if",
-      "else",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/LevelConfig.js": {
-    "md": 0,
-    "code": 7,
-    "terms": [
-      "if",
-      "else",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/LevelIndexResolve.js": {
-    "md": 0,
-    "code": 7,
-    "terms": [
-      "if",
-      "else",
-      "select",
-      "lemming"
-    ]
-  },
-  "js/OddTableReader.js": {
-    "md": 0,
-    "code": 7,
-    "terms": [
-      "if",
-      "else",
-      "select",
-      "lemming"
-    ]
-  },
-  "test/gameskills.test.js": {
-    "md": 0,
-    "code": 9,
-    "terms": [
-      "if",
-      "else",
-      "selection",
-      "rect",
-      "select",
-      "lemming",
-      "cursor"
-    ]
-  },
-  "test/gamevictory.test.js": {
-    "md": 0,
-    "code": 7,
-    "terms": [
-      "if",
-      "else",
-      "select",
-      "lemming"
-    ]
-  },
-  "test/tools/archiveDir.test.js": {
-    "md": 0,
-    "code": 3,
-    "terms": [
-      "if",
-      "else",
-      "spawn"
-    ]
-  },
-  "test/tools/exportGroundImages.test.js": {
-    "md": 0,
-    "code": 11,
-    "terms": [
-      "if",
-      "else",
-      "draw",
-      "corner",
-      "rect",
-      "select",
-      "lemming"
-    ]
-  },
-  "tools/cleanExports.js": {
+  "js/UserInputManager.js": {
     "md": 0,
     "code": 2,
     "terms": [
-      "if",
-      "else"
-    ]
-  },
-  "tools/packLevels.js": {
-    "md": 0,
-    "code": 2,
-    "terms": [
-      "if",
-      "else"
-    ]
-  },
-  ".agentInfo/notes/editor-mode.md": {
-    "md": 6,
-    "code": 0,
-    "terms": [
-      "spawn",
-      "select",
-      "lemming"
-    ]
-  },
-  ".agentInfo/notes/lemming-manager.md": {
-    "md": 8,
-    "code": 0,
-    "terms": [
-      "spawn",
-      "selection",
-      "rect",
-      "select",
-      "lemming",
-      "cursor"
-    ]
-  },
-  ".agentInfo/notes/overview.md": {
-    "md": 17,
-    "code": 0,
-    "terms": [
-      "spawn",
-      "bench",
-      "select",
-      "lemming",
-      "cursor"
-    ]
-  },
-  "test/check-undefined.test.js": {
-    "md": 0,
-    "code": 1,
-    "terms": [
-      "spawn"
-    ]
-  },
-  "test/listSprites.test.js": {
-    "md": 0,
-    "code": 7,
-    "terms": [
-      "spawn",
-      "line",
-      "select",
-      "lemming"
-    ]
-  },
-  "test/packLevels.test.js": {
-    "md": 0,
-    "code": 6,
-    "terms": [
-      "spawn",
-      "select",
-      "lemming"
-    ]
-  },
-  "test/tools/cleanExports.test.js": {
-    "md": 0,
-    "code": 1,
-    "terms": [
-      "spawn"
-    ]
-  },
-  "test/tools/exportAllPacks.test.js": {
-    "md": 0,
-    "code": 1,
-    "terms": [
-      "spawn"
-    ]
-  },
-  "test/tools/listSprites.test.js": {
-    "md": 0,
-    "code": 7,
-    "terms": [
-      "spawn",
-      "line",
-      "select",
-      "lemming"
-    ]
-  },
-  "test/tools/packLevels.test.js": {
-    "md": 0,
-    "code": 6,
-    "terms": [
-      "spawn",
-      "select",
-      "lemming"
-    ]
-  },
-  ".agentInfo/notes/bench-mode-docs.md": {
-    "md": 11,
-    "code": 0,
-    "terms": [
-      "bench",
-      "scale",
-      "nearest"
-    ]
-  },
-  ".agentInfo/notes/bench-speed-adjust.md": {
-    "md": 11,
-    "code": 0,
-    "terms": [
-      "bench",
-      "scale",
-      "nearest"
-    ]
-  },
-  ".agentInfo/notes/norm-tick-count-removal.md": {
-    "md": 10,
-    "code": 0,
-    "terms": [
-      "bench"
-    ]
-  },
-  ".agentInfo/notes/test-bench-speed-adjust.md": {
-    "md": 10,
-    "code": 0,
-    "terms": [
-      "bench"
-    ]
-  },
-  ".agentInfo/notes/test-coverage.md": {
-    "md": 10,
-    "code": 0,
-    "terms": [
-      "bench"
-    ]
-  },
-  "CHANGELOG.md": {
-    "md": 17,
-    "code": 0,
-    "terms": [
-      "bench",
-      "selection",
-      "rect",
-      "select",
-      "lemming",
-      "cursor"
-    ]
-  },
-  ".agentInfo/notes/webmidi-overview.md": {
-    "md": 6,
-    "code": 0,
-    "terms": [
-      "line",
-      "select",
-      "lemming"
-    ]
-  },
-  ".agentInfo/notes/todo-review.md": {
-    "md": 1,
-    "code": 0,
-    "terms": [
-      "line"
-    ]
-  },
-  ".agentInfo/notes/tools.md": {
-    "md": 7,
-    "code": 0,
-    "terms": [
-      "line",
-      "select",
-      "lemming",
-      "cursor"
-    ]
-  },
-  ".agentInfo/notes/webmidi-tasks.md": {
-    "md": 1,
-    "code": 0,
-    "terms": [
-      "line"
-    ]
-  },
-  "js/xbrz/scalers/Scaler2x.js": {
-    "md": 0,
-    "code": 6,
-    "terms": [
-      "line",
-      "draw",
-      "corner",
-      "rect",
-      "scale",
-      "nearest"
-    ]
-  },
-  "js/xbrz/scalers/Scaler3x.js": {
-    "md": 0,
-    "code": 6,
-    "terms": [
-      "line",
-      "draw",
-      "corner",
-      "rect",
-      "scale",
-      "nearest"
-    ]
-  },
-  "js/xbrz/scalers/Scaler4x.js": {
-    "md": 0,
-    "code": 6,
-    "terms": [
-      "line",
-      "draw",
-      "corner",
-      "rect",
-      "scale",
-      "nearest"
-    ]
-  },
-  ".agentInfo/notes/game.md": {
-    "md": 7,
-    "code": 0,
-    "terms": [
-      "selection",
-      "rect",
-      "select",
-      "lemming",
-      "cursor"
-    ]
-  },
-  "docs/levelpacks.md": {
-    "md": 6,
-    "code": 0,
-    "terms": [
-      "selection",
-      "rect",
-      "select",
-      "lemming",
-      "cursor"
-    ]
-  },
-  "test/keyboardshortcuts.test.js": {
-    "md": 0,
-    "code": 11,
-    "terms": [
-      "selection",
-      "rect",
-      "draw",
-      "corner",
-      "select",
-      "lemming",
-      "cursor"
-    ]
-  },
-  "css/game.css": {
-    "md": 0,
-    "code": 6,
-    "terms": [
-      "selection",
-      "rect",
-      "select",
-      "lemming",
-      "cursor"
-    ]
-  },
-  "js/LemmingsBootstrap.js": {
-    "md": 0,
-    "code": 11,
-    "terms": [
-      "selection",
-      "rect",
-      "draw",
-      "corner",
-      "select",
-      "lemming",
-      "cursor"
-    ]
-  },
-  "test/commandselectskill.test.js": {
-    "md": 0,
-    "code": 7,
-    "terms": [
-      "selection",
-      "rect",
-      "select",
-      "lemming",
-      "cursor"
-    ]
-  },
-  ".agentInfo/notes/ground-renderer.md": {
-    "md": 4,
-    "code": 0,
-    "terms": [
-      "draw",
-      "corner",
+      "start",
+      "overlay",
+      "fade",
       "rect"
     ]
   },
-  ".agentInfo/notes/stage.md": {
-    "md": 5,
-    "code": 0,
-    "terms": [
-      "draw",
-      "corner",
-      "rect",
-      "scale",
-      "nearest"
-    ]
-  },
-  "test/exportLemmingsSprites.test.js": {
+  "js/VGASpecReader.js": {
     "md": 0,
-    "code": 9,
+    "code": 1,
     "terms": [
-      "draw",
-      "corner",
-      "rect",
-      "select",
-      "lemming"
+      "start",
+      "overlay",
+      "fade"
     ]
   },
-  "test/frame.test.js": {
+  "test/processHtmlFile.test.js": {
     "md": 0,
-    "code": 9,
+    "code": 1,
     "terms": [
-      "draw",
-      "corner",
-      "rect",
-      "select",
-      "lemming"
+      "start",
+      "overlay",
+      "fade"
     ]
   },
-  "test/gameresources.test.js": {
+  "tools/check-undefined.js": {
     "md": 0,
-    "code": 10,
+    "code": 1,
     "terms": [
-      "draw",
-      "corner",
-      "rect",
-      "select",
-      "lemming",
-      "cursor"
+      "start",
+      "overlay",
+      "fade"
     ]
   },
-  "test/levelreader.test.js": {
+  "tools/patchSprites.js": {
     "md": 0,
-    "code": 9,
+    "code": 1,
     "terms": [
-      "draw",
-      "corner",
-      "rect",
-      "select",
-      "lemming"
+      "start",
+      "overlay",
+      "fade"
     ]
   },
-  "test/tools/exportAllSprites.test.js": {
+  "tools/processHtmlFile.js": {
     "md": 0,
-    "code": 9,
+    "code": 1,
     "terms": [
-      "draw",
-      "corner",
-      "rect",
-      "select",
-      "lemming"
+      "start",
+      "overlay",
+      "fade"
     ]
   },
-  ".agentInfo/notes/bit-writer.md": {
-    "md": 5,
-    "code": 0,
-    "terms": [
-      "select",
-      "lemming"
-    ]
-  },
-  ".agentInfo/notes/game-resources.md": {
-    "md": 6,
-    "code": 0,
-    "terms": [
-      "select",
-      "lemming",
-      "cursor"
-    ]
-  },
-  ".agentInfo/notes/level-format.md": {
-    "md": 5,
-    "code": 0,
-    "terms": [
-      "select",
-      "lemming"
-    ]
-  },
-  ".agentInfo/notes/mechanics-flags.md": {
-    "md": 5,
-    "code": 0,
-    "terms": [
-      "select",
-      "lemming"
-    ]
-  },
-  ".agentInfo/notes/nl-objects.md": {
-    "md": 5,
-    "code": 0,
-    "terms": [
-      "select",
-      "lemming"
-    ]
-  },
-  "docs/exporting-sprites.md": {
-    "md": 5,
-    "code": 0,
-    "terms": [
-      "select",
-      "lemming"
-    ]
-  },
-  "docs/TESTING.md": {
-    "md": 5,
-    "code": 0,
-    "terms": [
-      "select",
-      "lemming"
-    ]
-  },
-  "test/patchSprites.test.js": {
+  "js/TriggerManager.js": {
     "md": 0,
-    "code": 5,
+    "code": 2,
     "terms": [
-      "select",
-      "lemming"
+      "start",
+      "overlay",
+      "fade",
+      "rect"
     ]
   },
-  "test/skillpanelsprites.test.js": {
-    "md": 0,
-    "code": 5,
-    "terms": [
-      "select",
-      "lemming"
-    ]
-  },
-  "config.json": {
-    "md": 0,
-    "code": 5,
-    "terms": [
-      "select",
-      "lemming"
-    ]
-  },
-  "eslint.config.js": {
-    "md": 0,
-    "code": 5,
-    "terms": [
-      "select",
-      "lemming"
-    ]
-  },
-  "js/BaseImageInfo.js": {
-    "md": 0,
-    "code": 5,
-    "terms": [
-      "select",
-      "lemming"
-    ]
-  },
-  "js/ColorPalette.js": {
-    "md": 0,
-    "code": 5,
-    "terms": [
-      "select",
-      "lemming"
-    ]
-  },
-  "js/GameConfig.js": {
-    "md": 0,
-    "code": 5,
-    "terms": [
-      "select",
-      "lemming"
-    ]
-  },
-  "js/GameResult.js": {
-    "md": 0,
-    "code": 5,
-    "terms": [
-      "select",
-      "lemming"
-    ]
-  },
-  "js/GameStateTypes.js": {
-    "md": 0,
-    "code": 5,
-    "terms": [
-      "select",
-      "lemming"
-    ]
-  },
-  "js/LemmingStateType.js": {
-    "md": 0,
-    "code": 5,
-    "terms": [
-      "select",
-      "lemming"
-    ]
-  },
-  "js/LevelIndexType.js": {
-    "md": 0,
-    "code": 5,
-    "terms": [
-      "select",
-      "lemming"
-    ]
-  },
-  "js/LevelProperties.js": {
-    "md": 0,
-    "code": 5,
-    "terms": [
-      "select",
-      "lemming"
-    ]
-  },
-  "js/MaskProvider.js": {
-    "md": 0,
-    "code": 5,
-    "terms": [
-      "select",
-      "lemming"
-    ]
-  },
-  "js/MaskTypes.js": {
-    "md": 0,
-    "code": 5,
-    "terms": [
-      "select",
-      "lemming"
-    ]
-  },
-  "js/ObjectImageInfo.js": {
-    "md": 0,
-    "code": 5,
-    "terms": [
-      "select",
-      "lemming"
-    ]
-  },
-  "js/packMechanics.js": {
-    "md": 0,
-    "code": 5,
-    "terms": [
-      "select",
-      "lemming"
-    ]
-  },
-  "js/SkillTypes.js": {
-    "md": 0,
-    "code": 5,
-    "terms": [
-      "select",
-      "lemming"
-    ]
-  },
-  "js/SpriteTypes.js": {
-    "md": 0,
-    "code": 5,
-    "terms": [
-      "select",
-      "lemming"
-    ]
-  },
-  "js/steelSprites.json": {
-    "md": 0,
-    "code": 5,
-    "terms": [
-      "select",
-      "lemming"
-    ]
-  },
-  "js/TerrainImageInfo.js": {
-    "md": 0,
-    "code": 5,
-    "terms": [
-      "select",
-      "lemming"
-    ]
-  },
-  "js/TriggerTypes.js": {
-    "md": 0,
-    "code": 5,
-    "terms": [
-      "select",
-      "lemming"
-    ]
-  },
-  "test/animation.test.js": {
-    "md": 0,
-    "code": 5,
-    "terms": [
-      "select",
-      "lemming"
-    ]
-  },
-  "test/binaryreader.test.js": {
-    "md": 0,
-    "code": 5,
-    "terms": [
-      "select",
-      "lemming"
-    ]
-  },
-  "test/bitreader.test.js": {
-    "md": 0,
-    "code": 5,
-    "terms": [
-      "select",
-      "lemming"
-    ]
-  },
-  "test/bitwriter.test.js": {
-    "md": 0,
-    "code": 5,
-    "terms": [
-      "select",
-      "lemming"
-    ]
-  },
-  "test/colorpalette.test.js": {
-    "md": 0,
-    "code": 5,
-    "terms": [
-      "select",
-      "lemming"
-    ]
-  },
-  "test/configreader.test.js": {
-    "md": 0,
-    "code": 5,
-    "terms": [
-      "select",
-      "lemming"
-    ]
-  },
-  "test/eventhandler.test.js": {
-    "md": 0,
-    "code": 5,
-    "terms": [
-      "select",
-      "lemming"
-    ]
-  },
-  "test/filecontainer-errors.test.js": {
-    "md": 0,
-    "code": 5,
-    "terms": [
-      "select",
-      "lemming"
-    ]
-  },
-  "test/game.queuecommand.test.js": {
-    "md": 0,
-    "code": 5,
-    "terms": [
-      "select",
-      "lemming"
-    ]
-  },
-  "test/gamefactory.test.js": {
-    "md": 0,
-    "code": 5,
-    "terms": [
-      "select",
-      "lemming"
-    ]
-  },
-  "test/gameresult.test.js": {
-    "md": 0,
-    "code": 5,
-    "terms": [
-      "select",
-      "lemming"
-    ]
-  },
-  "test/groundreader.test.js": {
-    "md": 0,
-    "code": 5,
-    "terms": [
-      "select",
-      "lemming"
-    ]
-  },
-  "test/levelloader.test.js": {
-    "md": 0,
-    "code": 5,
-    "terms": [
-      "select",
-      "lemming"
-    ]
-  },
-  "test/maskprovider.test.js": {
-    "md": 0,
-    "code": 5,
-    "terms": [
-      "select",
-      "lemming"
-    ]
-  },
-  "test/packfilepart.test.js": {
-    "md": 0,
-    "code": 5,
-    "terms": [
-      "select",
-      "lemming"
-    ]
-  },
-  "test/tools/exportScripts.test.js": {
-    "md": 0,
-    "code": 6,
-    "terms": [
-      "select",
-      "lemming",
-      "cursor"
-    ]
-  },
-  "test/tools/patchSprites.test.js": {
-    "md": 0,
-    "code": 5,
-    "terms": [
-      "select",
-      "lemming"
-    ]
-  },
-  "test/unpackfilepart.test.js": {
-    "md": 0,
-    "code": 5,
-    "terms": [
-      "select",
-      "lemming"
-    ]
-  },
-  ".agentInfo/notes/userinput-zoom.md": {
+  ".agentInfo/notes/display-image.md": {
     "md": 1,
     "code": 0,
     "terms": [
-      "select",
-      "cursor"
+      "overlay",
+      "rect"
     ]
   },
-  ".agentInfo/notes/userinput-zoom.md": {
+  ".agentInfo/notes/draw-corner-rect.md": {
     "md": 1,
     "code": 0,
     "terms": [
-      "scale",
-      "nearest"
+      "overlay",
+      "rect"
     ]
   },
-  ".agentInfo/notes/game-speed-input.md": {
-    "md": 2,
+  ".agentInfo/notes/drawMarchingAntRect.md": {
+    "md": 1,
     "code": 0,
     "terms": [
-      "scale",
-      "nearest"
+      "overlay",
+      "rect"
+    ]
+  },
+  ".agentInfo/notes/game-display.md": {
+    "md": 1,
+    "code": 0,
+    "terms": [
+      "overlay",
+      "rect"
+    ]
+  },
+  "js/DisplayImage.js": {
+    "md": 0,
+    "code": 1,
+    "terms": [
+      "overlay",
+      "rect"
+    ]
+  },
+  "js/GameGui.js": {
+    "md": 0,
+    "code": 1,
+    "terms": [
+      "overlay",
+      "rect"
+    ]
+  },
+  "test/userinput.test.js": {
+    "md": 0,
+    "code": 1,
+    "terms": [
+      "overlay",
+      "rect"
+    ]
+  },
+  "js/Frame.js": {
+    "md": 0,
+    "code": 1,
+    "terms": [
+      "overlay",
+      "rect"
+    ]
+  },
+  "js/GameDisplay.js": {
+    "md": 0,
+    "code": 1,
+    "terms": [
+      "overlay",
+      "rect"
+    ]
+  },
+  "js/MiniMap.js": {
+    "md": 0,
+    "code": 1,
+    "terms": [
+      "overlay",
+      "rect"
+    ]
+  },
+  "js/Trigger.js": {
+    "md": 0,
+    "code": 1,
+    "terms": [
+      "overlay",
+      "rect"
+    ]
+  },
+  "test/displayimage.test.js": {
+    "md": 0,
+    "code": 1,
+    "terms": [
+      "overlay",
+      "rect"
+    ]
+  },
+  "test/geometry.test.js": {
+    "md": 0,
+    "code": 1,
+    "terms": [
+      "overlay",
+      "rect"
+    ]
+  },
+  "test/minimap.test.js": {
+    "md": 0,
+    "code": 1,
+    "terms": [
+      "overlay",
+      "rect"
+    ]
+  },
+  "test/rectangle.test.js": {
+    "md": 0,
+    "code": 1,
+    "terms": [
+      "overlay",
+      "rect"
+    ]
+  },
+  "test/stage.test.js": {
+    "md": 0,
+    "code": 1,
+    "terms": [
+      "overlay",
+      "rect"
+    ]
+  },
+  "test/stage.updateStageSize.test.js": {
+    "md": 0,
+    "code": 1,
+    "terms": [
+      "overlay",
+      "rect"
+    ]
+  },
+  "test/stage.updateviewpoint.test.js": {
+    "md": 0,
+    "code": 1,
+    "terms": [
+      "overlay",
+      "rect"
+    ]
+  },
+  "test/stageimageprops.test.js": {
+    "md": 0,
+    "code": 1,
+    "terms": [
+      "overlay",
+      "rect"
+    ]
+  },
+  "test/trigger.test.js": {
+    "md": 0,
+    "code": 1,
+    "terms": [
+      "overlay",
+      "rect"
+    ]
+  },
+  "test/triggermanager.test.js": {
+    "md": 0,
+    "code": 1,
+    "terms": [
+      "overlay",
+      "rect"
     ]
   }
 }

--- a/js/Stage.js
+++ b/js/Stage.js
@@ -463,7 +463,9 @@ class Stage {
       if (this.overlayAlpha <= 0) {
         clearInterval(this.overlayTimer);
         this.overlayTimer = 0;
-        this.overlayRect = null;
+        setTimeout(() => {
+          if (!this.overlayTimer) this.overlayRect = null;
+        }, 0);
       }
     }, 40);
   }

--- a/test/stage.overlayfade.test.js
+++ b/test/stage.overlayfade.test.js
@@ -90,4 +90,23 @@ describe('Stage overlay fade', function() {
     const match = rectCalls.some(r => r.x === rect.x && r.y === rect.y && r.w === rect.width && r.h === rect.height);
     expect(match).to.equal(true);
   });
+
+  it('retains overlayRect until fade completes', function() {
+    const canvas = createStubCanvas();
+    const stage = new Stage(canvas);
+    stage.clear = () => {};
+
+    const rect = { x: 1, y: 2, width: 3, height: 4 };
+    stage.startOverlayFade('blue', rect);
+
+    clock.tick(500);
+    expect(stage.overlayRect).to.equal(rect);
+
+    clock.tick(1500); // finish fade
+    expect(stage.overlayTimer).to.equal(0);
+    expect(stage.overlayRect).to.equal(rect);
+
+    clock.tick(1); // allow cleanup timeout
+    expect(stage.overlayRect).to.equal(null);
+  });
 });


### PR DESCRIPTION
## Summary
- keep `overlayRect` during fade animation
- test overlay rect retention until fade completes
- record search usage

## Testing
- `npm test` *(fails: Stage pointer events, Stage.updateStageSize, Stage updateViewPoint, tools/exportGroundImages.js with mock NodeFileProvider, UserInputManager)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6842e9f648e8832d9a03476914942754