### PR TITLE
Move voice docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ The goal is to create a solid, performant port first. Then build out the sequenc
 - See [docs/testing.md](docs/TESTING.md) for how to run the Mocha test suite.
 - See [docs/ci.md](docs/ci.md) for gh actions workflow info.
 - See [docs/config.md](docs/config.md) for configuration details.
+- See [docs/port-info/voice-manager.md](docs/port-info/voice-manager.md) for an overview of the Lemmix voice manager.
 - See [contributing.md](CONTRIBUTING.md) for contribution guidelines.
 
 ### Running tests

--- a/docs/port-info/README.md
+++ b/docs/port-info/README.md
@@ -4,3 +4,4 @@ This folder collects notes on porting the original Pascal Lemmix codebase to the
 JavaScript/Node project. Each document covers a specific subsystem or topic.
 
 - [Sound system overview](sound-system-overview.md)
+- [Voice manager](voice-manager.md)

--- a/docs/port-info/voice-manager.md
+++ b/docs/port-info/voice-manager.md
@@ -18,4 +18,22 @@ The `TVoiceMgr` class attempts to create a Windows SAPI `ISpeechVoice` instance 
 
 The voice manager tracks whether speech synthesis is installed (`Installed`) and whether speaking is currently allowed (`Enabled`). Calls to `Speak` and `ForcedSpeak` respect these flags so the game can disable spoken feedback when appropriate. Option sets determine which predefined messages are active.
 
+## Voice Options
+
+`Base.Types.pas` defines `TVoiceOption`, listing the spoken message categories:
+
+```
+BinLevelSaved, BinLevelSavingOff, BinLevelSavingOn, Cheater,
+CurrentSection, CurrentStyle, GameSaved, ReplayFail,
+SoundFX, StartReplay, VoiceDisable, VoiceEnable
+```
+
+`TVoiceOptions` is a set of these values. When constructing `TVoiceMgr` the
+caller passes both the desired options and an `Enabled` flag. `Speak` only
+voices a predefined message when its option is present in this set.
+
+Actual speech synthesis relies on the generated COM wrapper
+`SpeechLib_TLB.pas`, which exposes `ISpeechVoice` and the `CoSpVoice` class
+instantiated by `TVoiceMgr`.
+
 


### PR DESCRIPTION
## Summary
- move Lemmix voice manager documentation under `docs/`
- link it from port info README
- reference the new document from README
- expand the doc with details on voice options and SAPI wrapper

## Testing
- `npm test` *(fails: TypeError: Lemmings.Lemming is not a constructor)*
- `npm run format`
- `npm run agent-precommit`


------
https://chatgpt.com/codex/tasks/task_e_6849cc49ff0c832d96996655fd9bd877