### PR TITLE
Update search metrics handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ node_modules/
 .jshintconfig
 .jshintignore
 exports/
+
+.searchMetrics/

--- a/tools/build_index.js
+++ b/tools/build_index.js
@@ -19,9 +19,9 @@ const CHUNK = +argv.chunk;
 const DIMS = +argv.dims;
 const ROOT = process.cwd();
 const SKIP_DIRS = new Set([
-  'node_modules','.git','dist','coverage','index-code','index-prose',
+  'node_modules', '.git', 'dist', 'coverage', 'index-code', 'index-prose',
   'lemmings', 'lemmings_all', 'lemmings_ohNo', 'holiday93', 'holiday94',
-  'xmas91', 'xmas92', 'img', '.github'
+  'xmas91', 'xmas92', 'img', '.github', '.searchMetrics'
 ]);
 
 
@@ -105,7 +105,6 @@ async function build(mode) {
     'wordInfo.json',
     'package.json',
     'package-lock.json',
-    '.searchMetrics',
     'searchHistory',
     '.gitignore',
     '.gitattributes',


### PR DESCRIPTION
## Summary
- ignore `.searchMetrics/`
- skip `.searchMetrics` as a directory in the index builder

## Testing
- `npm run format`
- `npm test` *(fails: `27 failing`)*

------
https://chatgpt.com/codex/tasks/task_e_6843198fed1c832db62d005dadcc18e7