### PR TITLE
Improve search metrics logging

### DIFF
--- a/test/search-script.test.js
+++ b/test/search-script.test.js
@@ -33,4 +33,101 @@ describe('tools/search.js', function () {
 
     fs.rmSync(dir, { recursive: true, force: true });
   });
+
+  it('updates metrics.json after a search', function () {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'search-'));
+    for (const sub of ['index-prose', 'index-code']) {
+      fs.mkdirSync(path.join(dir, sub));
+    }
+    for (const f of ['sparse_postings.json', 'chunk_meta.json']) {
+      fs.copyFileSync(path.join('index-prose', f), path.join(dir, 'index-prose', f));
+      fs.copyFileSync(path.join('index-code', f), path.join(dir, 'index-code', f));
+    }
+
+    const script = path.resolve('tools/search.js');
+    const res = spawnSync(process.execPath, [script, 'lemmings'], {
+      cwd: dir,
+      encoding: 'utf8'
+    });
+    expect(res.status).to.equal(0);
+
+    const metrics = path.join(dir, '.searchMetrics', 'metrics.json');
+    expect(fs.existsSync(metrics)).to.be.true;
+    const json = JSON.parse(fs.readFileSync(metrics, 'utf8'));
+    expect(Object.keys(json).length).to.be.greaterThan(0);
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('logs no-result queries', function () {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'search-'));
+    for (const sub of ['index-prose', 'index-code']) {
+      fs.mkdirSync(path.join(dir, sub));
+    }
+    for (const f of ['sparse_postings.json', 'chunk_meta.json']) {
+      fs.copyFileSync(path.join('index-prose', f), path.join(dir, 'index-prose', f));
+      fs.copyFileSync(path.join('index-code', f), path.join(dir, 'index-code', f));
+    }
+
+    const script = path.resolve('tools/search.js');
+    const res = spawnSync(process.execPath, [script, 'zzzzzz'], {
+      cwd: dir,
+      encoding: 'utf8'
+    });
+    expect(res.status).to.equal(0);
+
+    const noRes = path.join(dir, '.searchMetrics', 'noResultQueries');
+    expect(fs.existsSync(noRes)).to.be.true;
+    const lines = fs.readFileSync(noRes, 'utf8').trim().split(/\n/);
+    expect(lines).to.include('zzzzzz');
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('omits (func: when no function is found', function () {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'search-'));
+    for (const sub of ['index-prose', 'index-code']) {
+      fs.mkdirSync(path.join(dir, sub));
+    }
+    for (const f of ['sparse_postings.json', 'chunk_meta.json']) {
+      fs.copyFileSync(path.join('index-prose', f), path.join(dir, 'index-prose', f));
+      fs.copyFileSync(path.join('index-code', f), path.join(dir, 'index-code', f));
+    }
+
+    const script = path.resolve('tools/search.js');
+    const res = spawnSync(process.execPath, [script, 'Progressive'], {
+      cwd: dir,
+      encoding: 'utf8'
+    });
+    expect(res.status).to.equal(0);
+    expect(res.stdout).to.not.include('(func:');
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('--json output has correct structure', function () {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'search-'));
+    for (const sub of ['index-prose', 'index-code']) {
+      fs.mkdirSync(path.join(dir, sub));
+    }
+    for (const f of ['sparse_postings.json', 'chunk_meta.json']) {
+      fs.copyFileSync(path.join('index-prose', f), path.join(dir, 'index-prose', f));
+      fs.copyFileSync(path.join('index-code', f), path.join(dir, 'index-code', f));
+    }
+
+    const script = path.resolve('tools/search.js');
+    const res = spawnSync(process.execPath, [script, 'lemmings', '--json'], {
+      cwd: dir,
+      encoding: 'utf8'
+    });
+    expect(res.status).to.equal(0);
+    const out = JSON.parse(res.stdout);
+    expect(out).to.have.keys(['markdown', 'code']);
+    expect(out.markdown).to.be.an('array');
+    expect(out.code).to.be.an('array');
+    if (out.markdown.length) {
+      expect(out.markdown[0]).to.have.all.keys('file', 'totalMatches', 'score', 'realPos', 'enclosingFunction');
+    }
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
 });

