### PR TITLE
Add tests for DisplayImage corner and blit logic

### DIFF
--- a/.repoMetrics/metrics.json
+++ b/.repoMetrics/metrics.json
@@ -1,1 +1,1 @@
-{}
+{"docs\\camanis\\lemmings_2_style_file_format_l2gfx.txt":{"md":4,"code":0,"terms":["position"]},"js\\BaseImageInfo.js":{"md":0,"code":2,"terms":["position"]},"js\\Position2D.js":{"md":0,"code":2,"terms":["position"]},"js\\Rectangle.js":{"md":0,"code":2,"terms":["position"]},"js\\xbrz\\xbrz.js":{"md":0,"code":2,"terms":["position"]},"js\\UserInputManager.js":{"md":0,"code":2,"terms":["position"]}}

--- a/.repoMetrics/noResultQueries
+++ b/.repoMetrics/noResultQueries
@@ -29,3 +29,4 @@
 {"time":"2025-06-08T22:02:31.258Z","query":"builder"}
 {"time":"2025-06-08T22:02:47.385Z","query":"blocker"}
 {"time":"2025-06-08T22:02:51.317Z","query":"Blocker"}
+{"time":"2025-06-08T23:48:25.573Z","query":"buffer"}

--- a/.repoMetrics/searchHistory
+++ b/.repoMetrics/searchHistory
@@ -429,3 +429,6 @@
 {"time":"2025-06-08T19:43:19.533Z","query":"MapObject","mdFiles":10,"codeFiles":15,"ms":242}
 {"time":"2025-06-08T21:49:57.430Z","query":"foo","mdFiles":1,"codeFiles":0,"ms":2494}
 {"time":"2025-06-08T22:03:23.562Z","query":"_animationCache","mdFiles":0,"codeFiles":1,"ms":851}
+{"time":"2025-06-08T23:48:22.843Z","query":"position","mdFiles":2,"codeFiles":5,"ms":456}
+{"time":"2025-06-08T23:48:25.572Z","query":"buffer","mdFiles":0,"codeFiles":0,"ms":598}
+{"time":"2025-06-08T23:48:29.036Z","query":"position","mdFiles":2,"codeFiles":5,"ms":590}

--- a/test/displayimage.primitives.test.js
+++ b/test/displayimage.primitives.test.js
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import { DisplayImage } from '../js/DisplayImage.js';
+import { Frame } from '../js/Frame.js';
 
 class StubStage {
   constructor() { this.calls = []; }
@@ -129,5 +130,55 @@ describe('DisplayImage primitives', function() {
     expect(disp.buffer32[0*3 + 2]).to.equal(0);
     expect(disp.buffer32[1*3 + 1]).to.equal(0);
     expect(disp.buffer32[1*3 + 2]).to.equal(WHITE);
+  });
+
+  it('drawCornerRect draws corners and midlines correctly', function() {
+    const disp = new DisplayImage(stage);
+    disp.initSize(7, 7);
+    disp.clear(0);
+    disp.drawCornerRect(1, 1, { width: 5, height: 5 }, 1, 2, 3, 2, true, 3);
+    const c = 0xFF030201;
+    const expected = new Set();
+    for (let x = 1; x <= 5; x++) {
+      expected.add(`${x},1`);
+      expected.add(`${x},5`);
+    }
+    for (let y = 1; y <= 5; y++) {
+      expected.add(`1,${y}`);
+      expected.add(`5,${y}`);
+    }
+    const seen = new Set();
+    for (let y = 0; y < 7; y++) {
+      for (let x = 0; x < 7; x++) {
+        if (disp.buffer32[y * 7 + x] === c) seen.add(`${x},${y}`);
+        else expect(disp.buffer32[y * 7 + x]).to.equal(0);
+      }
+    }
+    expect(seen).to.eql(expected);
+  });
+
+  it('_blit writes pixels without scaling', function() {
+    const disp = new DisplayImage(stage);
+    disp.initSize(3, 2);
+    disp.clear(0);
+    const frame = new Frame(2, 2);
+    frame.data.set([1, 2, 3, 4]);
+    frame.mask.set([1, 0, 0, 1]);
+    disp._blit(frame, 1, 0, { nullColor32: 9 });
+    expect(Array.from(disp.buffer32)).to.eql([
+      0, 1, 9,
+      0, 9, 4
+    ]);
+  });
+
+  it('_blit flips vertically when upsideDown is true', function() {
+    const disp = new DisplayImage(stage);
+    disp.initSize(2, 2);
+    disp.clear(0);
+    const frame = new Frame(2, 2);
+    frame.data.set([1, 2, 3, 4]);
+    frame.mask.fill(1);
+    disp._blit(frame, 0, 0, { upsideDown: true });
+    expect(Array.from(disp.buffer32)).to.eql([3, 4, 1, 2]);
   });
 });


### PR DESCRIPTION
## Summary
- extend displayimage.primitives.test.js
- cover `drawCornerRect` and `_blit` unscaled path
- record search metrics

## Testing
- `npm test` *(fails: Missing script)*
- `npm run coverage`

------
https://chatgpt.com/codex/tasks/task_e_684620cd2cec832dbeb08bdade843d0e