### PR TITLE
Add fallback tests for upscale helpers

### DIFF
--- a/.repoMetrics/metrics.json
+++ b/.repoMetrics/metrics.json
@@ -1,1 +1,1 @@
-{}
+{"test/displayimage.scaling.test.js":{"md":0,"code":1,"terms":["scaleXbrz","scaleHqx"]}}

--- a/.repoMetrics/searchHistory
+++ b/.repoMetrics/searchHistory
@@ -429,3 +429,4 @@
 {"time":"2025-06-08T19:43:19.533Z","query":"MapObject","mdFiles":10,"codeFiles":15,"ms":242}
 {"time":"2025-06-08T21:49:57.430Z","query":"foo","mdFiles":1,"codeFiles":0,"ms":2494}
 {"time":"2025-06-08T22:03:23.562Z","query":"_animationCache","mdFiles":0,"codeFiles":1,"ms":851}
+{"time":"2025-06-08T23:59:59Z","query":"Scaler2x","mdFiles":2,"codeFiles":2,"ms":2488}

--- a/test/displayimage.scaling.test.js
+++ b/test/displayimage.scaling.test.js
@@ -55,6 +55,22 @@ describe('DisplayImage scaling helpers', function() {
         3, 3, 3, 4
       ]);
     });
+
+    it('scaleXbrz falls back to nearest for non-integer scale', function() {
+      const exp = new Uint32Array(9);
+      scaleNearest(frame, 3, 3, { dest32: exp, destW: 3, destH: 3, baseX: 0, baseY: 0 });
+      const dest = new Uint32Array(9);
+      scaleXbrz(frame, 3, 3, { dest32: dest, destW: 3, destH: 3, baseX: 0, baseY: 0 });
+      expect(Array.from(dest)).to.eql(Array.from(exp));
+    });
+
+    it('scaleHqx falls back to nearest for non-integer scale', function() {
+      const exp = new Uint32Array(9);
+      scaleNearest(frame, 3, 3, { dest32: exp, destW: 3, destH: 3, baseX: 0, baseY: 0 });
+      const dest = new Uint32Array(9);
+      scaleHqx(frame, 3, 3, { dest32: dest, destW: 3, destH: 3, baseX: 0, baseY: 0 });
+      expect(Array.from(dest)).to.eql(Array.from(exp));
+    });
   });
 
   describe('draw rect helpers', function() {


### PR DESCRIPTION
## Summary
- extend scaling tests to cover fallback branches
- update repo metrics

## Testing
- `npx mocha test/displayimage.scaling.test.js`

------
https://chatgpt.com/codex/tasks/task_e_684620c6a640832db56fa30b45265e69