### PR TITLE
Fix redraw when moving cursor without drag

### DIFF
--- a/js/Stage.js
+++ b/js/Stage.js
@@ -129,7 +129,10 @@ class Stage {
         const localY = e.y - stageImage.y;
         const worldX = stageImage.viewPoint.getSceneX(localX);
         const worldY = stageImage.viewPoint.getSceneY(localY);
-        stageImage.display.onMouseMove.trigger(new Lemmings.Position2D(worldX, worldY));
+        stageImage.display.onMouseMove.trigger(
+          new Lemmings.Position2D(worldX, worldY)
+        );
+        this.redraw();
       }
     });
   }


### PR DESCRIPTION
## Summary
- refresh the stage when moving the cursor while no button is pressed

## Testing
- `npm test` *(fails: ReferenceError: worldW is not defined)*
- `npm run agent-precommit` *(fails: unable to parse .searchMetrics)*

------
https://chatgpt.com/codex/tasks/task_e_684320db99b4832da83d633bf6409af8