### PR TITLE
Add cross-env for c8 fork coverage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "c8": "^10.1.3",
         "chai": "^5.2.0",
         "cheerio": "^1.0.0",
+        "cross-env": "^7.0.3",
         "depcheck": "^1.4.7",
         "eslint": "^9.28.0",
         "http-server": "^14.1.1",
@@ -1211,6 +1212,25 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "http-server --cors=*",
     "check-undefined": "node tools/check-undefined.js",
     "test": "node tools/runTests.js",
-    "coverage": "c8 node tools/runTests.js",
+    "coverage": "cross-env C8_FORK=1 c8 node tools/runTests.js",
     "export-panel-sprite": "node tools/exportPanelSprite.js",
     "export-lemmings-sprites": "node tools/exportLemmingsSprites.js",
     "export-ground-images": "node tools/exportGroundImages.js",
@@ -61,6 +61,7 @@
     "snowball-stemmers": "^0.6.0",
     "strip-comments": "^2.0.1",
     "svd-js": "^1.1.1",
+    "cross-env": "^7.0.3",
     "tar": "^7.4.3"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- enable coverage for spawned node processes
- add `cross-env` dev dependency so environment variable works on Windows

## Testing
- `npm test workflow`
- `npm run coverage -- workflow`
- `npm run coverage -- tools`


------
https://chatgpt.com/codex/tasks/task_e_6844dbd1248c832db82e629f0dc42e98