### PR TITLE
Add CLI coverage for mergeSearchHistory

### DIFF
--- a/test/search-history-workflow.test.js
+++ b/test/search-history-workflow.test.js
@@ -100,4 +100,48 @@ describe('mergeSearchHistory', function () {
     const queries = lines.map(l => JSON.parse(l).query);
     expect(queries).to.eql(['foo', 'bar']);
   });
+
+  it('deduplicates via the CLI with explicit files', function () {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mhjs-'));
+    const base = path.join(dir, 'base.jsonl');
+    const dest = path.join(dir, '.repoMetrics', 'hist.jsonl');
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+
+    const rec1 = { time: '2020-01-01T00:00:00Z', query: 'foo' };
+    const rec2 = { time: '2020-01-02T00:00:00Z', query: 'bar' };
+    fs.writeFileSync(base, JSON.stringify(rec1) + JSON.stringify(rec2) + '\n');
+    fs.writeFileSync(dest, JSON.stringify(rec1) + '\n');
+
+    const script = path.resolve('tools/mergeSearchHistory.js');
+    const res = spawnSync(process.execPath, [script, base, dest], { encoding: 'utf8' });
+    expect(res.status).to.equal(0);
+
+    const lines = fs.readFileSync(dest, 'utf8').trim().split(/\n/);
+    expect(lines).to.have.length(2);
+    const parsed = lines.map(l => JSON.parse(l));
+    expect(parsed[0].query).to.equal('foo');
+    expect(parsed[1].query).to.equal('bar');
+  });
+
+  it('deduplicates via the CLI using default files', function () {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mhjs-'));
+    const base = path.join(dir, 'base_history');
+    const dest = path.join(dir, '.repoMetrics', 'searchHistory');
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+
+    const rec1 = { time: '2020-01-01T00:00:00Z', query: 'foo' };
+    const rec2 = { time: '2020-01-02T00:00:00Z', query: 'bar' };
+    fs.writeFileSync(base, JSON.stringify(rec1) + JSON.stringify(rec2) + '\n');
+    fs.writeFileSync(dest, JSON.stringify(rec1) + '\n');
+
+    const script = path.resolve('tools/mergeSearchHistory.js');
+    const res = spawnSync(process.execPath, [script], { cwd: dir, encoding: 'utf8' });
+    expect(res.status).to.equal(0);
+
+    const lines = fs.readFileSync(dest, 'utf8').trim().split(/\n/);
+    expect(lines).to.have.length(2);
+    const parsed = lines.map(l => JSON.parse(l));
+    expect(parsed[0].query).to.equal('foo');
+    expect(parsed[1].query).to.equal('bar');
+  });
 });


### PR DESCRIPTION
## Summary
- test CLI deduplication logic in mergeSearchHistory.js

## Testing
- `npm run coverage`

------
https://chatgpt.com/codex/tasks/task_e_684620c2b834832dbd0d1260dcf309e9