### PR TITLE
Implement custom crosshair cursor

### DIFF
--- a/css/game.css
+++ b/css/game.css
@@ -16,7 +16,7 @@ body * {
     overflow: hidden;
 }
 .gameCanvas {
-    /* cursor: none; keep the system cursor */
+    cursor: none;
 }
 
 @media (orientation: landscape) {

--- a/js/CrosshairCursor.js
+++ b/js/CrosshairCursor.js
@@ -1,0 +1,22 @@
+import { Lemmings } from './LemmingsNamespace.js';
+
+function createCrosshairFrame(size = 24) {
+  const frame = new Lemmings.Frame(size, size);
+  const center = Math.floor(size / 2);
+  const cw = Lemmings.ColorPalette.colorFromRGB(144, 238, 144); // light green
+  const ccw = Lemmings.ColorPalette.colorFromRGB(255, 255, 255); // white
+
+  for (let y = 0; y < size; y++) {
+    frame.setPixel(center, y, cw);
+    frame.setPixel(center - 1, y, ccw);
+  }
+
+  for (let x = 0; x < size; x++) {
+    frame.setPixel(x, center, cw);
+    frame.setPixel(x, center - 1, ccw);
+  }
+
+  return frame;
+}
+Lemmings.createCrosshairFrame = createCrosshairFrame;
+export { createCrosshairFrame };

--- a/js/GameView.js
+++ b/js/GameView.js
@@ -1,6 +1,7 @@
 import { Lemmings } from './LemmingsNamespace.js';
 import './LogHandler.js';
 import './KeyboardShortcuts.js';
+import { createCrosshairFrame } from './CrosshairCursor.js';
 
 class GameView extends Lemmings.BaseLogger {
   constructor() {
@@ -57,9 +58,8 @@ class GameView extends Lemmings.BaseLogger {
       game.setGameDisplay(this.stage.getGameDisplay());
       game.setGuiDisplay(this.stage.getGuiDisplay());
       game.getGameTimer().speedFactor = this.gameSpeedFactor;
-      // The stage previously set a custom cursor sprite here, but we now keep
-      // the system cursor visible so no sprite is loaded.
-      // game.gameResources.getCursorSprite().then(f => this.stage.setCursorSprite(f));
+      // Display a custom crosshair cursor sized relative to a lemming
+      this.stage.setCursorSprite(createCrosshairFrame(24));
       game.start();
       this.changeHtmlText(this.elementGameState, Lemmings.GameStateTypes.toString(Lemmings.GameStateTypes.RUNNING));
       game.onGameEnd.on(state => this.onGameEnd(state));


### PR DESCRIPTION
## Summary
- hide system cursor via CSS
- draw a custom crosshair cursor with white/green bevel
- show crosshair when game starts

## Testing
- `npm run format`
- `npm test` *(fails: AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_68429d2703ec832d9ed6cccbd9ca468d