### PR TITLE
Add resource packaging docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ The goal is to create a solid, performant port first. Then build out the sequenc
 - See [docs/testing.md](docs/TESTING.md) for how to run the Mocha test suite.
 - See [docs/ci.md](docs/ci.md) for gh actions workflow info.
 - See [docs/config.md](docs/config.md) for configuration details.
+- See [docs/port-info/resource-packaging.md](docs/port-info/resource-packaging.md) for an overview of how game assets are packaged.
 - See [contributing.md](CONTRIBUTING.md) for contribution guidelines.
 
 ### Running tests

--- a/docs/port-info/resource-packaging.md
+++ b/docs/port-info/resource-packaging.md
@@ -1,0 +1,40 @@
+# Lemmix Resource Packaging
+
+This note explains how the original Pascal version packages game assets into `.RES` files and how the JavaScript port loads the same resources without a compile step.
+
+## Pascal build process
+
+Lemmix stores all graphics, sound effects and style files under a `Data` directory. Each subfolder contains a ZIP archive and a matching `.rc` file referencing it as `RCDATA`:
+
+```rc
+CURSORS RCDATA "Cursors.zip"
+```
+
+`BuildResources.bat` runs `brcc32.exe` on each `.rc` file to produce `.RES` files:
+
+```bat
+brcc32.exe -fo .\Misc.RES .\Misc\Misc.rc
+brcc32.exe -fo .\Cursors.RES .\Cursors\Cursors.rc
+...
+```
+
+`lem_resources.inc` includes these resources so the Delphi compiler links them directly into the executable:
+
+```pascal
+{$resource '.\Data\Misc.RES'}
+{$resource '.\Data\Cursors.RES'}
+{$resource '.\Data\Orig.RES'}
+```
+
+## JavaScript approach
+
+This repository keeps the original data files unpacked inside folders such as `lemmings/` and `xmas91/`. Instead of `.RES` files the engine loads assets at runtime using `NodeFileProvider`, which can read from directories or archives (`.zip`, `.tar.gz`, `.rar`). Packs are listed in `config.json` and follow the layout described in [docs/levelpacks.md](../levelpacks.md).
+
+No compilation is required—assets remain editable, and tools under `tools/` operate on the raw DAT files. When running in Node, `NodeFileProvider` locates files on disk or inside archives.
+
+## Custom assets
+
+To add custom music or graphics, create a new pack folder and place files under `music/`, `styles/`, `sprites/` and other subdirectories. You can keep the folder zipped (e.g. `myPack.zip`) and `NodeFileProvider` will still locate the contents. Update `config.json` with the pack path so the game can load it.
+
+Music tracks may be OGG, IT, MOD, XM or WAV. Graphic sets use the same DAT or VGASPEC formats as NeoLemmix. Because resources are not baked into `.RES` files you can swap them without rebuilding.
+


### PR DESCRIPTION
## Summary
- document how Lemmix compiles resources and how the JS port loads them
- link to the new guide from README

## Testing
- `npm run format`
- `npm test` *(fails: 177 failing)*
- `npm run agent-precommit`

------
https://chatgpt.com/codex/tasks/task_e_6849cc4afd18832dbf94ac29a8c6053d