### PR TITLE
Fix coverage command

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test-bench": "mocha \"test/bench*.test.js\"",
     "test-workflow": "mocha \"test/*workflow*.test.js\"",
     "test-tools": "mocha \"test/tools/*.test.js\"",
-    "coverage": "cross-env C8_FORK=1 c8 node tools/runTests.js",
+    "coverage": "cross-env C8_FORK=1 c8 mocha --recursive",
     "export-panel-sprite": "node tools/exportPanelSprite.js",
     "export-lemmings-sprites": "node tools/exportLemmingsSprites.js",
     "export-ground-images": "node tools/exportGroundImages.js",


### PR DESCRIPTION
## Summary
- restore mocha invocation for coverage script

## Testing
- `npm test core --silent` *(fails: Timeout of 2000ms exceeded)*
- `npm run agent-precommit` *(fails: unable to parse .repoMetrics)*

------
https://chatgpt.com/codex/tasks/task_e_6845152189a0832dad19edfd5f04fec0