### PR TITLE
Add arrow key panning test

### DIFF
--- a/js/Stage.js
+++ b/js/Stage.js
@@ -210,6 +210,8 @@ class Stage {
     // argX,argY are deltaX,deltaY (screen pixels)
     const winW = stageImage.width;
     const winH = stageImage.height;
+    const worldW = stageImage.display.getWidth();
+    const worldH = stageImage.display.getHeight();
     const scale = stageImage.viewPoint.scale;
     const viewW_world = winW / scale;
     const viewH_world = winH / scale;

--- a/test/keyboardshortcuts.test.js
+++ b/test/keyboardshortcuts.test.js
@@ -3,10 +3,52 @@ import { Lemmings } from '../js/LemmingsNamespace.js';
 import { KeyboardShortcuts } from '../js/KeyboardShortcuts.js';
 import '../js/CommandSelectSkill.js';
 import '../js/CommandLemmingsAction.js';
+import '../js/EventHandler.js';
+import '../js/Position2D.js';
+import '../js/ViewPoint.js';
+import '../js/StageImageProperties.js';
+import '../js/DisplayImage.js';
+import '../js/UserInputManager.js';
+import { Stage } from '../js/Stage.js';
+import fakeTimers from '@sinonjs/fake-timers';
 
 globalThis.lemmings = { game: { showDebug: false } };
 
 describe('KeyboardShortcuts', function() {
+  function createStubCanvas(width = 800, height = 600) {
+    const ctx = {
+      canvas: { width, height },
+      fillRect() {},
+      drawImage() {},
+      putImageData() {}
+    };
+    return {
+      width,
+      height,
+      getContext() { return ctx; },
+      addEventListener() {},
+      removeEventListener() {}
+    };
+  }
+
+  function createDocumentStub() {
+    return {
+      createElement() {
+        const ctx = {
+          canvas: {},
+          fillRect() {},
+          drawImage() {},
+          putImageData() {},
+          createImageData(w, h) { return { width: w, height: h, data: new Uint8ClampedArray(w * h * 4) }; }
+        };
+        return {
+          width: 0,
+          height: 0,
+          getContext() { ctx.canvas = this; return ctx; }
+        };
+      }
+    };
+  }
   function createShortcuts(timer, manager, lemMgr = null) {
 
     const lm = lemMgr || { getSelectedLemming() { return { id: 1 }; }, setSelectedLemming() {} };
@@ -124,5 +166,54 @@ describe('KeyboardShortcuts', function() {
     const evt = { code: 'BracketLeft', shiftKey: false, ctrlKey: false, metaKey: false, preventDefault() {} };
     ks._onKeyDown(evt);
     expect(count).to.equal(-1);
+  });
+
+  it('pans right when ArrowRight held', function() {
+    global.document = createDocumentStub();
+    const canvas = createStubCanvas();
+    const stage = new Stage(canvas);
+    stage.clear = () => {};
+    stage.draw = () => {};
+    stage.redraw = () => {};
+    stage.updateViewPoint = (img, dx, dy) => {
+      img.viewPoint.x += dx / img.viewPoint.scale;
+      img.viewPoint.y += dy / img.viewPoint.scale;
+    };
+    stage.getGameDisplay().initSize(1000, 1000);
+
+    const timer = { speedFactor: 1, isRunning() { return true; } };
+    const game = {
+      commandManager: { queueCommand() {} },
+      gameGui: {},
+      getGameTimer() { return timer; },
+      queueCommand() {},
+      getGameSkills() { return { getSelectedSkill() { return Lemmings.SkillTypes.CLIMBER; }, setSelectedSkill() {} }; },
+      getLemmingManager() { return { getSelectedLemming() { return { id: 1 }; }, setSelectedLemming() {} }; }
+    };
+    let raf;
+    const win = globalThis;
+    const origRAF = win.requestAnimationFrame;
+    const origCancel = win.cancelAnimationFrame;
+    win.addEventListener = () => {};
+    win.removeEventListener = () => {};
+    win.requestAnimationFrame = (cb) => { raf = cb; return 1; };
+    win.cancelAnimationFrame = () => {};
+    global.window = win;
+    const view = { game, stage, nextFrame() {}, prevFrame() {} };
+    const clock = fakeTimers.withGlobal(globalThis).install({ now: 0 });
+
+    const ks = new KeyboardShortcuts(view);
+    const startX = stage.gameImgProps.viewPoint.x;
+
+    const evt = { code: 'ArrowRight', shiftKey: false, ctrlKey: false, metaKey: false, preventDefault() {} };
+    ks._onKeyDown(evt);
+    clock.tick(16);
+    raf(clock.now);
+    expect(stage.gameImgProps.viewPoint.x).to.be.greaterThan(startX);
+    clock.uninstall();
+    win.requestAnimationFrame = origRAF;
+    win.cancelAnimationFrame = origCancel;
+    delete global.document;
+    delete global.window;
   });
 });


### PR DESCRIPTION
## Summary
- test that ArrowRight key pans the stage
- expose world width and height for Stage panning

## Testing
- `npm test` *(fails: ENOENT errors)*

------
https://chatgpt.com/codex/tasks/task_e_684320e79b4c832da0e882cd7f03e3c6