### PR TITLE
Add parachute landing tests

### DIFF
--- a/.repoMetrics/metrics.json
+++ b/.repoMetrics/metrics.json
@@ -1,0 +1,1 @@
+{"js\\ActionFloatingSystem.js":{"md":0,"code":2,"terms":["parachute"]}}

--- a/.repoMetrics/searchHistory
+++ b/.repoMetrics/searchHistory
@@ -428,3 +428,5 @@
 {"time":"2025-06-08T19:42:48.268Z","query":"Stage.updateStageSize","mdFiles":15,"codeFiles":15,"ms":247}
 {"time":"2025-06-08T19:43:19.533Z","query":"MapObject","mdFiles":10,"codeFiles":15,"ms":242}
 {"time":"2025-06-08T21:49:57.430Z","query":"foo","mdFiles":1,"codeFiles":0,"ms":2494}
+{"time":"2025-06-08T22:02:53.812Z","query":"parachute","mdFiles":0,"codeFiles":1,"ms":1449}
+{"time":"2025-06-08T22:02:56.850Z","query":"parachute","mdFiles":0,"codeFiles":1,"ms":1178}

--- a/test/action-systems.test.js
+++ b/test/action-systems.test.js
@@ -689,6 +689,30 @@ describe('Action Systems process()', function() {
     expect(lem.state).to.be.above(16);
   });
 
+  it('ActionFallSystem lands with parachute when ground one step below', function() {
+    const level = new StubLevel();
+    const sys = new ActionFallSystem(new Map());
+    const lem = new StubLemming();
+    lem.hasParachute = true;
+    level.ground.add(level.key(lem.x, lem.y + 1));
+    const state = sys.process(level, lem);
+    expect(state).to.equal(Lemmings.LemmingStateType.WALKING);
+    expect(lem.y).to.equal(1);
+    expect(lem.state).to.equal(0);
+  });
+
+  it('ActionFallSystem lands with parachute when ground two steps below', function() {
+    const level = new StubLevel();
+    const sys = new ActionFallSystem(new Map());
+    const lem = new StubLemming();
+    lem.hasParachute = true;
+    level.ground.add(level.key(lem.x, lem.y + 2));
+    const state = sys.process(level, lem);
+    expect(state).to.equal(Lemmings.LemmingStateType.WALKING);
+    expect(lem.y).to.equal(2);
+    expect(lem.state).to.equal(0);
+  });
+
   it('ActionFallSystem walks or splats depending on fall distance', function() {
     const level = new StubLevel();
     const sys = new ActionFallSystem(new Map());


### PR DESCRIPTION
## Summary
- add tests to cover early parachute landings when ground is nearby
- update search history and repo metrics

## Testing
- `npm run coverage`


------
https://chatgpt.com/codex/tasks/task_e_684608384df4832d924d4f1ffab4b7fb