### PR TITLE
Fix search history merge step

### DIFF
--- a/.github/workflows/search-history.yml
+++ b/.github/workflows/search-history.yml
@@ -29,11 +29,7 @@ jobs:
           git show origin/master:.searchMetrics/searchHistory > base_history || touch base_history
       - name: Merge base lines
         run: |
-          mkdir -p .searchMetrics
-          touch .searchMetrics/searchHistory
-          while IFS= read -r line; do
-            grep -Fxq "$line" .searchMetrics/searchHistory || echo "$line" >> .searchMetrics/searchHistory
-          done < base_history
+          node tools/mergeSearchHistory.js base_history .searchMetrics/searchHistory
       - name: Commit and push if changed
         run: |
           if ! git diff --quiet -- .searchMetrics/searchHistory; then


### PR DESCRIPTION
## Summary
- streamline history merge step to use mergeSearchHistory.js

## Testing
- `npm test` *(fails: winW not defined)*
- `npm run agent-precommit` *(fails: local .searchMetrics invalid JSON)*

------
https://chatgpt.com/codex/tasks/task_e_6844c4a42fd8832d864ac1e35d5b154c