### PR TITLE
Add coverage step to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,3 +22,8 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm test
+      - run: npm run coverage
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage


### PR DESCRIPTION
## Summary
- run `npm run coverage` in the workflow
- upload generated coverage reports using `actions/upload-artifact`

## Testing
- `npm test` *(fails: SyntaxError in displayimage.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_6842fca11674832da1e35e0eedbe2285