### PR TITLE
Add L2 bitmap doc

### DIFF
--- a/.agentInfo/index-detailed.md
+++ b/.agentInfo/index-detailed.md
@@ -69,3 +69,4 @@ This expanded listing preserves the original bullet format with short descriptio
 
 
 - **search, baseimageinfo**: [notes/baseimageinfo-search.md](notes/baseimageinfo-search.md) - Search for BaseImageInfo returned 94 matches in docs and 678 code files.
+- **l2bitmap, doc**: [notes/l2bitmap-overview.md](notes/l2bitmap-overview.md) - Summary of L2 bitmap file layout and palette info.

--- a/.agentInfo/index.md
+++ b/.agentInfo/index.md
@@ -55,3 +55,4 @@ nl-pack-toolkit.md: pack-toolkit resources doc
 third-party-policy.md: policy third-party
 display-image.md: display canvas scaling image
 baseimageinfo-search.md: search
+l2bitmap-overview.md: l2bitmap doc

--- a/.agentInfo/notes/l2bitmap-overview.md
+++ b/.agentInfo/notes/l2bitmap-overview.md
@@ -1,0 +1,11 @@
+# L2Bitmap overview
+
+tags: l2bitmap, doc
+
+`docs/camanis/lemmings_2_bitmap_file_format_l2bitmap.md` summarizes the bitmap layout used by many Lemmings 2 files. Images are stored in an unusual column-based order and rely on external palettes from `.iff` files. Some data chunks are compressed with a `GCSM` header and need `lem2zip` for decompression. The doc lists palette sources and dimensions for each `.dat` file.
+
+### TODOs
+
+- Write a parser that reads the column-major format and applies the chosen palette.
+- Support automatic `GCSM` decompression when loading `.dat` resources.
+- Add tests verifying that decoded images match the reference PNGs from camanis.net.

--- a/docs/camanis/lemmings_2_bitmap_file_format_l2bitmap.md
+++ b/docs/camanis/lemmings_2_bitmap_file_format_l2bitmap.md
@@ -1,0 +1,46 @@
+# Lemmings 2 Bitmap File Format (`l2bitmap`)
+
+Source: [camanis.net](https://www.camanis.net/lemmings/files/docs/lemmings_2_bitmap_file_format_l2bitmap.txt)
+
+Lemmings 2 stores various images in a compact bitmap layout. Some of the files are compressed with the `GCSM` signature and must be decompressed (e.g. with Mindless' `lem2zip`) before parsing. The format is similar to style tiles but the bitmap sizes vary and are not stored in the files. Palettes also come from separate `.iff` files.
+
+## Bitmap Layout
+
+Pixels are listed by column groups. First all pixels where `x % 4 == 0` are stored, then `x % 4 == 1`, etc. The pseudocode below illustrates the order:
+
+```text
+p = 0
+for v = 0 to 3
+    for y = 0 to (y_size - 1)
+        for x = 0 to (x_size - 1) step 4
+            pset((x + v, y), d[p])
+            p += 1
+        next
+    next
+next
+```
+
+`d` is a byte pointer to the current tile and `pset` writes a pixel.
+
+## Contents
+
+- **font.dat** – practice.iff (1), 102 bitmaps of 16×11
+- **panel.dat** – practice.iff (1) subtract 0x80, sizes:
+  - 1 bitmap of 32×30
+  - 1 bitmap of 32×20
+  - 59 bitmaps of 8×8
+  - 1 bitmap of 16×9
+  - non-bitmap L2SS data (see `l2ss.txt`)
+- **pointer.dat** – practice.iff (1) subtract 0x80, 18 bitmaps of 16×16
+- **rockwall.dat** – same as `frontend/screens/rockwall.dat`
+- **vilscene.dat** – same as `introdat/bckgrnds/vilscene.dat`
+- **frontend/screens/award.dat** – award.iff (1), 320×200
+- **frontend/screens/end1-5.dat** – end.iff (1), 320×200
+- **frontend/screens/map.dat** – map.iff (1), 320×200
+- **frontend/screens/menu.dat** – menu.iff (1), 320×200
+- **frontend/screens/rockwall.dat** – practice.iff (1), 320×200
+- **introdat/bckgrnds/black.dat** – a single black screen, 320×200
+- **introdat/bckgrnds/cosyroom.dat** – waking.iff (2), 320×200
+- **introdat/bckgrnds/nightvil.dat** – intro.iff (2), 320×200
+- **introdat/bckgrnds/vilscene.dat** – talis2.iff (2), 320×200
+


### PR DESCRIPTION
## Summary
- document L2 bitmap file layout from Camanis
- add l2bitmap overview note with TODOs for missing features
- update `.agentInfo` indexes

## Testing
- `npm run format`
- `npm test` *(fails: ReferenceError scale is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_684311ff3a5c832d976ab1a023d6bfe7