### PR TITLE
Improve search history merging

### DIFF
--- a/test/search-history-workflow.test.js
+++ b/test/search-history-workflow.test.js
@@ -5,38 +5,42 @@ import path from 'path';
 import { mergeSearchHistory } from '../tools/mergeSearchHistory.js';
 
 describe('mergeSearchHistory', function () {
-  it('appends missing lines from the base file', function () {
+  it('merges records and sorts by time', function () {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'history-'));
     const base = path.join(dir, 'base_history');
     const target = path.join(dir, '.searchMetrics', 'searchHistory');
     fs.mkdirSync(path.dirname(target), { recursive: true });
-    fs.writeFileSync(base, 'a\nb\nc\n');
-    fs.writeFileSync(target, 'b\nc\nd\n');
+
+    const rec1 = { time: '2020-01-03T00:00:00Z', query: 'A' };
+    const rec2 = { time: '2020-01-01T00:00:00Z', query: 'B' };
+    const rec3 = { time: '2020-01-02T00:00:00Z', query: 'C' };
+    fs.writeFileSync(base, JSON.stringify(rec1) + '\n' + JSON.stringify(rec2) + '\n');
+    fs.writeFileSync(target, JSON.stringify(rec3) + '\n');
 
     mergeSearchHistory(base, target);
 
-    const result = fs.readFileSync(target, 'utf8').trim().split(/\n/);
-    expect(result).to.eql(['b', 'c', 'd', 'a']);
+    const lines = fs.readFileSync(target, 'utf8').trim().split(/\n/);
+    const times = lines.map(l => JSON.parse(l).time);
+    expect(times).to.eql([rec2.time, rec3.time, rec1.time]);
   });
 
-  it('deduplicates JSON records and preserves valid output', function () {
+  it('splits concatenated records and deduplicates', function () {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'history-'));
     const base = path.join(dir, 'base_history');
     const target = path.join(dir, '.searchMetrics', 'searchHistory');
     fs.mkdirSync(path.dirname(target), { recursive: true });
-    const rec1 = { query: 'foo' };
-    const rec2 = { query: 'bar' };
-    fs.writeFileSync(
-      base,
-      JSON.stringify(rec1) + '\n' + JSON.stringify(rec1) + '\n' + JSON.stringify(rec2) + '\n'
-    );
+
+    const rec1 = { time: '2020-01-01T00:00:00Z', query: 'foo' };
+    const rec2 = { time: '2020-01-02T00:00:00Z', query: 'bar' };
+    fs.writeFileSync(base, JSON.stringify(rec1) + JSON.stringify(rec2) + '\n');
     fs.writeFileSync(target, JSON.stringify(rec1) + '\n');
 
     mergeSearchHistory(base, target);
 
     const lines = fs.readFileSync(target, 'utf8').trim().split(/\n/);
     expect(lines).to.have.length(2);
-    expect(JSON.parse(lines[0])).to.eql(rec1);
-    expect(JSON.parse(lines[1])).to.eql(rec2);
+    const parsed = lines.map(l => JSON.parse(l));
+    expect(parsed[0].query).to.equal('foo');
+    expect(parsed[1].query).to.equal('bar');
   });
 });

--- a/tools/mergeSearchHistory.js
+++ b/tools/mergeSearchHistory.js
@@ -3,22 +3,35 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
-export function mergeSearchHistory(baseFile, targetFile) {
-  if (!fs.existsSync(baseFile)) return;
-  if (!fs.existsSync(targetFile)) {
-    fs.mkdirSync(path.dirname(targetFile), { recursive: true });
-    fs.writeFileSync(targetFile, '');
-  }
-  const baseLines = fs.readFileSync(baseFile, 'utf8').split(/\r?\n/).filter(Boolean);
-  const targetLines = fs.readFileSync(targetFile, 'utf8').split(/\r?\n/).filter(Boolean);
-  const seen = new Set(targetLines);
-  for (const line of baseLines) {
-    if (!seen.has(line)) {
-      targetLines.push(line);
-      seen.add(line);
+function parseFile(file) {
+  if (!fs.existsSync(file)) return [];
+  const data = fs.readFileSync(file, 'utf8').replace(/}\s*{/g, '}\n{');
+  const lines = data.split(/\r?\n/).filter(Boolean);
+  const records = [];
+  for (const line of lines) {
+    try {
+      records.push(JSON.parse(line));
+    } catch {
+      // ignore malformed JSON
     }
   }
-  const out = targetLines.join('\n');
+  return records;
+}
+
+export function mergeSearchHistory(baseFile, targetFile) {
+  const baseRecords = parseFile(baseFile);
+  const targetRecords = parseFile(targetFile);
+  const seen = new Set(targetRecords.map(r => JSON.stringify(r)));
+  for (const rec of baseRecords) {
+    const str = JSON.stringify(rec);
+    if (!seen.has(str)) {
+      targetRecords.push(rec);
+      seen.add(str);
+    }
+  }
+  targetRecords.sort((a, b) => (a.time || '').localeCompare(b.time || ''));
+  const out = targetRecords.map(r => JSON.stringify(r)).join('\n');
+  fs.mkdirSync(path.dirname(targetFile), { recursive: true });
   fs.writeFileSync(targetFile, out + (out ? '\n' : ''));
 }
 


### PR DESCRIPTION
## Summary
- fix search history merger to split concatenated records
- sort merged history by timestamp
- update workflow tests for new behaviour

## Testing
- `npm ci`
- `npm test` *(fails: UserInputManager adjusts viewport when zooming)*

------
https://chatgpt.com/codex/tasks/task_e_6844dbbfcc70832da8f1b6e23012f553