### PR TITLE
Handle zero checksum

### DIFF
--- a/.repoMetrics/metrics.json
+++ b/.repoMetrics/metrics.json
@@ -1,1 +1,1 @@
-{}
+{"docs\\compression-format.md":{"md":1,"code":0,"terms":["checksum"]},"js\\BitReader.js":{"md":0,"code":3,"terms":["checksum"]},"js\\UnpackFilePart.js":{"md":0,"code":2,"terms":["checksum"]},"test\\filecontainer.test.js":{"md":0,"code":2,"terms":["checksum"]}}

--- a/.repoMetrics/searchHistory
+++ b/.repoMetrics/searchHistory
@@ -429,3 +429,4 @@
 {"time":"2025-06-08T19:43:19.533Z","query":"MapObject","mdFiles":10,"codeFiles":15,"ms":242}
 {"time":"2025-06-08T21:49:57.430Z","query":"foo","mdFiles":1,"codeFiles":0,"ms":2494}
 {"time":"2025-06-08T22:03:23.562Z","query":"_animationCache","mdFiles":0,"codeFiles":1,"ms":851}
+{"time":"2025-06-08T23:47:34.417Z","query":"checksum","mdFiles":1,"codeFiles":7,"ms":1068}

--- a/js/UnpackFilePart.js
+++ b/js/UnpackFilePart.js
@@ -142,7 +142,9 @@ class UnpackFilePart extends Lemmings.BaseLogger {
           }
         }
 
-        if (this.#checksum === bitReader.getCurrentChecksum()) {
+        if (this.#checksum === 0) {
+          this.log.debug(`doUnpacking(${fileReader.filename}) skipping checksum`);
+        } else if (this.#checksum === bitReader.getCurrentChecksum()) {
           this.log.debug(`doUnpacking(${fileReader.filename}) done!`);
         } else {
           this.log.log(`doUnpacking(${fileReader.filename}): Checksum mismatch!`);

--- a/test/unpackfilepart.test.js
+++ b/test/unpackfilepart.test.js
@@ -70,4 +70,21 @@ describe('UnpackFilePart', function () {
     Lemmings.LogHandler = origLog;
     expect(part.log.debugged.some(m => m.includes('done!'))).to.be.true;
   });
+
+  it('skips validation when checksum is zero', function () {
+    const origLog = Lemmings.LogHandler;
+    Lemmings.LogHandler = MockLogHandler;
+    const arr = Uint8Array.from([4, 5, 6]);
+    const packed = PackFilePart.pack(arr);
+    const br = new BinaryReader(packed.byteArray);
+    const part = new UnpackFilePart(br);
+    part.offset = 0;
+    part.compressedSize = br.length;
+    part.initialBufferLen = packed.initialBits;
+    part.checksum = 0;
+    part.decompressedSize = arr.length;
+    part.unpack();
+    Lemmings.LogHandler = origLog;
+    expect(part.log.debugged.some(m => m.includes('skipping checksum'))).to.be.true;
+  });
 });


### PR DESCRIPTION
## Summary
- bypass checksum comparison when the header value is zero
- add test to exercise the zero checksum path

## Testing
- `npm run format`
- `npx mocha test/unpackfilepart.test.js` *(fails: Lemmings.BitReader is not a constructor)*

------
https://chatgpt.com/codex/tasks/task_e_684620c8c904832dad87af39f16aa204