### PR TITLE
Add tests for sprite caching and fallback

### DIFF
--- a/.repoMetrics/metrics.json
+++ b/.repoMetrics/metrics.json
@@ -1,0 +1,1 @@
+{"js\\LemmingsSprite.js":{"md":0,"code":1,"terms":["animation","cache"]}}

--- a/.repoMetrics/searchHistory
+++ b/.repoMetrics/searchHistory
@@ -428,3 +428,4 @@
 {"time":"2025-06-08T19:42:48.268Z","query":"Stage.updateStageSize","mdFiles":15,"codeFiles":15,"ms":247}
 {"time":"2025-06-08T19:43:19.533Z","query":"MapObject","mdFiles":10,"codeFiles":15,"ms":242}
 {"time":"2025-06-08T21:49:57.430Z","query":"foo","mdFiles":1,"codeFiles":0,"ms":2494}
+{"time":"2025-06-08T22:03:23.562Z","query":"_animationCache","mdFiles":0,"codeFiles":1,"ms":851}

--- a/test/displayimage.primitives.test.js
+++ b/test/displayimage.primitives.test.js
@@ -45,6 +45,21 @@ describe('DisplayImage primitives', function() {
     expect(Array.from(disp.buffer32)).to.eql([0xFF112233, 0xFF445566]);
   });
 
+  it('setBackground logs error for other array types', function() {
+    globalThis.lemmings = { game: { showDebug: true } };
+    const disp = new DisplayImage(stage);
+    disp.initSize(1, 1);
+    disp.clear(0);
+    const errors = [];
+    const origErr = console.error;
+    console.error = msg => errors.push(String(msg));
+    disp.setBackground(new Uint8Array([1, 2, 3, 4]));
+    console.error = origErr;
+    delete globalThis.lemmings;
+    expect(errors[0]).to.match(/setBackground fallback/);
+    expect(Array.from(disp.buffer32)).to.eql([0]);
+  });
+
   it('drawRect draws outlines and fills', function() {
     const disp = new DisplayImage(stage);
     disp.initSize(5, 5);

--- a/test/lemmingssprite.cache.test.js
+++ b/test/lemmingssprite.cache.test.js
@@ -1,0 +1,49 @@
+import { expect } from 'chai';
+import { Lemmings } from '../js/LemmingsNamespace.js';
+import { LemmingsSprite } from '../js/LemmingsSprite.js';
+import '../js/SpriteTypes.js';
+import '../js/ColorPalette.js';
+import '../js/Animation.js';
+
+globalThis.lemmings = { game: { showDebug: false } };
+
+describe('LemmingsSprite caching', function() {
+  let OrigAnimation;
+  let callCount;
+  beforeEach(function() {
+    OrigAnimation = Lemmings.Animation;
+    callCount = 0;
+    Lemmings.Animation = class {
+      constructor() { callCount++; }
+      loadFromFile() {}
+    };
+  });
+
+  afterEach(function() {
+    Lemmings.Animation = OrigAnimation;
+  });
+
+  it('reuses animations for identical palette', function() {
+    const pal = new Lemmings.ColorPalette();
+    const fr = {};
+    const s1 = new LemmingsSprite(fr, pal);
+    const first = callCount;
+    const anim1 = s1.getAnimation(Lemmings.SpriteTypes.WALKING, true);
+
+    const s2 = new LemmingsSprite(fr, pal);
+    const anim2 = s2.getAnimation(Lemmings.SpriteTypes.WALKING, true);
+
+    expect(anim2).to.equal(anim1);
+    expect(callCount).to.equal(first);
+  });
+
+  it('creates animations for different palettes', function() {
+    const fr = {};
+    const pal1 = new Lemmings.ColorPalette();
+    new LemmingsSprite(fr, pal1);
+    const count1 = callCount;
+    const pal2 = new Lemmings.ColorPalette();
+    new LemmingsSprite(fr, pal2);
+    expect(callCount).to.be.greaterThan(count1);
+  });
+});


### PR DESCRIPTION
## Summary
- cover sprite cache reuse in `LemmingsSprite`
- verify `DisplayImage.setBackground` logs error on fallback path
- update search metrics

## Testing
- `npm test` *(fails: Missing script)*
- `npx mocha test/lemmingssprite.cache.test.js`
- `npx mocha --grep "logs error" test/displayimage.primitives.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68460846580c832d8068c186419f1592