### PR TITLE
Add search history doc note

### DIFF
--- a/.agentInfo/index-detailed.md
+++ b/.agentInfo/index-detailed.md
@@ -97,3 +97,5 @@ This expanded listing preserves the original bullet format with short descriptio
 - **l2, savegame, doc**: [notes/l2-save-format.md](notes/l2-save-format.md) - docs/camanis/lemmings_2_save_file_format.md outlines eight save slots with per-tribe progress; loader/writer not implemented.
 - **lemmings2, save-file, doc, todo**: [notes/l2-save-format.md](notes/l2-save-format.md) - 8 slots hold tribe progress and medal info; not yet supported.
 - **naming, cleanup**: [notes/naming-cleanup.md](notes/naming-cleanup.md) - Clarify variables that confuse viewport size with world data size.
+- **search, doc**: [notes/search-tool-doc.md](notes/search-tool-doc.md) - docs/ci.md lines 24-29 describe the search-history workflow and its new zeroResultHistory file.
+

--- a/.agentInfo/index.md
+++ b/.agentInfo/index.md
@@ -81,3 +81,4 @@ l2-guyperfect.md: l2 file-format doc
 l2-level-format.md: l2-level-format doc
 l3-level-format.md: level-format l3 doc
 l2bitmap-overview.md: l2bitmap doc
+search-tool-doc.md: search doc

--- a/.agentInfo/notes/search-tool-doc.md
+++ b/.agentInfo/notes/search-tool-doc.md
@@ -1,0 +1,5 @@
+# Search tool CI docs
+
+tags: search, doc
+
+`docs/ci.md` lines 24-29 explain the `search-history.yml` workflow that syncs `.searchMetrics/searchHistory` on PR updates. The same section now references a new `.searchMetrics/zeroResultHistory` file storing queries that returned no matches.


### PR DESCRIPTION
## Summary
- document CI search-history workflow in `.agentInfo`
- link to docs mentioning the new zeroResultHistory file

## Testing
- `npm run format`
- `npm test` *(fails: TypeError in Action Systems)*
- `npm run agent-precommit` *(fails: unable to parse .searchMetrics)*

------
https://chatgpt.com/codex/tasks/task_e_6844c246f3b4832dbd25af278d93026a