### PR TITLE
Fix test case bracket

### DIFF
--- a/test/bench-speed-adjust.test.js
+++ b/test/bench-speed-adjust.test.js
@@ -94,6 +94,7 @@ describe('benchSpeedAdjust recovery', function() {
       height: 10 * gui.viewPoint.scale
     });
     expect(dashLen).to.be.at.least(2);
+  });
 
   it('updates frameTime when speed changes', function() {
     let raf;


### PR DESCRIPTION
## Summary
- fix missing brace in bench-speed-adjust test

## Testing
- `npm run format`
- `npm run lint`
- `npm test` *(fails: Timeout of 2000ms exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_68434a11068c832d834c22d1e4ffe1c4