### PR TITLE
Add bench mode game over bypass

### DIFF
--- a/js/Game.js
+++ b/js/Game.js
@@ -152,6 +152,9 @@ class Game extends Lemmings.BaseLogger {
   }
 
   getGameState () {
+    if (typeof lemmings !== 'undefined' && lemmings.bench) {
+      return Lemmings.GameStateTypes.RUNNING;
+    }
     if (this.finalGameState !== Lemmings.GameStateTypes.UNKNOWN) {
       return this.finalGameState;
     }
@@ -166,7 +169,7 @@ class Game extends Lemmings.BaseLogger {
       return won ? Lemmings.GameStateTypes.SUCCEEDED
         : Lemmings.GameStateTypes.FAILED_LESS_LEMMINGS;
     }
-    if (this.gameTimer?.getGameLeftTime() <= 0) {
+    if (!lemmings?.endless && this.gameTimer?.getGameLeftTime() <= 0) {
       return won ? Lemmings.GameStateTypes.SUCCEEDED
         : Lemmings.GameStateTypes.FAILED_OUT_OF_TIME;
     }
@@ -174,6 +177,7 @@ class Game extends Lemmings.BaseLogger {
   }
 
   checkForGameOver () {
+    if (typeof lemmings !== 'undefined' && lemmings.bench) return;
     if (this.finalGameState !== Lemmings.GameStateTypes.UNKNOWN) return;
 
     const state = this.getGameState();

--- a/test/bench-no-end.test.js
+++ b/test/bench-no-end.test.js
@@ -1,0 +1,42 @@
+import { expect } from 'chai';
+import { Lemmings } from '../js/LemmingsNamespace.js';
+import '../js/EventHandler.js';
+import '../js/GameStateTypes.js';
+import { Game } from '../js/Game.js';
+import { GameVictoryCondition } from '../js/GameVictoryCondition.js';
+
+globalThis.lemmings = Lemmings;
+
+function makeGame() {
+  const level = {
+    releaseCount: 1,
+    needCount: 1,
+    releaseRate: 1,
+    timeLimit: 5,
+    triggers: [],
+    objects: [],
+    colorPalette: 0
+  };
+  const g = new Game({});
+  g.gameVictoryCondition = new GameVictoryCondition(level);
+  g.gameTimer = { getGameLeftTime() { return 60; } };
+  return g;
+}
+
+describe('bench mode game continues', function() {
+  beforeEach(function() {
+    lemmings.bench = true;
+    lemmings.endless = false;
+  });
+
+  it('returns RUNNING when all lemmings removed', function() {
+    const game = makeGame();
+    const vc = game.gameVictoryCondition;
+    vc.leftCount = 0;
+    vc.outCount = 0;
+    vc.survivorCount = 0;
+    expect(game.getGameState()).to.equal(Lemmings.GameStateTypes.RUNNING);
+    game.checkForGameOver();
+    expect(game.finalGameState).to.equal(Lemmings.GameStateTypes.UNKNOWN);
+  });
+});


### PR DESCRIPTION
## Summary
- prevent Game from ending when running in bench mode
- ignore time limit if endless mode is enabled
- add a regression test for bench mode game state

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: requestAnimationFrame/worldW not defined)*

------
https://chatgpt.com/codex/tasks/task_e_684325fc3de8832d843a4c0724bd7883