### PR TITLE
Document failing gametimer test

### DIFF
--- a/docs/broken-tests.md
+++ b/docs/broken-tests.md
@@ -1,0 +1,6 @@
+# Broken tests
+
+The following unit tests are currently failing and need additional investigation:
+
+- [`test/gametimer.test.js`](../test/gametimer.test.js) – the *pause/resume via visibilitychange stops ticks* and *catchupSpeedAdjust scales across repeated delays* cases do not yield the expected `speedFactor` when run with fake timers. Mocked `requestAnimationFrame` calls and changes to the timer logic were unable to match the test expectations.
+


### PR DESCRIPTION
## Summary
- add a new `docs/broken-tests.md` file
- describe failing GameTimer tests with link to the file and rationale

## Testing
- `npm test` *(fails: Timeout of 2000ms exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_68452c899d60832d9ab382cb1054d286