### PR TITLE
Add automated bench sequence mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ URL parameters (shortcut in brackets):
 - `cheat (c)`: Enable cheat mode (infinite actions) (default: false)
 - `debug (dbg)`: Enable debug mode until the page is refreshed (default: false)
 - `bench (b)`: Enable bench mode, lemmings never stop spawning with smooth speed modulation. The overlay fades out automatically and the timer resumes afterward. Only the pause button flashes red/green via `suspendWithColor` during adjustments (default: false)
+- `benchSequence (bs)`: Run automated bench tests with 10, 5, 2 and 1 random entrances (default: false)
 - `endless (e)`: Disables time limit (default: false)
 - `nukeAfter (na)`: Automatically nukes after x*10 (default: 0)
 - `scale (sc)`: Adjusts starting zoom .0125-5 (default: 2)

--- a/js/GameTimer.js
+++ b/js/GameTimer.js
@@ -13,6 +13,8 @@ class GameTimer {
   #stableTicks;
   #catchupSlow;
   #visHandler;
+  benchStartupFrames = 0;
+  benchStableFactor = 1;
 
   constructor(level) {
     this.TIME_PER_FRAME_MS = 60;
@@ -47,6 +49,8 @@ class GameTimer {
     window.addEventListener('blur',  this.#visHandler, false);
     window.addEventListener('focus', this.#visHandler, false);
     this.#updateFrameTime();
+    this.benchStartupFrames = 0;
+    this.benchStableFactor = 1;
   }
 
   isRunning() { return this.#running; }
@@ -159,68 +163,53 @@ class GameTimer {
     lemmings.steps = steps;
     const oldSpeed = this.#speedFactor;
 
+    const mult = this.benchStartupFrames > 0 ? this.benchStableFactor : 1;
     const slowThreshold = Math.max(10, 16 / this.#speedFactor);
     const recoverThreshold = Math.max(4, 4 / this.#speedFactor);
 
-    if (steps > 100) {
-      this.suspend();
-      this.#stableTicks = 0;
-      this.#speedFactor = 0.1;
-    } else if (steps > slowThreshold) {
-      this.#stableTicks = 0;
-      const sf = this.#speedFactor;
-      if (sf > 60) {
-        this.#speedFactor = 60;
-      }
-      else if (sf > 40) {
-        this.#speedFactor -= 10;
-      }
-      else if (sf > 10) {
-        this.#speedFactor -= 9;
-      }
-      else if (sf <= 10 && sf > 1) {
-        this.#speedFactor -= 1;
-      }
-      else if (sf <= 1 && sf > 0.2) {
-        this.#speedFactor = ((this.#speedFactor * 10) - 1) / 10;
-      }
+    if (steps > recoverThreshold) this.#stableTicks -= 32;
+    if (steps <= recoverThreshold / 2) this.#stableTicks += 1;
+
+    if (this.benchStartupFrames > 0) {
+      this.benchStartupFrames -= steps;
     }
 
-    if (steps > recoverThreshold) {
-      this.#stableTicks -= 32;
-    }
+    if (this.benchStartupFrames <= 0) {
+      if (steps > 100) {
+        this.suspend();
+        this.#stableTicks = 0;
+        this.#speedFactor = 0.1;
+      } else if (steps > slowThreshold) {
+        this.#stableTicks = 0;
+        const sf = this.#speedFactor;
+        if (sf > 60) this.#speedFactor = 60;
+        else if (sf > 40) this.#speedFactor -= 10;
+        else if (sf > 10) this.#speedFactor -= 9;
+        else if (sf <= 10 && sf > 1) this.#speedFactor -= 1;
+        else if (sf <= 1 && sf > 0.2) this.#speedFactor = ((this.#speedFactor * 10) - 1) / 10;
+      }
 
-    if (steps <= recoverThreshold / 2) {
-      this.#stableTicks += 1;
-    }
-
-    if (this.#stableTicks > 32 && this.#speedFactor < 60) {
-      this.#stableTicks = 0;
-      this.#speedFactor += 1;
-    }
-    if (this.#stableTicks > 2 && this.#speedFactor < 1) {
-      this.#stableTicks = 0;
-      this.#speedFactor = ((this.#speedFactor * 10) + 1) / 10;
+      if (this.#stableTicks > 32 * mult && this.#speedFactor < 60) {
+        this.#stableTicks = 0;
+        this.#speedFactor += 1;
+      }
+      if (this.#stableTicks > 2 * mult && this.#speedFactor < 1) {
+        this.#stableTicks = 0;
+        this.#speedFactor = ((this.#speedFactor * 10) + 1) / 10;
+      }
     }
 
     const diff = this.#speedFactor - oldSpeed;
     if (diff !== 0) {
       const intensity = Math.min(Math.abs(diff) / 5, 1);
-      const color = diff > 0
-        ? `rgba(0,255,0,${intensity})`
-        : `rgba(255,0,0,${intensity})`;
+      const color = diff > 0 ? `rgba(0,255,0,${intensity})` : `rgba(255,0,0,${intensity})`;
       const stage = lemmings?.stage;
       if (stage?.startOverlayFade) {
         let rect = null;
         if (lemmings.bench) {
           const gui = stage.guiImgProps;
           const scale = gui.viewPoint.scale;
-          rect = {
-            x: gui.x + 160 * scale,
-            y: gui.y + 32 * scale,
-            width: 16 * scale,
-            height: 10 * scale
-          };
+          rect = { x: gui.x + 160 * scale, y: gui.y + 32 * scale, width: 16 * scale, height: 10 * scale };
         }
         stage.startOverlayFade(color, rect);
       }

--- a/js/Stage.js
+++ b/js/Stage.js
@@ -167,6 +167,9 @@ class Stage {
   updateViewPoint(stageImage, argX, argY, deltaZoom, veloUpdate = false) {
     if (!stageImage || !stageImage.display) return;
 
+    const worldW = stageImage.display.getWidth ? stageImage.display.getWidth() : stageImage.width;
+    const worldH = stageImage.display.getHeight ? stageImage.display.getHeight() : stageImage.height;
+
     // ZOOM
     if (deltaZoom !== 0) {
       const oldScale = stageImage.viewPoint.scale || 1;

--- a/test/bench-sequence.test.js
+++ b/test/bench-sequence.test.js
@@ -1,0 +1,94 @@
+import { expect } from 'chai';
+import { Lemmings } from '../js/LemmingsNamespace.js';
+import '../js/EventHandler.js';
+import { GameTimer } from '../js/GameTimer.js';
+import fakeTimers from '@sinonjs/fake-timers';
+
+class KeyboardShortcutsMock { constructor() {} dispose() {} }
+class StageMock {
+  constructor() { this.guiImgProps = { x:0, y:0, viewPoint:{ scale:1 }}; }
+  getGameDisplay() { return {}; }
+  getGuiDisplay() { return {}; }
+  setCursorSprite() {}
+  updateStageSize() {}
+  clear() {}
+  startFadeOut() {}
+  startOverlayFade() {}
+}
+
+class GameMock {
+  constructor() {
+    this.timer = new GameTimer({ timeLimit: 1 });
+    this.lemmingManager = { spawnCount:0, getLemmings: () => new Array(this.lemmingManager.spawnCount) };
+    this.level = { width:100, height:50, entrances:[], screenPositionX:0, render(){} };
+    this.onGameEnd = new Lemmings.EventHandler();
+  }
+  async loadLevel() {}
+  setGameDisplay() {}
+  setGuiDisplay() {}
+  start() { this.timer.continue(); }
+  getCommandManager() { return { loadReplay(){} }; }
+  getGameTimer() { return this.timer; }
+  getLemmingManager() { return this.lemmingManager; }
+}
+
+class GameResourcesMock {
+  async getLevel() { return { width:100, height:50, screenPositionX:0, entrances:[], render(){}}; }
+  getLevelGroups() { return [0]; }
+}
+
+class GameFactoryMock {
+  async getGame() { return new GameMock(); }
+  async getGameResources() { return new GameResourcesMock(); }
+  get configReader() { return { configs: Promise.resolve([{ name:'test', gametype:1 }]) }; }
+}
+
+describe('bench sequence', function() {
+  let clock;
+  let origStage, origKeyboard, origFactory;
+  before(function() {
+    global.window = { location:{ search:'' }, setTimeout, clearTimeout, addEventListener() {}, removeEventListener() {} };
+    origStage = Lemmings.Stage;
+    origKeyboard = Lemmings.KeyboardShortcuts;
+    origFactory = Lemmings.GameFactory;
+    Lemmings.Stage = StageMock;
+    Lemmings.KeyboardShortcuts = KeyboardShortcutsMock;
+    Lemmings.GameFactory = GameFactoryMock;
+    Lemmings.GameTypes = { toString: () => '' };
+    Lemmings.GameStateTypes = { toString: () => '' };
+    global.lemmings = { game: { showDebug: false } };
+  });
+  beforeEach(function(){ clock = fakeTimers.withGlobal(globalThis).install({ now:0 }); });
+  afterEach(function(){ clock.uninstall(); });
+  after(function(){
+    delete global.window;
+    Lemmings.Stage = origStage;
+    Lemmings.KeyboardShortcuts = origKeyboard;
+    Lemmings.GameFactory = origFactory;
+  });
+
+  it('pauses and logs before restarting', async function() {
+    const { GameView } = await import('../js/GameView.js');
+    const view = new GameView();
+    view.gameCanvas = {};
+    view.benchSequence = true;
+    const logs = [];
+    const orig = console.log; console.log = m => logs.push(m);
+    await view.setup();
+
+    let timer = view.game.getGameTimer();
+    expect(timer.speedFactor).to.equal(6);
+    timer.speedFactor = 0.9;
+    timer.eachGameSecond.trigger();
+    await Promise.resolve();
+
+    expect(logs[0]).to.equal(10);
+    timer = view.game.getGameTimer();
+    timer.speedFactor = 0.9;
+    timer.eachGameSecond.trigger();
+    await Promise.resolve();
+    expect(logs[1]).to.equal(5);
+
+    console.log = orig;
+  });
+});


### PR DESCRIPTION
## Summary
- add benchSequence flag and helper methods
- support bench startup frames in GameTimer
- document benchSequence URL parameter
- provide integration test for bench sequence

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: ENOENT terrain_9_0.png)*

------
https://chatgpt.com/codex/tasks/task_e_684325fcd4dc832d94de1bb728fc3b9b