### PR TITLE
Add archive format tests

### DIFF
--- a/.repoMetrics/metrics.json
+++ b/.repoMetrics/metrics.json
@@ -1,1 +1,1 @@
-{}
+{"docs\\levelpacks.md":{"md":1,"code":0,"terms":["archive"]},"docs\\tools.md":{"md":1,"code":0,"terms":["archive"]}}

--- a/.repoMetrics/noResultQueries
+++ b/.repoMetrics/noResultQueries
@@ -29,3 +29,4 @@
 {"time":"2025-06-08T22:02:31.258Z","query":"builder"}
 {"time":"2025-06-08T22:02:47.385Z","query":"blocker"}
 {"time":"2025-06-08T22:02:51.317Z","query":"Blocker"}
+{"time":"2025-06-08T23:48:05.654Z","query":"archiving"}

--- a/.repoMetrics/searchHistory
+++ b/.repoMetrics/searchHistory
@@ -429,3 +429,5 @@
 {"time":"2025-06-08T19:43:19.533Z","query":"MapObject","mdFiles":10,"codeFiles":15,"ms":242}
 {"time":"2025-06-08T21:49:57.430Z","query":"foo","mdFiles":1,"codeFiles":0,"ms":2494}
 {"time":"2025-06-08T22:03:23.562Z","query":"_animationCache","mdFiles":0,"codeFiles":1,"ms":851}
+{"time":"2025-06-08T23:47:16.549Z","query":"archive","mdFiles":2,"codeFiles":0,"ms":533}
+{"time":"2025-06-08T23:48:05.653Z","query":"archiving","mdFiles":0,"codeFiles":0,"ms":1017}

--- a/test/archiveDir.test.js
+++ b/test/archiveDir.test.js
@@ -38,14 +38,16 @@ describe('archiveDir (patched)', function () {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
-  it('creates a tar.gz archive', async function () {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'arch-'));
-    fs.writeFileSync(path.join(dir, 'file.txt'), 'tar');
-    await archiveDir(dir, 'tar');
-    assert.ok(fs.existsSync(`${dir}.tar.gz`));
-    fs.rmSync(`${dir}.tar.gz`, { force: true });
-    fs.rmSync(dir, { recursive: true, force: true });
-  });
+  for (const fmt of ['tar', 'tar.gz', 'tgz']) {
+    it(`creates a ${fmt} archive`, async function () {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'arch-'));
+      fs.writeFileSync(path.join(dir, 'file.txt'), 'tar');
+      await archiveDir(dir, fmt);
+      assert.ok(fs.existsSync(`${dir}.tar.gz`));
+      fs.rmSync(`${dir}.tar.gz`, { force: true });
+      fs.rmSync(dir, { recursive: true, force: true });
+    });
+  }
 
   it('uses spawnSync for rar archives', async function () {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'arch-'));

--- a/test/tools/archiveDir.test.js
+++ b/test/tools/archiveDir.test.js
@@ -18,14 +18,16 @@ describe('archiveDir', function () {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
-  it('creates a tar.gz archive', async function () {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'arch-'));
-    fs.writeFileSync(path.join(dir, 'file.txt'), 'tar');
-    await archiveDir(dir, 'tar');
-    assert.ok(fs.existsSync(`${dir}.tar.gz`));
-    fs.rmSync(`${dir}.tar.gz`, { force: true });
-    fs.rmSync(dir, { recursive: true, force: true });
-  });
+  for (const fmt of ['tar', 'tar.gz', 'tgz']) {
+    it(`creates a ${fmt} archive`, async function () {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'arch-'));
+      fs.writeFileSync(path.join(dir, 'file.txt'), 'tar');
+      await archiveDir(dir, fmt);
+      assert.ok(fs.existsSync(`${dir}.tar.gz`));
+      fs.rmSync(`${dir}.tar.gz`, { force: true });
+      fs.rmSync(dir, { recursive: true, force: true });
+    });
+  }
 
   it('creates a rar archive', async function () {
     if (!hasRar) this.skip();


### PR DESCRIPTION
## Summary
- test additional archive formats for archiveDir

## Testing
- `npm run coverage`

------
https://chatgpt.com/codex/tasks/task_e_684620c231bc832da33fcce3a1648bbb