### PR TITLE
Implement categorized test runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "scripts": {
     "start": "http-server --cors=*",
     "check-undefined": "node tools/check-undefined.js",
-    "test": "mocha --recursive",
-    "coverage": "c8 mocha --recursive",
+    "test": "node tools/runTests.js",
+    "coverage": "c8 node tools/runTests.js",
     "export-panel-sprite": "node tools/exportPanelSprite.js",
     "export-lemmings-sprites": "node tools/exportLemmingsSprites.js",
     "export-ground-images": "node tools/exportGroundImages.js",

--- a/tools/runTests.js
+++ b/tools/runTests.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+
+const CATEGORY_PATTERNS = {
+  core: ['test/*game*.test.js'],
+  bench: ['test/bench*.test.js'],
+  workflow: ['test/*workflow*.test.js'],
+  tools: ['test/tools/*.test.js']
+};
+
+const categories = process.argv.slice(2);
+
+if (categories.length === 0) {
+  const res = spawnSync('mocha', ['--recursive'], { stdio: 'inherit' });
+  process.exit(res.status);
+}
+
+const patterns = [];
+for (const cat of categories) {
+  const globs = CATEGORY_PATTERNS[cat];
+  if (!globs) {
+    console.error(`Unknown category: ${cat}`);
+    process.exit(1);
+  }
+  patterns.push(...globs);
+}
+
+const res = spawnSync('mocha', patterns, { stdio: 'inherit' });
+process.exit(res.status);


### PR DESCRIPTION
## Summary
- create `tools/runTests.js` to run mocha by category
- hook new script into `package.json` test and coverage commands

## Testing
- `npm test` *(fails: ReferenceError: worldW is not defined)*
- `npm run agent-precommit` *(fails: unable to parse .searchMetrics)*

------
https://chatgpt.com/codex/tasks/task_e_6844d0c18870832d8a1636e175eb801c