### PR TITLE
Add test category note

### DIFF
--- a/.agentInfo/index-detailed.md
+++ b/.agentInfo/index-detailed.md
@@ -100,3 +100,4 @@ This expanded listing preserves the original bullet format with short descriptio
 - **naming, cleanup**: [notes/naming-cleanup.md](notes/naming-cleanup.md) - Clarify variables that confuse viewport size with world data size.
 - **search, doc**: [notes/search-tool-doc.md](notes/search-tool-doc.md) - docs/ci.md lines 24-29 describe the search-history workflow and its new zeroResultHistory file.
 
+- **tests, categories**: [notes/test-categories.md](notes/test-categories.md) - Lists test groups so you can run subsets of the suite.

--- a/.agentInfo/index.md
+++ b/.agentInfo/index.md
@@ -83,3 +83,4 @@ l3-level-format.md: level-format l3 doc
 l2bitmap-overview.md: l2bitmap doc
 search-tool-doc.md: search doc
 bench-sequence.md: bench-sequence bench-mode
+test-categories.md: tests categories

--- a/.agentInfo/notes/test-categories.md
+++ b/.agentInfo/notes/test-categories.md
@@ -1,0 +1,14 @@
+# Test categories
+
+tags: tests, categories
+
+Tests are organized into categories so you can run only the relevant suites during development. This speeds up iteration when touching specific subsystems.
+
+- **core** – fundamental game logic such as `GameTimer` and `LemmingManager`. Example: `test/core/game-timer.js`.
+- **rendering** – verifies canvas drawing helpers and animation. Example: `test/rendering/game-display.js`.
+- **level** – covers level file parsing and serialization. Example: `test/level/level-reader.js`.
+- **io** – reads/writes archives or pack resources. Example: `test/io/node-file-provider.js`.
+- **tools** – Node command-line utilities like exporters or packers. Example: `test/tools/export-all-sprites.js`.
+- **bench** – stress and benchmark scenarios to measure performance. Example: `test/bench/bench-speed-adjust.js`.
+- **workflow** – developer workflow helpers including lint rules or git hooks. Example: `test/workflow/search-history.js`.
+- **utils** – small helper classes and math utilities. Example: `test/utils/rectangle.js`.


### PR DESCRIPTION
## Summary
- document grouping of tests into categories
- index the new test categories doc

## Testing
- `npm run format`
- `npm test` *(fails: ReferenceError: worldW is not defined)*
- `npm run agent-precommit` *(fails to parse `.searchMetrics`)*

------
https://chatgpt.com/codex/tasks/task_e_6844d0bea620832d956d037eb8171bfc