### PR TITLE
Update docs for hi-res true-color sprite support

### DIFF
--- a/docs/camanis/lemmings_main_dat_file_format.md
+++ b/docs/camanis/lemmings_main_dat_file_format.md
@@ -19,6 +19,14 @@ After decompression of main.dat, you should get 7 sections.  The contents of eac
 
 Note that this doc concerns the main.dat file from the DOS version of "Lemmings".  The DOS Xmas Lemmings games and the "Oh No! More Lemmings" games have slightly different graphics, so their main.dat should be slightly different, but the overall format should be identical, so you can still use the information here to explore the contents in those games' main.dat.
 
+### Modern extensions
+
+This project extends the format with optional **true‑color PNG** sprites.
+Uncompressed 32‑bit images may replace planar bitmaps at the same offsets.
+High‑resolution versions live in `styles/<set>-hr/` and use double the
+dimensions.  Engines that support these features load the PNG blocks
+transparently, falling back to the 16‑color originals when absent.
+
 
 ## 2) format and palette of graphics
 

--- a/docs/highres-migration.md
+++ b/docs/highres-migration.md
@@ -1,0 +1,15 @@
+# Migrating Packs to High-Resolution True-Color Sprites
+
+NeoLemmix packs built with 16‑color graphics continue to load without changes.
+To take advantage of the new high‑resolution, 32‑bit sprite support:
+
+1. Convert existing DAT graphics to PNG and place them in `styles/<set>-hr/`.
+   Images should be exactly twice the pixel dimensions of their standard
+   counterparts.
+2. Keep the original 16‑color files in `styles/<set>/` as fallbacks.
+3. Update any custom lemming sprite sheets to 32‑bit PNGs. The `scheme.nxmi`
+   file does not change.
+4. Rebuild archives with `npm run pack-levels` or your usual workflow.
+
+Older engines will ignore the `-hr` folders and continue using the low‑resolution
+sprites. New versions automatically load the high‑resolution PNGs when present.

--- a/docs/levelpacks.md
+++ b/docs/levelpacks.md
@@ -61,6 +61,10 @@ The engine reads these files in order to present the levels.
 * **sign_*.png, skill_panels.png** &ndash; custom menu graphics.
 * **music/** and **styles/** folders &ndash; include custom music tracks and graphic sets referenced by the pack.
 
+High‑resolution sprites belong in `styles/<set>-hr/` next to the
+standard-resolution `styles/<set>/` folder. See
+[`highres-migration.md`](highres-migration.md) for upgrade steps.
+
 ### Archive Formats
 
 Packs may be distributed as:

--- a/docs/nl-file-format.md
+++ b/docs/nl-file-format.md
@@ -149,6 +149,8 @@ $END                   # End group
 | `0xFF00`       | End-of-file                                                                           |
 
 Images referenced by the tables are stored **uncompressed** PNG blocks at byte offsets specified in the records. A global RLE wrapper may surround the entire DAT (see § 5).
+The PNGs may use full 32‑bit color with transparency. Classic 16‑color images
+remain valid and can coexist with their true‑color replacements.
 
 ### 4.2 High-Resolution folders (`style-hr`)
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,7 +1,10 @@
 # Tools
 
 This document describes the Node.js scripts found in the `tools` directory. These utilities help export,
-patch and package game assets.
+patch and package game assets.  Sprite exports now write **32‑bit PNGs** with
+alpha channels. If a pack includes a `styles/<set>-hr/` folder the tools
+automatically pick these double-resolution images.  Standard-resolution sprites
+remain available for older packs.
 
 All scripts accept paths to level packs. A pack can be a folder or an archive
 (`.zip`, `.tar`, `.tar.gz`, `.tgz`, or `.rar`). The `NodeFileProvider` class lets
@@ -70,7 +73,9 @@ node tools/patchSprites.js [--sheet-orientation=horizontal|vertical] <target DAT
 
 Replaces sprites in an existing DAT archive with PNG data. Multiple frames can
 be supplied as a sprite sheet when `--sheet-orientation` matches the sheet
-layout.
+layout.  The patched DAT supports **true‑color** PNGs, so edits may include
+alpha transparency and any palette.  High-resolution sprites simply use larger
+PNG files and follow the same naming conventions.
 
 ## packLevels.js
 
@@ -101,4 +106,5 @@ Removes all `export_*` directories created by the other scripts.
 
 Exported assets now live under the `exports/` directory. The game can load levels
 directly from packed archives, so you may keep your level packs compressed while
-still running these tools.
+still running these tools.  See [`highres-migration.md`](highres-migration.md)
+for guidelines on upgrading packs to the new sprite format.


### PR DESCRIPTION
## Summary
- mention 32-bit PNG exports in docs/tools
- document true-color PNG extension in main.dat notes
- note 32-bit image support in NL DAT format
- add high-res sprite upgrade instructions
- reference migration doc from level pack docs

## Testing
- `npm run test-workflow`
- `npm run test-tools` *(fails: ENOENT for test fixtures)*


------
https://chatgpt.com/codex/tasks/task_e_6846222b2f00832dbe2da5895fe6602f