### PR TITLE
Stub DOM APIs in GameView tests

### DIFF
--- a/test/bench-sequence.test.js
+++ b/test/bench-sequence.test.js
@@ -6,15 +6,20 @@ import fakeTimers from '@sinonjs/fake-timers';
 
 class KeyboardShortcutsMock { constructor() {} dispose() {} }
 class StageMock {
-  constructor() { this.guiImgProps = { x:0, y:0, viewPoint:{ scale:1 }}; }
+  constructor() {
+    this.guiImgProps = { x:0, y:0, viewPoint:{ scale:1 }};
+    this.gameImgProps = { viewPoint: { scale: 1 } };
+  }
   getGameDisplay() { return { clear() {}, setScreenPosition() {}, redraw() {} }; }
   getGuiDisplay() { return {}; }
   setCursorSprite() {}
   updateStageSize() {}
   clear() {}
+  redraw() {}
   resetFade() {}
   startFadeOut() {}
   startOverlayFade() {}
+  applyViewport() {}
 }
 
 class LemmingManagerMock {
@@ -70,8 +75,11 @@ describe('bench sequence', function() {
           const ctx = { canvas:{}, fillRect() {}, drawImage() {}, putImageData() {}, createImageData(w, h) { return { width:w, height:h, data:new Uint8ClampedArray(w*h*4) }; } };
           return { width:0, height:0, getContext() { ctx.canvas = this; return ctx; } };
         },
+        querySelector() { return null; },
         addEventListener() {},
-        removeEventListener() {}
+        removeEventListener() {},
+        visibilityState: 'visible',
+        hasFocus() { return true; }
       };
     }
     global.document = createDocumentStub();
@@ -93,6 +101,8 @@ describe('bench sequence', function() {
     Lemmings.GameFactory = GameFactoryMock;
     Lemmings.GameTypes = { toString: () => '' };
     Lemmings.GameStateTypes = { toString: () => '' };
+    Lemmings.TriggerTypes = { DROWN: 0, FRYING: 1, KILL: 2, TRAP: 3 };
+    Lemmings.Lemming = { LEM_MAX_FALLING: 59 };
     global.lemmings = { game: { showDebug: false } };
   });
   beforeEach(function(){ clock = fakeTimers.withGlobal(globalThis).install({ now:0 }); });
@@ -118,6 +128,7 @@ describe('bench sequence', function() {
 
     view.game = new GameMock();
     view.game.stop = function() {};
+    view.loadLevel = async () => { view.game = new GameMock(); };
     view.benchSequence = true;
     view._benchCounts = [50, 25];
     view._benchIndex = 0;

--- a/test/gameview.helpers.test.js
+++ b/test/gameview.helpers.test.js
@@ -14,20 +14,39 @@ function createWindow() {
     setTimeout,
     clearTimeout,
     addEventListener() {},
-    removeEventListener() {}
+    removeEventListener() {},
+    requestAnimationFrame() {},
+    cancelAnimationFrame() {}
+  };
+}
+
+function createDocumentStub() {
+  return {
+    createElement() { return {}; },
+    querySelector() { return null; },
+    addEventListener() {},
+    removeEventListener() {},
+    visibilityState: 'visible',
+    hasFocus() { return true; }
   };
 }
 
 describe('GameView helper methods', function () {
   beforeEach(function () {
     global.window = createWindow();
+    global.document = createDocumentStub();
     global.history = { replaceState() {} };
     Lemmings.GameFactory = GameFactoryStub;
+    Lemmings.GameTypes = { TYPE1: 0, TYPE2: 1, TYPE3: 2, toString: () => '' };
+    Lemmings.GameStateTypes = { toString: () => '' };
   });
 
   afterEach(function () {
     delete global.window;
+    delete global.document;
     delete global.history;
+    delete Lemmings.GameTypes;
+    delete Lemmings.GameStateTypes;
   });
 
   it('parseNumber handles ranges and defaults', async function () {
@@ -201,15 +220,19 @@ describe('moveToLevel transitions', function () {
   beforeEach(function () {
     requests = [];
     global.window = createWindow();
+    global.document = createDocumentStub();
     global.history = { replaceState() {} };
     Lemmings.GameFactory = GameFactoryMock;
-    Lemmings.GameTypes = { TYPE1: 0, TYPE2: 1 };
+    Lemmings.GameTypes = { TYPE1: 0, TYPE2: 1, TYPE3: 2 };
+    Lemmings.GameStateTypes = { toString: () => '' };
     configs[1].level.order = [[0], [0]];
     configs[2].level.order = [[0]];
   });
   afterEach(function () {
     delete global.window;
+    delete global.document;
     delete global.history;
+    delete Lemmings.GameStateTypes;
   });
 
   it('advances to next group when level exceeds group length', async function () {
@@ -288,6 +311,7 @@ describe('moveToLevel transitions', function () {
     view.levelIndex = 0;
     view.levelGroupIndex = 0;
     view.gameType = 2; // not in GameTypes keys
+    Lemmings.GameTypes = { TYPE1: 0, TYPE2: 1 };
     await view.moveToLevel(0);
     expect(view.gameType).to.equal(1);
     expect(view.levelGroupIndex).to.equal(0);


### PR DESCRIPTION
## Summary
- add document and DOM stubs for GameView tests
- ensure requestAnimationFrame is stubbed
- update Stage mocks for bench and GameView tests
- adjust GameTypes stubs in helper tests

## Testing
- `npx mocha test/bench-sequence.test.js`
- `npx mocha test/gameview.helpers.test.js`
- `npx mocha test/gameview.test.js`


------
https://chatgpt.com/codex/tasks/task_e_684606fca2ec832d8f06d8afd0946fe8