### PR TITLE
Update AGENTS guidelines to load grep aliases

### DIFF
--- a/.agentInfo/AGENTS.md
+++ b/.agentInfo/AGENTS.md
@@ -2,6 +2,11 @@
 
 This folder stores design notes and metadata for Codex agents. The notes are searchable via a local TF‑IDF index.
 
+Run `source ../.bash_aliases` from this directory to load the repo's custom
+`grep` aliases before working with the notes.
+Choose a short agent name for your session and include it with `--name=YOURNAME`
+when running repo scripts that accept a name flag.
+
 -## Index & Searching
 - The indexes live in `index-prose/` and `index-code/` at the repository root. They store TF‑IDF vectors for text chunks across the repo.
 - Query them with `node tools/search.js "SEARCH TERM" --json | jq .` for machine-readable results. Omit `--json` for a human readable listing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,11 @@ This repository hosts a JavaScript/Node implementation of **Lemmings**. The foll
 This repository uses ESLint for code style.
 Run `npm run format` before committing to automatically fix indentation,
 quotes, and semicolons across the JavaScript codebase.
+Run `source .bash_aliases` from the repository root at the start of each
+session to activate the custom `grep` and `gitgrep` aliases used
+throughout these instructions.
+Choose a short agent name for your session and pass it with `--name=YOURNAME`
+to any repo scripts that support a name flag.
 
 -## Index & Searching
 - The indexes live in `index-prose/` and `index-code/` at the repository root. They store TF‑IDF vectors for text chunks across the repo.


### PR DESCRIPTION
## Summary
- tell agents to `source .bash_aliases` at repo root
- add same note inside `.agentInfo/`
- instruct agents to pick a short name and pass it to commands with `--name`

## Testing
- `npm run format`
- `npm test` *(fails: 80 failing)*

------
https://chatgpt.com/codex/tasks/task_e_6845064128c8832dbe56f28bbe19422e