### PR TITLE
Fix bench sequence test

### DIFF
--- a/test/bench-tps.test.js
+++ b/test/bench-tps.test.js
@@ -17,6 +17,7 @@ class DisplayImageStub {
     this.onMouseMove = new Lemmings.EventHandler();
     this.onDoubleClick = new Lemmings.EventHandler();
     this.calls = [];
+    this.stage = { updateStageSize() {} };
   }
   initSize(w, h) { this.initArgs = [w, h]; }
   setBackground(bg) { this.background = bg; }


### PR DESCRIPTION
## Summary
- rewrite bench-sequence test to use fake timers and check monitor
- stub DisplayImage in bench TPS tests with `stage.updateStageSize`

## Testing
- `npm test bench`

------
https://chatgpt.com/codex/tasks/task_e_6845594486a8832d855d4e2bd891c426