### PR TITLE
Update Node.js 20 references

### DIFF
--- a/.agentInfo/notes/overview.md
+++ b/.agentInfo/notes/overview.md
@@ -17,7 +17,7 @@ Browser modules live under `js/` and Node tools under `tools/`.
 - Notes for agents live in `.agentInfo/` (see `index.md`).
 
 ## Development workflow
-- Requires Node 16+ (`package.json` uses ES modules). CI tests on Node 18.
+- Requires Node 20+ (`package.json` uses ES modules). CI tests on Node 20.
 - `npm install` brings in ESLint and Mocha.
 - Run `npm run format` then `npm run lint` and `npm test` before commits.
 - `npm start` launches `http-server` for local play.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4.2.2
       - uses: actions/setup-node@v4.2.0
         with:
-          node-version: 18
+          node-version: 20
           cache: npm
           cache-dependency-path: package-lock.json
       - run: npm ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   upper-left corner.
 
 ### Changed
-- Project now requires Node.js 16+ (tests use Node 18 in CI).
+- Project now requires Node.js 20+ (tests use Node 20 in CI).
 - `patchSprites.js` can slice sprite sheets using `--sheet-orientation`.
 - `packLevels.js` creates DAT archives from 2048-byte level files.
 - These tools rely on `NodeFileProvider` to read packs from folders or archives.

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ The goal is to create a solid, performant port first. Then build out the sequenc
 
 ## Play Locally
 
-- Install [Node.js 16 or later](https://nodejs.org)
+- Install [Node.js 20 or later](https://nodejs.org)
 - Clone: `git clone https://github.com/doublemover/LemmingsJS-MIDI`
 - Terminal:
   - `npm install`

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -10,7 +10,7 @@ The command uses Mocha and is launched with Node's `--import` option so that `js
 
 ## npm test workflow
 
-Run `npm run check-undefined` manually before `npm test` to verify no uninitialized references remain in the build. GitHub Actions performs the same checks on **Node 18** during the CI job after running `npm run lint`.
+Run `npm run check-undefined` manually before `npm test` to verify no uninitialized references remain in the build. GitHub Actions performs the same checks on **Node 20** during the CI job after running `npm run lint`.
 
 To mirror the CI environment locally:
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -2,12 +2,12 @@
 
 This project uses GitHub Actions to run tests on every push and pull request targeting the `master` branch.
 
-The workflow is defined in [`.github/workflows/test.yml`](../.github/workflows/test.yml). Although the `package.json` requires Node 16 or newer, the workflow installs **Node 18**:
+The workflow is defined in [`.github/workflows/test.yml`](../.github/workflows/test.yml). Although the `package.json` requires Node 20 or newer, the workflow installs **Node 20**:
 
 ```yaml
 - uses: actions/setup-node@v4
   with:
-    node-version: 18
+    node-version: 20
 ```
 
 The CI job performs the following steps:


### PR DESCRIPTION
## Summary
- use Node 20 in GitHub Actions
- update docs to state Node 20 or later

## Testing
- `npm run lint` *(fails: Parsing error in Stage.js)*
- `npm test` *(fails: Identifier 'scale' has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_6842fdc49c10832dab2ad7524de0f2b1