### PR TITLE
Track search queries with no results

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,7 @@
 # Tell Git to invoke our "merge-metrics" driver on metrics.json
 .searchMetrics/metrics.json    merge=merge_metrics
 .searchMetrics/searchHistory   merge=merge_history
+.searchMetrics/noResultQueries merge=merge_no_results
 .agentInfo/index.md             merge=merge_agentinfo_index
 .agentInfo/index-detailed.md    merge=merge_agentinfo_index
 .agentInfo/notes/*.md           merge=merge_agentinfo_notes

--- a/.github/workflows/no-result-history.yml
+++ b/.github/workflows/no-result-history.yml
@@ -1,0 +1,47 @@
+name: Sync no result queries
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Sync tools from master
+        run: |
+          git fetch origin master
+          git checkout origin/master -- tools
+      - uses: actions/setup-node@v4.2.0
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - name: Fetch master history
+        run: |
+          git fetch origin master
+          git show origin/master:.searchMetrics/noResultQueries > base_history || touch base_history
+      - name: Merge base lines
+        run: |
+          mkdir -p .searchMetrics
+          touch .searchMetrics/noResultQueries
+          while IFS= read -r line; do
+            grep -Fxq "$line" .searchMetrics/noResultQueries || echo "$line" >> .searchMetrics/noResultQueries
+          done < base_history
+      - name: Commit and push if changed
+        run: |
+          if ! git diff --quiet -- .searchMetrics/noResultQueries; then
+            git config user.name "github-actions"
+            git config user.email "github-actions@github.com"
+            git add .searchMetrics/noResultQueries
+            git commit -m "chore: sync no-result queries"
+            git push origin HEAD:${{ github.head_ref }}
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "agent-update-searchmetrics": "node tools/agentUpdateSearchMetrics.js",
     "agent-update-searchhistory": "node tools/mergeSearchHistory.js",
     "agent-precommit": "npm run agent-update-searchmetrics && npm run agent-update-searchhistory && git add .searchHistory .searchMetrics/metrics.json",
-    "test-workflows": "mocha test/search-history-workflow.test.js"
+    "test-workflows": "mocha test/search-history-workflow.test.js test/no-result-queries-workflow.test.js test/no-result-queries-ci-workflow.test.js test/search-history-ci-workflow.test.js"
   },
   "repository": {
     "type": "git",

--- a/test/no-result-queries-ci-workflow.test.js
+++ b/test/no-result-queries-ci-workflow.test.js
@@ -1,0 +1,15 @@
+import { expect } from 'chai';
+import fs from 'fs';
+import yaml from 'js-yaml';
+
+describe('no-result-queries workflow', function () {
+  it('syncs tools from master', function () {
+    const text = fs.readFileSync('.github/workflows/no-result-history.yml', 'utf8');
+    const config = yaml.load(text);
+    const steps = config.jobs.sync.steps;
+    const syncStep = steps.find(
+      s => s.run && s.run.includes('git checkout origin/master -- tools')
+    );
+    expect(syncStep, 'sync tools step missing').to.exist;
+  });
+});

--- a/test/no-result-queries-workflow.test.js
+++ b/test/no-result-queries-workflow.test.js
@@ -1,0 +1,21 @@
+import { expect } from 'chai';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { mergeNoResultQueries } from '../tools/mergeNoResultQueries.js';
+
+describe('mergeNoResultQueries', function () {
+  it('appends missing lines from the base file', function () {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nores-'));
+    const base = path.join(dir, 'base_no_results');
+    const target = path.join(dir, '.searchMetrics', 'noResultQueries');
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(base, 'a\nb\nc\n');
+    fs.writeFileSync(target, 'b\nc\nd\n');
+
+    mergeNoResultQueries(base, target);
+
+    const result = fs.readFileSync(target, 'utf8').trim().split(/\n/);
+    expect(result).to.eql(['b', 'c', 'd', 'a']);
+  });
+});

--- a/tools/merge-no-results.sh
+++ b/tools/merge-no-results.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# tools/merge-no-results.sh
+#
+# A small wrapper that takes three arguments:
+#   $1 = path/to/base_noResultQueries
+#   $2 = path/to/ours_noResultQueries
+#   $3 = path/to/theirs_noResultQueries
+#
+# It then merges the contents of “theirs” into “ours” (via union, no duplicates)
+# using mergeNoResultQueries.js.  The result is written back to “ours” ($2).
+#
+# Usage (Git will call this with):
+#   tools/merge-no-results.sh <base> <ours> <theirs>
+#
+
+set -euo pipefail
+
+BASE_FILE="$1"
+OURS_FILE="$2"
+THEIRS_FILE="$3"
+
+# Ensure the directory for the “ours” file exists (e.g. .searchMetrics/)
+mkdir -p "$(dirname "$OURS_FILE")"
+
+# If “ours” doesn’t exist yet, start with an empty file
+if [ ! -f "$OURS_FILE" ]; then
+  echo -n "" > "$OURS_FILE"
+fi
+
+# If “theirs” doesn’t exist, nothing to merge—just keep “ours” as is
+if [ ! -f "$THEIRS_FILE" ]; then
+  exit 0
+fi
+
+# We want to produce a union of “ours” + “theirs” (no duplicate lines).
+# mergeNoResultQueries.js expects two args: (baseFile, targetFile).  We can
+# simply pass “theirs” as the “baseFile” and “ours” as the “targetFile”,
+# so that any lines in “theirs” not already in “ours” get appended.
+
+# (If you truly needed a three-way diff with base, you could run more
+# complex logic.  But for “append‐only” history, this union is usually enough.)
+
+# Invoke the Node script:
+node "$(dirname "$0")/mergeNoResultQueries.js" "$THEIRS_FILE" "$OURS_FILE"
+
+# At this point, “ours” has been updated in place to include every unique line
+# from both “ours” and “theirs.”  Exit successfully.
+exit 0

--- a/tools/mergeNoResultQueries.js
+++ b/tools/mergeNoResultQueries.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+export function mergeNoResultQueries(baseFile, targetFile) {
+  if (!fs.existsSync(baseFile)) return;
+  if (!fs.existsSync(targetFile)) {
+    fs.mkdirSync(path.dirname(targetFile), { recursive: true });
+    fs.writeFileSync(targetFile, '');
+  }
+  const baseLines = fs.readFileSync(baseFile, 'utf8').split(/\r?\n/).filter(Boolean);
+  const targetLines = fs.readFileSync(targetFile, 'utf8').split(/\r?\n/).filter(Boolean);
+  const seen = new Set(targetLines);
+  for (const line of baseLines) {
+    if (!seen.has(line)) {
+      targetLines.push(line);
+      seen.add(line);
+    }
+  }
+  const out = targetLines.join('\n');
+  fs.writeFileSync(targetFile, out + (out ? '\n' : ''));
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const base = process.argv[2] || 'base_no_results';
+  const dest = process.argv[3] || '.searchMetrics/noResultQueries';
+  mergeNoResultQueries(base, dest);
+}

--- a/tools/search.js
+++ b/tools/search.js
@@ -463,6 +463,7 @@ if (argv.stats) {
 /* ---------- Update .searchMetrics and .searchHistory ---------- */
 const metricsPath = path.join(metricsDir, 'metrics.json');
 const historyPath = path.join(metricsDir, 'searchHistory');
+const noResultPath = path.join(metricsDir, 'noResultQueries');
 await fs.mkdir(path.dirname(metricsPath), { recursive: true });
 
 let metrics = {};
@@ -492,3 +493,10 @@ await fs.appendFile(
     ms: Date.now() - t0,
   }) + '\n'
 );
+
+if (totalMdFiles === 0 && totalCodeFiles === 0) {
+  await fs.appendFile(
+    noResultPath,
+    JSON.stringify({ time: new Date().toISOString(), query }) + '\n'
+  );
+}


### PR DESCRIPTION
## Summary
- log searches with no results
- add merge utilities for `noResultQueries`
- sync no-result history via workflow
- cover new utilities with tests

## Testing
- `npm test` *(fails: UserInputManager adjusts viewport when zooming)*

------
https://chatgpt.com/codex/tasks/task_e_6844c23831f8832d886528eecdcdcfd1