--- a/tools/search.js
+++ b/tools/search.js
@@ -271,8 +271,11 @@ function agentText() {
 
       const scoreMd1 = colorScore(md1.totalMatches, maxMdMatches).padEnd(4);
       out += `[${scoreMd1}] ` +
-        c.magentaBright(path.basename(md1.file)) +
-        ` (func: ${md1.enclosingFunction || '‹none›'})\n`;
+        c.magentaBright(path.basename(md1.file));
+      if (md1.enclosingFunction) {
+        out += ` (func: ${md1.enclosingFunction})`;
+      }
+      out += '\n';
       for (let i = st1; i < en1; i++) {
         const num = c.green(String(i + 1).padStart(4));
         const hl = linesMd[i].replace(rx, (m) => c.bold.yellowBright(m));
@@ -286,8 +289,11 @@ function agentText() {
       const h = mdHitsAll[i];
       const sc = colorScore(h.totalMatches, maxMdMatches).padEnd(4);
       out += `[${sc}] ` +
-        c.magentaBright(path.basename(h.file)) +
-        ` (func: ${h.enclosingFunction || '‹none›'})\n`;
+        c.magentaBright(path.basename(h.file));
+      if (h.enclosingFunction) {
+        out += ` (func: ${h.enclosingFunction})`;
+      }
+      out += '\n';
     }
     out += '\n';
   }
@@ -310,8 +316,11 @@ function agentText() {
 
       const sc = colorScore(h.totalMatches, maxCodeMatches).padEnd(4);
       out += `[${sc}] ` +
-        c.blueBright(path.basename(h.file)) +
-        ` (func: ${h.enclosingFunction || '‹none›'})\n`;
+        c.blueBright(path.basename(h.file));
+      if (h.enclosingFunction) {
+        out += ` (func: ${h.enclosingFunction})`;
+      }
+      out += '\n';
       for (let j = stC; j < enC; j++) {
         const num = c.green(String(j + 1).padStart(4));
         const hl = linesC[j].replace(rx, (m) => c.bold.yellowBright(m));
@@ -325,8 +334,11 @@ function agentText() {
       const h = codeHitsAll[i];
       const sc = colorScore(h.totalMatches, maxCodeMatches).padEnd(4);
       out += `[${sc}] ` +
-        c.blueBright(path.basename(h.file)) +
-        ` (func: ${h.enclosingFunction || '‹none›'})\n`;
+        c.blueBright(path.basename(h.file));
+      if (h.enclosingFunction) {
+        out += ` (func: ${h.enclosingFunction})`;
+      }
+      out += '\n';
     }
     out += '\n';
   }
@@ -374,7 +386,11 @@ function humanText() {
         : '(no matches)';
       out += `${i + 1}. ${c.magentaBright(path.basename(h.file))} ` +
         c.dim(path.dirname(h.file)) +
-        ` — hits: ${sc}, lines: ${pos}, func: ${h.enclosingFunction || 'N/A'}\n`;
+        ` — hits: ${sc}, lines: ${pos}`;
+      if (h.enclosingFunction) {
+        out += `, func: ${h.enclosingFunction}`;
+      }
+      out += '\n';
     }
     if (mdHitsAll.length > 10) {
       out += `... and ${mdHitsAll.length - 10} more Markdown files.\n`;
@@ -395,7 +411,11 @@ function humanText() {
         : '(no matches)';
       out += `${i + 1}. ${c.blueBright(path.basename(h.file))} ` +
         c.dim(path.dirname(h.file)) +
-        ` — hits: ${sc}, lines: ${pos}, func: ${h.enclosingFunction || 'N/A'}\n`;
+        ` — hits: ${sc}, lines: ${pos}`;
+      if (h.enclosingFunction) {
+        out += `, func: ${h.enclosingFunction}`;
+      }
+      out += '\n';
     }
     if (codeHitsAll.length > 10) {
       out += `... and ${codeHitsAll.length - 10} more code files.\n`;
@@ -463,6 +483,7 @@ if (argv.stats) {
 /* ---------- Update .searchMetrics and .searchHistory ---------- */
 const metricsPath = path.join(metricsDir, 'metrics.json');
 const historyPath = path.join(metricsDir, 'searchHistory');
+const noResPath = path.join(metricsDir, 'noResultQueries');
 await fs.mkdir(path.dirname(metricsPath), { recursive: true });
 
 let metrics = {};
@@ -492,3 +513,7 @@ await fs.appendFile(
     ms: Date.now() - t0,
   }) + '\n'
 );
+
+if (totalMdFiles === 0 && totalCodeFiles === 0) {
+  await fs.appendFile(noResPath, query + '\n');
+}


### PR DESCRIPTION
## Summary
- update search tool to skip empty `func:` labels
- write no-result queries to `.searchMetrics/noResultQueries`
- expand search tool tests for metrics, no-results, and JSON output

## Testing
- `npm test` *(fails: UserInputManager adjusts viewport when zooming)*

------
https://chatgpt.com/codex/tasks/task_e_6844c247e0a0832daea0891d647debd0