### PR TITLE
Add zoom and overlay tests

### DIFF
--- a/test/stageimageprops.test.js
+++ b/test/stageimageprops.test.js
@@ -4,7 +4,8 @@ import '../js/ViewPoint.js';
 import { StageImageProperties } from '../js/StageImageProperties.js';
 
 function createDocumentStub() {
-  return {
+  const doc = {
+    lastOpts: null,
     createElement() {
       const ctx = {
         canvas: {},
@@ -18,10 +19,11 @@ function createDocumentStub() {
       return {
         width: 0,
         height: 0,
-        getContext() { ctx.canvas = this; return ctx; }
+        getContext(type, opts) { doc.lastOpts = opts; ctx.canvas = this; return ctx; }
       };
     }
   };
+  return doc;
 }
 
 describe('StageImageProperties', function() {
@@ -41,5 +43,14 @@ describe('StageImageProperties', function() {
     expect(img.width).to.equal(5);
     expect(img.height).to.equal(7);
     expect(img.data).to.have.lengthOf(5 * 7 * 4);
+  });
+
+  it('createImage uses alpha context and clears data', function() {
+    const doc = global.document;
+    const props = new StageImageProperties();
+    const img = props.createImage(2, 2);
+    const allZero = Array.from(img.data).every(v => v === 0);
+    expect(allZero).to.equal(true);
+    expect(doc.lastOpts && doc.lastOpts.alpha).to.equal(true);
   });
 });


### PR DESCRIPTION
## Summary
- add tests for multiple zoom levels and overlay fade while resizing
- verify StageImageProperties `createImage` clears memory and uses alpha context

## Testing
- `npm test` *(fails: ReferenceError winW is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6844c413e038832d96b479eee992700c