### PR TITLE
Add coverage for tool utilities

### DIFF
--- a/test/check-undefined.test.js
+++ b/test/check-undefined.test.js
@@ -16,4 +16,13 @@ describe('tools/check-undefined.js', function () {
     expect(result.status).to.not.equal(0);
     expect(result.stderr || result.stdout).to.match(/missingCall|require is not defined/);
   });
+
+  it('detects global leaks assigned without var/let', function () {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'undef-'));
+    const file = path.join(dir, 'leak.js');
+    fs.writeFileSync(file, 'leakFn = function(){}; leakFn();');
+    const result = spawnSync('node', [script, file], { encoding: 'utf8' });
+    expect(result.status).to.not.equal(0);
+    expect(result.stderr || result.stdout).to.match(/leakFn is not defined/);
+  });
 });

--- a/test/search-history-workflow.test.js
+++ b/test/search-history-workflow.test.js
@@ -18,4 +18,25 @@ describe('mergeSearchHistory', function () {
     const result = fs.readFileSync(target, 'utf8').trim().split(/\n/);
     expect(result).to.eql(['b', 'c', 'd', 'a']);
   });
+
+  it('deduplicates JSON records and preserves valid output', function () {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'history-'));
+    const base = path.join(dir, 'base_history');
+    const target = path.join(dir, '.searchMetrics', 'searchHistory');
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    const rec1 = { query: 'foo' };
+    const rec2 = { query: 'bar' };
+    fs.writeFileSync(
+      base,
+      JSON.stringify(rec1) + '\n' + JSON.stringify(rec1) + '\n' + JSON.stringify(rec2) + '\n'
+    );
+    fs.writeFileSync(target, JSON.stringify(rec1) + '\n');
+
+    mergeSearchHistory(base, target);
+
+    const lines = fs.readFileSync(target, 'utf8').trim().split(/\n/);
+    expect(lines).to.have.length(2);
+    expect(JSON.parse(lines[0])).to.eql(rec1);
+    expect(JSON.parse(lines[1])).to.eql(rec2);
+  });
 });

--- a/test/tools/processHtmlFile.test.js
+++ b/test/tools/processHtmlFile.test.js
@@ -29,4 +29,27 @@ describe('tools/processHtmlFile', function () {
     expect(processed).to.include(pathToFileURL(path.join(dir, 'js', 'app.js')).href);
     expect(processed).to.include(pathToFileURL(path.join(dir, 'img', 'pic.png')).href);
   });
+
+  it('inlines scripts and styles when requested', function () {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'html-'));
+    fs.mkdirSync(path.join(dir, 'js'));
+    fs.mkdirSync(path.join(dir, 'css'));
+    const jsPath = path.join(dir, 'js', 'app.js');
+    const cssPath = path.join(dir, 'css', 'style.css');
+    fs.writeFileSync(jsPath, 'console.log("hi");');
+    fs.writeFileSync(cssPath, 'body{color:red;}');
+    const html = `<!DOCTYPE html><html><head>
+      <link rel="stylesheet" href="css/style.css">
+      <script src="js/app.js"></script>
+    </head><body></body></html>`;
+    const file = path.join(dir, 'index.html');
+    fs.writeFileSync(file, html);
+
+    const result = processHtmlFile(file, { inline: true });
+    const processed = result.html;
+    expect(processed).to.include('<style>body{color:red;}</style>');
+    expect(processed).to.include('<script>console.log("hi");</script>');
+    expect(processed).to.not.match(/href="css\/style.css"/);
+    expect(processed).to.not.match(/src="js\/app.js"/);
+  });
 });


### PR DESCRIPTION
## Summary
- test check-undefined.js with implicit globals
- verify script/style injection in processHtmlFile
- ensure mergeSearchHistory handles duplicate JSON records

## Testing
- `npm test` *(fails: ReferenceError winW is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6844c41d1130832d9c701716ce97ff48