### PR TITLE
Update tests for worldDataSize getter

### DIFF
--- a/test/bench-speed-adjust.test.js
+++ b/test/bench-speed-adjust.test.js
@@ -96,9 +96,6 @@ describe('benchSpeedAdjust recovery', function() {
     expect(dashLen).to.be.at.least(2);
   });
 
-
-  });
-
   it('updates frameTime when speed changes', function() {
     let raf;
     window.requestAnimationFrame = cb => { raf = cb; return 1; };

--- a/test/bench-tps.test.js
+++ b/test/bench-tps.test.js
@@ -22,6 +22,7 @@ class DisplayImageStub {
   setBackground(bg) { this.background = bg; }
   getWidth() { return this.width; }
   getHeight() { return this.height; }
+  get worldDataSize() { return { width: this.width, height: this.height }; }
   drawFrame(frame, x, y) { this.calls.push({ op: 'drawFrame', frame, x, y }); }
   drawFrameCovered(frame, x, y) { this.calls.push({ op: 'drawFrameCovered', frame, x, y }); }
   drawFrameResized(frame, x, y, w, h) { this.calls.push({ op: 'drawFrameResized', frame, x, y, w, h }); }

--- a/test/gamedisplay.test.js
+++ b/test/gamedisplay.test.js
@@ -31,7 +31,7 @@ describe('GameDisplay drawFrame', function() {
     gd.drawFrame(redFrame, 1, 1);
 
     const buf = gd.buffer32;
-    const w = gd.getWidth();
+    const { width: w } = gd.worldDataSize;
     const red = Lemmings.ColorPalette.colorFromRGB(255, 0, 0) >>> 0;
     expect(buf[1 + 1 * w]).to.equal(red);
     expect(buf[2 + 1 * w]).to.equal(red);
@@ -49,7 +49,7 @@ describe('GameDisplay drawFrame', function() {
     gd.drawFrame(blueFrame, 0, 0); // should draw at (1,1)
 
     const buf = gd.buffer32;
-    const w = gd.getWidth();
+    const { width: w } = gd.worldDataSize;
     const blue = Lemmings.ColorPalette.colorFromRGB(0, 0, 255) >>> 0;
     expect(buf[1 + 1 * w]).to.equal(blue);
   });
@@ -68,7 +68,7 @@ describe('GameDisplay drawFrame', function() {
     gd.drawFrame(yellowFrame, 1, 1);
 
     const buf = gd.buffer32;
-    const w = gd.getWidth();
+    const { width: w } = gd.worldDataSize;
     const yellow = Lemmings.ColorPalette.colorFromRGB(255, 255, 0) >>> 0;
     expect(buf[1 + 1 * w]).to.equal(yellow);
   });

--- a/test/gamegui.test.js
+++ b/test/gamegui.test.js
@@ -22,6 +22,7 @@ class DisplayImageStub {
   setBackground(bg) { this.background = bg; }
   getWidth() { return this.width; }
   getHeight() { return this.height; }
+  get worldDataSize() { return { width: this.width, height: this.height }; }
   drawFrame(frame, x, y) { this.calls.push({ op: 'drawFrame', frame, x, y }); }
   drawFrameCovered(frame, x, y) { this.calls.push({ op: 'drawFrameCovered', frame, x, y }); }
   drawFrameResized(frame, x, y, w, h) { this.calls.push({ op: 'drawFrameResized', frame, x, y, w, h }); }
@@ -183,6 +184,6 @@ describe('GameGui', function() {
     game.level.screenPositionX = 42;
     gui.render();
     expect(gui.miniMap.renderCalls[0].x).to.equal(42);
-    expect(gui.miniMap.renderCalls[0].w).to.equal(display.getWidth());
+    expect(gui.miniMap.renderCalls[0].w).to.equal(display.worldDataSize.width);
   });
 });

--- a/test/keyboardshortcuts.loop.test.js
+++ b/test/keyboardshortcuts.loop.test.js
@@ -17,7 +17,8 @@ class StageStub {
       height: 100,
       display: {
         getWidth() { return 200; },
-        getHeight() { return 200; }
+        getHeight() { return 200; },
+        get worldDataSize() { return { width: 200, height: 200 }; }
       },
       viewPoint: { x: 0, y: 0, scale: 1 }
     };

--- a/test/minimap.extra.test.js
+++ b/test/minimap.extra.test.js
@@ -13,6 +13,7 @@ function createDisplay(width, height) {
     onMouseMove: new Lemmings.EventHandler(),
     getWidth() { return this.width; },
     getHeight() { return this.height; },
+    get worldDataSize() { return { width: this.width, height: this.height }; },
     drawFrame(frame, x, y) { this.drawFrameCalls.push({ frame, x, y }); },
     setScreenPosition(x, y) { this.lastScreenPosition = [x, y]; }
   };
@@ -53,7 +54,7 @@ function createLevel(width, height) {
 function makeStage(level, display) {
   return {
     getGameViewRect() {
-      return { x: level.screenPositionX, y: 0, w: display.getWidth(), h: display.getHeight() };
+      return { x: level.screenPositionX, y: 0, w: display.worldDataSize.width, h: display.worldDataSize.height };
     }
   };
 }

--- a/test/minimap.test.js
+++ b/test/minimap.test.js
@@ -13,6 +13,7 @@ function createDisplay(width, height) {
     onMouseMove: new Lemmings.EventHandler(),
     getWidth() { return this.width; },
     getHeight() { return this.height; },
+    get worldDataSize() { return { width: this.width, height: this.height }; },
     drawFrame(frame, x, y) { this.drawFrameCalls.push({ frame, x, y }); },
     setScreenPosition(x, y) { this.lastScreenPosition = [x, y]; }
   };
@@ -53,7 +54,7 @@ function createLevel(width, height) {
 function makeStage(level, display) {
   return {
     getGameViewRect() {
-      return { x: level.screenPositionX, y: 0, w: display.getWidth(), h: display.getHeight() };
+      return { x: level.screenPositionX, y: 0, w: display.worldDataSize.width, h: display.worldDataSize.height };
     }
   };
 }
@@ -74,8 +75,8 @@ describe('MiniMap', function() {
     expect(mm.frame.data[idx]).to.equal(0x5500FFFF);
 
     const call = display.drawFrameCalls[0];
-    expect(call.x).to.equal(display.getWidth() - mm.width);
-    expect(call.y).to.equal(display.getHeight() - mm.height);
+    expect(call.x).to.equal(display.worldDataSize.width - mm.width);
+    expect(call.y).to.equal(display.worldDataSize.height - mm.height);
   });
 
   it('updates viewport when dragging', function() {
@@ -84,16 +85,16 @@ describe('MiniMap', function() {
     globalThis.lemmings = { stage: makeStage(level, display) };
     const mm = new MiniMap(null, level, display);
 
-    const destX = display.getWidth() - mm.width;
-    const destY = display.getHeight() - mm.height - 1;
+    const destX = display.worldDataSize.width - mm.width;
+    const destY = display.worldDataSize.height - mm.height - 1;
 
     display.onMouseDown.trigger({ x: destX + mm.width / 2, y: destY + 1 });
-    const first = ((level.width - display.getWidth()) * 0.5) | 0;
+    const first = ((level.width - display.worldDataSize.width) * 0.5) | 0;
     expect(level.screenPositionX).to.equal(first);
 
     display.onMouseMove.trigger({ x: destX + mm.width * 0.75, y: destY + 1 });
     display.onMouseUp.trigger({ x: destX + mm.width * 0.75, y: destY + 1 });
-    const expected = ((level.width - display.getWidth()) * 0.75) | 0;
+    const expected = ((level.width - display.worldDataSize.width) * 0.75) | 0;
     expect(level.screenPositionX).to.equal(expected);
 
     mm.render();

--- a/test/stage.setGameViewPointPosition.test.js
+++ b/test/stage.setGameViewPointPosition.test.js
@@ -72,7 +72,7 @@ describe('Stage.setGameViewPointPosition', function() {
     const expectedScale = stage.snapScale(1.37);
     const expectedY = Math.max(
       0,
-      display.getHeight() - stage.gameImgProps.height / expectedScale
+      display.worldDataSize.height - stage.gameImgProps.height / expectedScale
     );
 
     expect(stage.gameImgProps.viewPoint.scale).to.equal(expectedScale);

--- a/test/stage.updateStageSize.test.js
+++ b/test/stage.updateStageSize.test.js
@@ -68,8 +68,8 @@ describe('Stage.updateStageSize', function() {
     stage.updateStageSize();
 
     const scale = stage.guiImgProps.viewPoint.scale;
-    const guiW = display.getWidth() * scale;
-    const panelH = display.getHeight() * scale;
+    const guiW = display.worldDataSize.width * scale;
+    const panelH = display.worldDataSize.height * scale;
     expect(stage.guiImgProps.viewPoint.scale).to.equal(4);
     expect(stage.guiImgProps.x).to.equal((canvas.width - stage.guiImgProps.width) / 2);
     expect(stage.guiImgProps.y).to.equal(stage.gameImgProps.height);
@@ -77,7 +77,7 @@ describe('Stage.updateStageSize', function() {
     expect(stage.guiImgProps.height).to.equal(panelH);
     expect(stage.guiImgProps.width).to.equal(guiW);
     const viewH = stage.gameImgProps.height / stage.gameImgProps.viewPoint.scale;
-    const worldH = gameDisplay.getHeight();
+    const worldH = gameDisplay.worldDataSize.height;
     expect(stage.gameImgProps.viewPoint.y).to.equal(worldH - viewH);
   });
 
@@ -96,15 +96,15 @@ describe('Stage.updateStageSize', function() {
     stage.updateStageSize();
 
     const scale = stage.guiImgProps.viewPoint.scale;
-    const panelH = display.getHeight() * scale;
+    const panelH = display.worldDataSize.height * scale;
     expect(stage.guiImgProps.viewPoint.scale).to.equal(4);
     expect(stage.guiImgProps.x).to.equal((canvas.width - stage.guiImgProps.width) / 2);
     expect(stage.guiImgProps.y).to.equal(stage.gameImgProps.height);
     expect(stage.gameImgProps.height).to.equal(440);
     expect(stage.guiImgProps.height).to.equal(panelH);
-    expect(stage.guiImgProps.width).to.equal(display.getWidth() * scale);
+    expect(stage.guiImgProps.width).to.equal(display.worldDataSize.width * scale);
     const viewH = stage.gameImgProps.height / stage.gameImgProps.viewPoint.scale;
-    const worldH = gameDisplay.getHeight();
+    const worldH = gameDisplay.worldDataSize.height;
     expect(stage.gameImgProps.viewPoint.y).to.equal(worldH - viewH);
   });
 
@@ -127,8 +127,8 @@ describe('Stage.updateStageSize', function() {
     stage.updateStageSize();
 
     const scale = stage.guiImgProps.viewPoint.scale;
-    const panelW = display.getWidth() * scale;
-    const panelH = display.getHeight() * scale;
+    const panelW = display.worldDataSize.width * scale;
+    const panelH = display.worldDataSize.height * scale;
     expect(stage.gameImgProps.width).to.equal(canvas.width);
     expect(stage.gameImgProps.height).to.equal(canvas.height - panelH);
     expect(stage.guiImgProps.width).to.equal(panelW);

--- a/test/stage.updateviewpoint.test.js
+++ b/test/stage.updateviewpoint.test.js
@@ -105,8 +105,8 @@ describe('Stage updateViewPoint', function() {
     expect(Math.abs(afterX - beforeX)).to.be.at.most(1);
     expect(Math.abs(afterY - beforeY)).to.be.at.most(1);
 
-    const worldW = display.getWidth();
-    const worldH = display.getHeight();
+    const worldW = display.worldDataSize.width;
+    const worldH = display.worldDataSize.height;
     const viewW = img.width / vp.scale;
     const viewH = img.height / vp.scale;
 
@@ -147,8 +147,8 @@ describe('Stage updateViewPoint', function() {
       expect(Math.abs(postX - preX)).to.be.at.most(1);
       expect(Math.abs(postY - preY)).to.be.at.most(1);
 
-      const worldW = display.getWidth();
-      const worldH = display.getHeight();
+      const worldW = display.worldDataSize.width;
+      const worldH = display.worldDataSize.height;
       const viewW = img.width / vp.scale;
       const viewH = img.height / vp.scale;
       expect(vp.x).to.be.at.least(0);
@@ -183,8 +183,8 @@ describe('Stage updateViewPoint', function() {
     vp.scale = 2;
 
     const checkClamp = () => {
-      const worldW = display.getWidth();
-      const worldH = display.getHeight();
+      const worldW = display.worldDataSize.width;
+      const worldH = display.worldDataSize.height;
       const viewW = img.width / vp.scale;
       const viewH = img.height / vp.scale;
       expect(vp.x).to.be.at.least(0);


### PR DESCRIPTION
## Summary
- adjust test stubs to implement `worldDataSize`
- switch width/height accesses in tests to use `display.worldDataSize`

## Testing
- `npm run format`
- `npm test` *(fails: 53 failing)*

------
https://chatgpt.com/codex/tasks/task_e_6843570c4738832dbdcf39183be386f4