### PR TITLE
Update AGENTS guidelines to load grep aliases

### DIFF
--- a/.agentInfo/AGENTS.md
+++ b/.agentInfo/AGENTS.md
@@ -2,6 +2,11 @@
 
 This folder stores design notes and metadata for Codex agents. The notes are searchable via a local TF‑IDF index.
 
+Run `source ../.bash_aliases` from this directory to load the repo's custom
+`grep` aliases before working with the notes.
+Choose a short agent name for your session and include it with `--name=YOURNAME`
+when running repo scripts that accept a name flag.
+
 -## Index & Searching
 - The indexes live in `index-prose/` and `index-code/` at the repository root. They store TF‑IDF vectors for text chunks across the repo.
 - Query them with `node tools/search.js "SEARCH TERM" --json | jq .` for machine-readable results. Omit `--json` for a human readable listing.

--- a/.searchMetrics/searchHistory
+++ b/.searchMetrics/searchHistory
@@ -240,6 +240,11 @@
 {"time":"2025-06-08T00:56:51.781Z","query":"entrances.push","mdFiles":6,"codeFiles":65,"ms":109}
 {"time":"2025-06-08T01:21:33.227Z","query":"benchStart","mdFiles":27,"codeFiles":44,"ms":103}
 {"time":"2025-06-08T01:21:35.219Z","query":"benchStart","mdFiles":27,"codeFiles":44,"ms":86}
+{"time":"2025-06-08T01:50:44.758Z","query":"bench","mdFiles":13,"codeFiles":18,"ms":75}
+{"time":"2025-06-08T01:50:46.387Z","query":"bench","mdFiles":13,"codeFiles":18,"ms":67}
+{"time":"2025-06-08T01:50:49.902Z","query":"bench mode","mdFiles":22,"codeFiles":29,"ms":123}
+{"time":"2025-06-08T01:50:52.692Z","query":"benchMode","mdFiles":22,"codeFiles":29,"ms":89}
+{"time":"2025-06-08T01:50:54.372Z","query":"bench","mdFiles":13,"codeFiles":18,"ms":64}
 {"time":"2025-06-08T02:10:09.988Z","query":"bench series","mdFiles":13,"codeFiles":18,"ms":235}
 {"time":"2025-06-08T02:10:12.535Z","query":"bench series","mdFiles":13,"codeFiles":18,"ms":189}
 {"time":"2025-06-08T02:10:14.828Z","query":"bench series","mdFiles":13,"codeFiles":18,"ms":113}
@@ -251,8 +256,3 @@
 {"time":"2025-06-08T02:51:28.781Z","query":"Lemming.LEM_MAX_FALLING","mdFiles":36,"codeFiles":222,"ms":230}
 {"time":"2025-06-08T03:25:42.037Z","query":"benchMeasureExtras","mdFiles":16,"codeFiles":24,"ms":101}
 {"time":"2025-06-08T03:49:06.066Z","query":"benchMeasureExtras","mdFiles":16,"codeFiles":24,"ms":137}
-{"time":"2025-06-08T01:50:44.758Z","query":"bench","mdFiles":13,"codeFiles":18,"ms":75}
-{"time":"2025-06-08T01:50:46.387Z","query":"bench","mdFiles":13,"codeFiles":18,"ms":67}
-{"time":"2025-06-08T01:50:49.902Z","query":"bench mode","mdFiles":22,"codeFiles":29,"ms":123}
-{"time":"2025-06-08T01:50:52.692Z","query":"benchMode","mdFiles":22,"codeFiles":29,"ms":89}
-{"time":"2025-06-08T01:50:54.372Z","query":"bench","mdFiles":13,"codeFiles":18,"ms":64}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,11 @@ This repository hosts a JavaScript/Node implementation of **Lemmings**. The foll
 This repository uses ESLint for code style.
 Run `npm run format` before committing to automatically fix indentation,
 quotes, and semicolons across the JavaScript codebase.
+Run `source .bash_aliases` from the repository root at the start of each
+session to activate the custom `grep` and `gitgrep` aliases used
+throughout these instructions.
+Choose a short agent name for your session and pass it with `--name=YOURNAME`
+to any repo scripts that support a name flag.
 
 -## Index & Searching
 - The indexes live in `index-prose/` and `index-code/` at the repository root. They store TF‑IDF vectors for text chunks across the repo.


### PR DESCRIPTION
## Summary
- tell agents to `source .bash_aliases` at repo root
- add same note inside `.agentInfo/`
- instruct agents to pick a short name and pass it to commands with `--name`

## Testing
- `npm run format`
- `npm test` *(fails: 80 failing)*

------
https://chatgpt.com/codex/tasks/task_e_6845064128c8832dbe56f28bbe19422e