### PR TITLE
Fix stray closing bracket in bench speed adjust test

### DIFF
--- a/test/bench-speed-adjust.test.js
+++ b/test/bench-speed-adjust.test.js
@@ -96,9 +96,6 @@ describe('benchSpeedAdjust recovery', function() {
     expect(dashLen).to.be.at.least(2);
   });
 
-
-  });
-
   it('updates frameTime when speed changes', function() {
     let raf;
     window.requestAnimationFrame = cb => { raf = cb; return 1; };


### PR DESCRIPTION
## Summary
- remove extraneous `});` in `bench-speed-adjust.test.js`
- keep stage test timer hooks unchanged

## Testing
- `npx mocha test/stage.overlayfade.test.js test/stage.utilities.test.js`
- `npm test` *(fails: tools/scanGreenPanel.js timeout)*

------
https://chatgpt.com/codex/tasks/task_e_684356ee1418832d862a1be8362df668