### PR TITLE
Add tests for CommandManager state cleanup

### DIFF
--- a/.repoMetrics/metrics.json
+++ b/.repoMetrics/metrics.json
@@ -1,0 +1,1 @@
+{"docs\\replays.md":{"md":3,"code":0,"terms":["command","manager"]},"js\\Game.js":{"md":0,"code":3,"terms":["command","manager"]}}

--- a/.repoMetrics/searchHistory
+++ b/.repoMetrics/searchHistory
@@ -428,3 +428,4 @@
 {"time":"2025-06-08T19:42:48.268Z","query":"Stage.updateStageSize","mdFiles":15,"codeFiles":15,"ms":247}
 {"time":"2025-06-08T19:43:19.533Z","query":"MapObject","mdFiles":10,"codeFiles":15,"ms":242}
 {"time":"2025-06-08T21:49:57.430Z","query":"foo","mdFiles":1,"codeFiles":0,"ms":2494}
+{"time":"2025-06-08T22:05:01.607Z","query":"CommandManager","mdFiles":3,"codeFiles":3,"ms":1592}

--- a/test/commandmanager.test.js
+++ b/test/commandmanager.test.js
@@ -99,4 +99,52 @@ describe('CommandManager', function() {
     expect(cm.game).to.equal(undefined);
     expect(cm.gameTimer).to.equal(undefined);
   });
+
+  it('removes a preexisting tick listener on construction', function() {
+    const timer = new MockTimer();
+    const cm = new TestCommandManager(game, timer);
+    const oldListener = cm._tickListener;
+    let removed = false;
+    timer.onBeforeGameTick.off = function(fn) {
+      if (fn === oldListener) removed = true;
+      Lemmings.EventHandler.prototype.off.call(this, fn);
+    };
+    TestCommandManager.call(cm, game, timer);
+    expect(removed).to.equal(true);
+    expect(cm._tickListener).to.not.equal(oldListener);
+  });
+
+  it('setGame assigns new game and clears state', function() {
+    const timer = new MockTimer();
+    const cm = new TestCommandManager(game, timer);
+    cm.runCommands[1] = new StubCommand();
+    cm.loggedCommads[2] = new StubCommand();
+    const newGame = {};
+    cm.setGame(newGame);
+    expect(cm.game).to.equal(newGame);
+    expect(cm.runCommands).to.deep.equal({});
+    expect(cm.loggedCommads).to.deep.equal({});
+  });
+
+  it('dispose removes tick listener and clears references', function() {
+    const timer = new MockTimer();
+    const cm = new TestCommandManager(game, timer);
+    const listener = cm._tickListener;
+    let offCalled = false;
+    let disposed = false;
+    timer.onBeforeGameTick.off = function(fn) {
+      if (fn === listener) offCalled = true;
+      Lemmings.EventHandler.prototype.off.call(this, fn);
+    };
+    timer.onBeforeGameTick.dispose = function() { disposed = true; };
+    cm.dispose();
+    expect(offCalled).to.equal(true);
+    expect(disposed).to.equal(true);
+    expect(cm._tickListener).to.equal(null);
+    expect(cm.game).to.equal(null);
+    expect(cm.gameTimer).to.equal(null);
+    expect(cm.log).to.equal(null);
+    expect(cm.runCommands).to.deep.equal({});
+    expect(cm.loggedCommads).to.deep.equal({});
+  });
 });


### PR DESCRIPTION
## Summary
- test removing old tick listener when constructing CommandManager
- ensure setGame clears queued commands
- verify dispose detaches tick listener and nulls references

## Testing
- `npm run coverage`
- `npm run agent-precommit`


------
https://chatgpt.com/codex/tasks/task_e_6846083f5810832db66727dd50d0cfee