### PR TITLE
Add spawn counter and bench display

### DIFF
--- a/js/GameGui.js
+++ b/js/GameGui.js
@@ -410,6 +410,8 @@ class GameGui {
       } else if (lemmings.bench == true && this.gameSpeedChanged) {
         this.drawGreenString(d, 'T' + lemmings.steps, 120, 0);
         this.drawGreenString(d, 'TPS ' + Math.round(lemmings.tps), 152, 0);
+        const count = this.game.getLemmingManager?.().spawnTotal ?? 0;
+        this.drawGreenString(d, 'Spawn ' + count, 192, 0);
       }
     }
 

--- a/js/LemmingManager.js
+++ b/js/LemmingManager.js
@@ -46,6 +46,7 @@ class LemmingManager extends Lemmings.BaseLogger {
           this.lemmings = [];
         }
         this.minimapDots = new Uint8Array(0);
+        this.spawnTotal = 0;
         this.selectedIndex = -1;
         const maxDots = (gameVictoryCondition.getReleaseCount() +
           (lemmings.extraLemmings | 0)) * 2;
@@ -204,6 +205,7 @@ class LemmingManager extends Lemmings.BaseLogger {
         const lem = new Lemmings.Lemming(x, y, startingLemLength);
         this.setLemmingState(lem, Lemmings.LemmingStateType.FALLING);
         this.lemmings.push(lem);
+        this.spawnTotal += 1;
 
         const extraCount = lemmings.extraLemmings | 0;
         if (extraCount > 0) {
@@ -215,6 +217,7 @@ class LemmingManager extends Lemmings.BaseLogger {
             extras[i] = extra;
           }
           Array.prototype.push.apply(this.lemmings, extras);
+          this.spawnTotal += extraCount;
         }
       })();
   }

--- a/test/bench-sequence.test.js
+++ b/test/bench-sequence.test.js
@@ -16,10 +16,17 @@ class StageMock {
   startOverlayFade() {}
 }
 
+class LemmingManagerMock {
+  constructor() { this._spawnCount = 0; this.spawnTotal = 0; }
+  get spawnCount() { return this._spawnCount; }
+  set spawnCount(v) { this._spawnCount = v; this.spawnTotal += v; }
+  getLemmings() { return new Array(this._spawnCount); }
+}
+
 class GameMock {
   constructor() {
     this.timer = new GameTimer({ timeLimit: 1 });
-    this.lemmingManager = { spawnCount:0, getLemmings: () => new Array(this.lemmingManager.spawnCount) };
+    this.lemmingManager = new LemmingManagerMock();
     this.level = { width:100, height:50, entrances:[], screenPositionX:0, render(){} };
     this.onGameEnd = new Lemmings.EventHandler();
   }
@@ -76,17 +83,23 @@ describe('bench sequence', function() {
     const orig = console.log; console.log = m => logs.push(m);
     await view.setup();
 
+    expect(view.game.getLemmingManager().spawnTotal).to.equal(10);
+
     let timer = view.game.getGameTimer();
     expect(timer.speedFactor).to.equal(6);
     timer.speedFactor = 0.9;
     timer.eachGameSecond.trigger();
     await Promise.resolve();
 
+    expect(view.game.getLemmingManager().spawnTotal).to.equal(15);
+
     expect(logs[0]).to.equal(10);
     timer = view.game.getGameTimer();
     timer.speedFactor = 0.9;
     timer.eachGameSecond.trigger();
     await Promise.resolve();
+
+    expect(view.game.getLemmingManager().spawnTotal).to.equal(17);
     expect(logs[1]).to.equal(5);
 
     console.log = orig;


### PR DESCRIPTION
## Summary
- track spawnTotal in `LemmingManager`
- show spawnTotal in `GameGui` when benching
- expand bench sequence test to cover spawnTotal counter

## Testing
- `npm test` *(fails: ReferenceError: worldW is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6844acc49664832dbe62ed050b10ee9b