### PR TITLE
Refactor viewport management

### DIFF
--- a/js/KeyboardShortcuts.js
+++ b/js/KeyboardShortcuts.js
@@ -62,7 +62,9 @@ class KeyboardShortcuts {
       const dx = this.pan.vx;
       const dy = this.pan.vy;
       if (Math.abs(dx) > 0.05 || Math.abs(dy) > 0.05) {
-        stage.updateViewPoint(img, dx, dy, 0);
+        const nx = vp.x + dx / vp.scale;
+        const ny = vp.y + dy / vp.scale;
+        stage.applyViewport(img, nx, ny, vp.scale);
         stage.redraw();
         again = true;
       } else {
@@ -95,16 +97,12 @@ class KeyboardShortcuts {
         const newScale = stage.snapScale(stage._rawScale);
         const nx = centerX - cx / newScale;
         const ny = centerY - cy / newScale;
-        const maxX = img.display.worldDataSize.width  - img.canvasViewportSize.width  / newScale;
-        const maxY = img.display.worldDataSize.height - img.canvasViewportSize.height / newScale;
-        vp.x = Math.min(Math.max(0, nx), maxX);
-        vp.y = Math.min(Math.max(0, ny), maxY);
-        vp.scale = newScale;
+        stage.applyViewport(img, nx, ny, newScale);
         stage.redraw();
         again = true;
       } else if (this.zoom.reset !== null) {
         stage._rawScale = this.zoom.reset;
-        vp.scale = stage.snapScale(stage._rawScale);
+        stage.applyViewport(img, vp.x, vp.y, stage._rawScale);
         this.zoom.reset = null;
         stage.redraw();
         this.zoom.v = 0;

--- a/test/keyboardshortcuts.loop.test.js
+++ b/test/keyboardshortcuts.loop.test.js
@@ -31,6 +31,11 @@ class StageStub {
   redraw() { this.redrawCount++; }
   snapScale(s) { return s; }
   limitValue(min, val, max) { return Math.min(Math.max(val, min), max); }
+  applyViewport(img, x, y, scale) {
+    if (scale != null) img.viewPoint.scale = scale;
+    if (x != null) img.viewPoint.x = x;
+    if (y != null) img.viewPoint.y = y;
+  }
 }
 
 function createWindowStub() {

--- a/test/keyboardshortcuts.test.js
+++ b/test/keyboardshortcuts.test.js
@@ -356,6 +356,11 @@ describe('KeyboardShortcuts', function() {
       redraw() {}
       snapScale(s) { return s; }
       limitValue(min, val, max) { return Math.min(Math.max(min, val), max); }
+      applyViewport(img, x, y, scale) {
+        if (scale != null) img.viewPoint.scale = scale;
+        if (x != null) img.viewPoint.x = x;
+        if (y != null) img.viewPoint.y = y;
+      }
     }
     function createWindowStub() {
       let rafCb;


### PR DESCRIPTION
## Summary
- add `applyViewport` to consolidate view clamping and anchoring
- rely on `applyViewport` from `updateViewPoint`
- simplify `updateStageSize` using helper
- adjust keyboard controls to pan and zoom via `applyViewport`
- extend test stubs with `applyViewport`

## Testing
- `npm test` *(fails: Timeout and assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_68452ab19f64832db7d8e366898c5ebe