### PR TITLE
Fix overlayRect timing

### DIFF
--- a/js/Stage.js
+++ b/js/Stage.js
@@ -526,9 +526,7 @@ class Stage {
       if (this.overlayAlpha <= 0) {
         clearInterval(this.overlayTimer);
         this.overlayTimer = 0;
-        setTimeout(() => {
-          if (!this.overlayTimer) this.overlayRect = null;
-        }, 0);
+        this.overlayRect = null;
       }
     }, 40);
   }

--- a/test/stage.overlayfade.test.js
+++ b/test/stage.overlayfade.test.js
@@ -104,9 +104,6 @@ describe('Stage overlay fade', function() {
 
     clock.tick(1500); // finish fade
     expect(stage.overlayTimer).to.equal(0);
-    expect(stage.overlayRect).to.equal(rect);
-
-    clock.tick(1); // allow cleanup timeout
     expect(stage.overlayRect).to.equal(null);
   });
 });


### PR DESCRIPTION
## Summary
- end overlayRect when the fade timer finishes
- update overlay fade test to match new behavior

## Testing
- `npm run format` *(fails: Parsing error: Identifier 'scale' has already been declared)*
- `npm test` *(fails: SyntaxError: Identifier 'scale' has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_6842ff4c7fcc832da769929e7b774699